### PR TITLE
Use gpt-4o-mini for learning center suggestions

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -8,6 +8,7 @@ export const APP_CONFIG = {
 // OpenAI Configuration
 export const OPENAI_CONFIG = {
   MODEL: 'gpt-4',
+  SUGGESTIONS_MODEL: 'gpt-4o-mini',
   MAX_TOKENS: 1200,
   TEMPERATURE: 0.7,
   SYSTEM_PROMPT: `You are AcceleraQA, an AI assistant specialized in pharmaceutical quality and compliance. 

--- a/src/services/learningSuggestionsService.js
+++ b/src/services/learningSuggestionsService.js
@@ -3,6 +3,7 @@ import neonService from './neonService';
 import openaiService from './openaiService';
 import { getToken } from './authService';
 import { FEATURE_FLAGS } from '../config/featureFlags';
+import { OPENAI_CONFIG } from '../config/constants';
 
 class LearningSuggestionsService {
   constructor() {
@@ -111,8 +112,12 @@ class LearningSuggestionsService {
       // Create prompt for ChatGPT to generate learning suggestions
       const prompt = this.createLearningPrompt(conversationSummary);
       
-      // Get suggestions from ChatGPT
-      const response = await openaiService.getChatResponse(prompt);
+      // Get suggestions from ChatGPT using a lighter model
+      const response = await openaiService.getChatResponse(
+        prompt,
+        '',
+        OPENAI_CONFIG.SUGGESTIONS_MODEL
+      );
       
       // Parse and format the suggestions
       const suggestions = this.parseSuggestions(response.answer);

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -64,9 +64,9 @@ class OpenAIService {
     }
   }
 
-  createChatPayload(message) {
+  createChatPayload(message, model = OPENAI_CONFIG.MODEL) {
     return {
-      model: OPENAI_CONFIG.MODEL,
+      model,
       messages: [
         {
           role: "system",
@@ -82,7 +82,7 @@ class OpenAIService {
     };
   }
 
-  async getChatResponse(message, documentContent = '') {
+  async getChatResponse(message, documentContent = '', model = OPENAI_CONFIG.MODEL) {
     if ((!message || typeof message !== 'string' || message.trim().length === 0) && !documentContent) {
       throw new Error('Invalid message provided');
     }
@@ -91,7 +91,7 @@ class OpenAIService {
       ? `${message}\n\nDocument Content:\n${documentContent}`
       : message;
 
-    const payload = this.createChatPayload(combinedMessage);
+    const payload = this.createChatPayload(combinedMessage, model);
     
     try {
       const data = await this.makeRequest('/chat/completions', {


### PR DESCRIPTION
## Summary
- allow OpenAI service to accept a model override
- add `SUGGESTIONS_MODEL` constant and use gpt-4o-mini for learning suggestions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c40ee49930832a93654d410e4ae9c6