### PR TITLE
feat: allow admin to select chat model

### DIFF
--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -33,6 +33,7 @@ import { getToken, getTokenInfo } from '../services/authService';
 import { hasAdminRole } from '../utils/auth';
 import RAGConfigurationPage from './RAGConfigurationPage';
 import TrainingResourcesAdmin from './TrainingResourcesAdmin';
+import { MODEL_OPTIONS, getCurrentModel, setCurrentModel } from '../config/modelConfig';
 
 export const checkStorageHealth = async () => {
   // Check browser storage capacity
@@ -70,6 +71,13 @@ const AdminScreen = ({ user, onBack }) => {
   const [authStats, setAuthStats] = useState(null);
   const [systemHealth, setSystemHealth] = useState(null);
   const [error, setError] = useState(null);
+  const [chatModel, setChatModel] = useState(getCurrentModel());
+
+  const handleModelChange = (e) => {
+    const model = e.target.value;
+    setChatModel(model);
+    setCurrentModel(model);
+  };
 
   // Check if user has admin role
   const isAdmin = hasAdminRole(user);
@@ -709,6 +717,24 @@ const AdminScreen = ({ user, onBack }) => {
           {/* System Health Tab */}
           {activeTab === 'system' && (
             <div className="space-y-6">
+              <div className="bg-white rounded-lg shadow p-6">
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">AI Model Configuration</h3>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">
+                    Chat Model
+                    <select
+                      value={chatModel}
+                      onChange={handleModelChange}
+                      className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                    >
+                      {MODEL_OPTIONS.map(option => (
+                        <option key={option} value={option}>{option}</option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+              </div>
+
               <div className="bg-white rounded-lg shadow p-6">
                 <h3 className="text-lg font-semibold text-gray-900 mb-4">System Health Overview</h3>
                 <div className="space-y-6">

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -7,7 +7,7 @@ export const APP_CONFIG = {
 
 // OpenAI Configuration
 export const OPENAI_CONFIG = {
-  MODEL: 'gpt-4',
+  MODEL: 'gpt-4o-mini',
   SUGGESTIONS_MODEL: 'gpt-4o-mini',
   MAX_TOKENS: 1200,
   TEMPERATURE: 0.7,

--- a/src/config/modelConfig.js
+++ b/src/config/modelConfig.js
@@ -1,0 +1,27 @@
+import { isStorageAvailable } from '../utils/storageUtils';
+
+export const MODEL_STORAGE_KEY = 'acceleraqa_ai_model';
+export const MODEL_OPTIONS = ['gpt-4o-mini', 'gpt-4o', 'gpt-3.5-turbo'];
+export const DEFAULT_MODEL = 'gpt-4o-mini';
+
+export function getCurrentModel() {
+  try {
+    if (typeof localStorage !== 'undefined' && isStorageAvailable()) {
+      return localStorage.getItem(MODEL_STORAGE_KEY) || DEFAULT_MODEL;
+    }
+  } catch (error) {
+    console.warn('Model config read failed:', error);
+  }
+  return DEFAULT_MODEL;
+}
+
+export function setCurrentModel(model) {
+  if (!MODEL_OPTIONS.includes(model)) return;
+  try {
+    if (typeof localStorage !== 'undefined' && isStorageAvailable()) {
+      localStorage.setItem(MODEL_STORAGE_KEY, model);
+    }
+  } catch (error) {
+    console.warn('Model config write failed:', error);
+  }
+}

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -1,5 +1,6 @@
 import { OPENAI_CONFIG, ERROR_MESSAGES } from '../config/constants';
 import { generateResources } from '../utils/resourceGenerator';
+import { getCurrentModel } from '../config/modelConfig';
 
 class OpenAIService {
   constructor() {
@@ -86,7 +87,7 @@ class OpenAIService {
     }
   }
 
-  createChatPayload(message, model = OPENAI_CONFIG.MODEL) {
+  createChatPayload(message, model = getCurrentModel()) {
     return {
       model,
       messages: [
@@ -105,7 +106,7 @@ class OpenAIService {
     return messageTokens + (payload.max_tokens || 0);
   }
 
-  async getChatResponse(message, documentContent = '', model = OPENAI_CONFIG.MODEL) {
+  async getChatResponse(message, documentContent = '', model = getCurrentModel()) {
     if ((!message || typeof message !== 'string' || message.trim().length === 0) && !documentContent) {
       throw new Error('Invalid message provided');
     }


### PR DESCRIPTION
## Summary
- allow admins to choose the chat model from GPT-4o mini, GPT-4o, or GPT-3.5 turbo
- store chosen model in local storage and use it for chat completions
- default chat model updated to GPT-4o mini

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c471aaef88832ab3644877c534f7c8