### PR TITLE
Use assistants API file search for attachments

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -202,19 +202,12 @@ function App() {
     setMessages((prev) => [...prev, userMessage]);
     setInputMessage('');
 
-    let documentText = '';
-    if (uploadedFile) {
-      try {
-        documentText = await uploadedFile.text();
-      } catch (e) {
-        console.error('Error reading file:', e);
-      }
-    }
+    let fileToSend = uploadedFile;
 
     try {
-      const response = ragEnabled && !documentText
+      const response = ragEnabled && !fileToSend
         ? await ragSearch(inputMessage)
-        : await openaiService.getChatResponse(inputMessage, documentText);
+        : await openaiService.getChatResponse(inputMessage, fileToSend);
 
       const assistantMessage = {
         id: uuidv4(),


### PR DESCRIPTION
## Summary
- Upload user attachments to OpenAI and request responses with file_search
- Route chat requests with attachments through assistants API; keep RAG for text-only queries
- Fix file search request body to embed file references for responses API

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c545df2dc8832ab6201bec6ac6634d