### PR TITLE
feat: add token usage analytics

### DIFF
--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -34,6 +34,7 @@ import { hasAdminRole } from '../utils/auth';
 import RAGConfigurationPage from './RAGConfigurationPage';
 import TrainingResourcesAdmin from './TrainingResourcesAdmin';
 import { MODEL_OPTIONS, getCurrentModel, setCurrentModel } from '../config/modelConfig';
+import { getTokenUsageStats } from '../utils/tokenUsage';
 
 export const checkStorageHealth = async () => {
   // Check browser storage capacity
@@ -72,6 +73,7 @@ const AdminScreen = ({ user, onBack }) => {
   const [systemHealth, setSystemHealth] = useState(null);
   const [error, setError] = useState(null);
   const [chatModel, setChatModel] = useState(getCurrentModel());
+  const [tokenUsage, setTokenUsage] = useState({ daily: [], monthly: [] });
 
   const handleModelChange = (e) => {
     const model = e.target.value;
@@ -105,6 +107,7 @@ const AdminScreen = ({ user, onBack }) => {
       if (ragData.status === 'fulfilled') setRAGStats(ragData.value);
       if (health.status === 'fulfilled') setSystemHealth(health.value);
       if (auth.status === 'fulfilled') setAuthStats(auth.value);
+      setTokenUsage(getTokenUsageStats());
 
       // Log any failures
       [stats, ragData, health, auth].forEach((result, index) => {
@@ -434,6 +437,7 @@ const AdminScreen = ({ user, onBack }) => {
               { id: 'rag', label: 'RAG System', icon: FileText },
               { id: 'ragConfig', label: 'RAG Config', icon: Search },
               { id: 'system', label: 'System Health', icon: Activity },
+              { id: 'usage', label: 'Token Usage', icon: BarChart3 },
               { id: 'training', label: 'Training Resources', icon: BookOpen },
               { id: 'tools', label: 'Admin Tools', icon: Settings }
             ].map(tab => {
@@ -753,6 +757,55 @@ const AdminScreen = ({ user, onBack }) => {
                       </div>
                     </div>
                   ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Token Usage Tab */}
+          {activeTab === 'usage' && (
+            <div className="space-y-6">
+              <div className="bg-white rounded-lg shadow p-6">
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">Token Usage</h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div>
+                    <h4 className="font-medium mb-2">Last 30 Days</h4>
+                    <table className="min-w-full text-sm">
+                      <thead>
+                        <tr>
+                          <th className="text-left">Date</th>
+                          <th className="text-right">Tokens</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {tokenUsage.daily.map(day => (
+                          <tr key={day.date}>
+                            <td>{day.date}</td>
+                            <td className="text-right">{day.tokens}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                  <div>
+                    <h4 className="font-medium mb-2">Last 12 Months</h4>
+                    <table className="min-w-full text-sm">
+                      <thead>
+                        <tr>
+                          <th className="text-left">Month</th>
+                          <th className="text-right">Tokens</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {tokenUsage.monthly.map(month => (
+                          <tr key={month.month}>
+                            <td>{month.month}</td>
+                            <td className="text-right">{month.tokens}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/components/AdminScreen.test.js
+++ b/src/components/AdminScreen.test.js
@@ -96,4 +96,23 @@ describe('AdminScreen navigation', () => {
 
     expect(onBack).toHaveBeenCalled();
   });
+
+  it('renders Token Usage tab when selected', async () => {
+    const user = { roles: ['admin'] };
+
+    await act(async () => {
+      ReactDOM.render(<AdminScreen user={user} onBack={() => {}} />, container);
+    });
+
+    const usageButton = Array.from(container.querySelectorAll('button')).find(btn =>
+      btn.textContent && btn.textContent.includes('Token Usage')
+    );
+
+    await act(async () => {
+      usageButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const heading = container.querySelector('h3');
+    expect(heading && heading.textContent).toMatch(/Token Usage/i);
+  });
 });

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -1,6 +1,7 @@
 import { OPENAI_CONFIG, ERROR_MESSAGES } from '../config/constants';
 import { generateResources } from '../utils/resourceGenerator';
 import { getCurrentModel } from '../config/modelConfig';
+import { recordTokenUsage } from '../utils/tokenUsage';
 
 class OpenAIService {
   constructor() {
@@ -136,6 +137,11 @@ class OpenAIService {
 
       // Generate relevant resources based on the response content
       const resources = generateResources(message, aiResponse);
+
+      // Record token usage for admin analytics
+      if (data.usage?.total_tokens || tokenCount) {
+        recordTokenUsage(data.usage?.total_tokens || tokenCount);
+      }
 
       return {
         answer: aiResponse,

--- a/src/utils/tokenUsage.js
+++ b/src/utils/tokenUsage.js
@@ -1,0 +1,54 @@
+const TOKEN_USAGE_KEY = 'tokenUsage';
+
+// Record token usage with timestamp
+export function recordTokenUsage(tokens, timestamp = Date.now()) {
+  try {
+    const data = JSON.parse(localStorage.getItem(TOKEN_USAGE_KEY) || '[]');
+    // Remove entries older than 1 year for storage efficiency
+    const oneYearAgo = Date.now() - 365 * 24 * 60 * 60 * 1000;
+    const filtered = data.filter(entry => entry.timestamp >= oneYearAgo);
+    filtered.push({ tokens, timestamp });
+    localStorage.setItem(TOKEN_USAGE_KEY, JSON.stringify(filtered));
+  } catch (err) {
+    console.error('Failed to record token usage:', err);
+  }
+}
+
+// Get token usage statistics for last 30 days and 12 months
+export function getTokenUsageStats() {
+  try {
+    const data = JSON.parse(localStorage.getItem(TOKEN_USAGE_KEY) || '[]');
+    const now = new Date();
+
+    // Daily stats for last 30 days
+    const daily = [];
+    for (let i = 29; i >= 0; i--) {
+      const day = new Date(now);
+      day.setDate(now.getDate() - i);
+      const dateStr = day.toISOString().slice(0, 10);
+      const tokens = data
+        .filter(entry => new Date(entry.timestamp).toISOString().slice(0, 10) === dateStr)
+        .reduce((sum, entry) => sum + entry.tokens, 0);
+      daily.push({ date: dateStr, tokens });
+    }
+
+    // Monthly stats for last 12 months
+    const monthly = [];
+    for (let i = 11; i >= 0; i--) {
+      const monthDate = new Date(now.getFullYear(), now.getMonth() - i, 1);
+      const monthStr = monthDate.toISOString().slice(0, 7);
+      const tokens = data
+        .filter(entry => {
+          const d = new Date(entry.timestamp);
+          return d.getFullYear() === monthDate.getFullYear() && d.getMonth() === monthDate.getMonth();
+        })
+        .reduce((sum, entry) => sum + entry.tokens, 0);
+      monthly.push({ month: monthStr, tokens });
+    }
+
+    return { daily, monthly };
+  } catch (err) {
+    console.error('Failed to get token usage stats:', err);
+    return { daily: [], monthly: [] };
+  }
+}


### PR DESCRIPTION
## Summary
- track token usage and store locally
- surface daily and monthly usage in new admin dashboard tab

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c47a555d3c832aa9ce143be2922bfe