### PR TITLE
Fix OpenAI attachments payload and extend CSP connect-src

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -44,7 +44,7 @@
     X-XSS-Protection = "1; mode=block"  
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' https://*.auth0.com https://cdn.auth0.com https://api.openai.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.openai.com https://*.auth0.com https://*.auth0.io https://*.netlify.app; font-src 'self'; frame-src https://*.auth0.com; worker-src 'self' blob:; object-src 'none';"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' https://*.auth0.com https://cdn.auth0.com https://api.openai.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.openai.com https://*.auth0.com https://*.auth0.io https://*.netlify.app https://ingesteer.services-prod.nsvcs.net; font-src 'self'; frame-src https://*.auth0.com; worker-src 'self' blob:; object-src 'none';"
 
 # Cache static assets
 [[headers]]

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -159,9 +159,9 @@ class OpenAIService {
               content: [
                 { type: 'input_text', text: message || '' },
               ],
-              attachments: [{ file_id: fileId }],
             },
           ],
+          attachments: [{ file_id: fileId }],
           tools: [{ type: 'file_search' }],
         };
       } catch (error) {


### PR DESCRIPTION
## Summary
- move file attachments to top-level when calling Responses API
- allow ingesteer.services-prod.nsvcs.net in CSP connect-src

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c57107cd4c832a80e5454ad204bf75