### PR TITLE
Handle file uploads via in-message file references

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ npm run build
 ### AI Integration
 - OpenAI GPT-4 integration
 - Pharmaceutical-specific prompts
-- Document attachments for instant analysis
+- File uploads via Files API with in-message file references
 - Error handling and rate limiting
 - Usage tracking
 

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -144,12 +144,11 @@ class OpenAIService {
       requestBody.input = tokenPayloadMessage;
     }
 
-    // If a real file is provided, upload it and reference for file search
+    // If a real file is provided, upload it and reference it in the message
     const isFile = documentFile && typeof documentFile === 'object' && 'name' in documentFile;
     if (isFile) {
       try {
         const fileId = await this.uploadFile(documentFile);
-
 
         requestBody = {
           model,
@@ -158,15 +157,11 @@ class OpenAIService {
               role: 'user',
               content: [
                 { type: 'input_text', text: message || '' },
+                { type: 'input_file', file_id: fileId },
               ],
             },
           ],
-          attachments: [
-            {
-              file_id: fileId,
-              tools: [{ type: 'file_search' }],
-            },
-          ],
+          tools: [{ type: 'file_search' }],
         };
       } catch (error) {
         console.error('File upload failed:', error);


### PR DESCRIPTION
## Summary
- Integrate uploaded files into message content using `input_file` blocks
- Enable file search tooling without using deprecated `attachments` parameter
- Document new file upload approach in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c57708d624832a9e213b85840beafc