### PR TITLE
Validate file upload types and restrict selectors

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -176,6 +176,7 @@ const ChatArea = ({
             <input
               type="file"
               id="chat-file-upload"
+              accept=".pdf,.txt,.md"
               className="hidden"
               onChange={(e) => setUploadedFile(e.target.files[0] || null)}
             />

--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -590,13 +590,13 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                     <label className="block text-sm font-medium text-gray-700 mb-2">
                       Select File (Text files work best)
                     </label>
-                    <input
-                      id="file-upload"
-                      type="file"
-                      accept=".txt,.pdf,.doc,.docx"
-                      onChange={handleFileSelect}
-                      className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
-                    />
+                      <input
+                        id="file-upload"
+                        type="file"
+                        accept=".pdf,.txt,.md"
+                        onChange={handleFileSelect}
+                        className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+                      />
                     <p className="text-xs text-gray-500 mt-1">
                       Persistent storage with Neon PostgreSQL database and full-text search
                     </p>

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -109,6 +109,16 @@ class OpenAIService {
   }
 
   async uploadFile(file) {
+    const allowedExtensions = ['.pdf', '.txt', '.md'];
+    const allowedMimeTypes = ['application/pdf', 'text/plain', 'text/markdown'];
+    const fileName = file?.name?.toLowerCase() || '';
+    const fileType = file?.type?.toLowerCase() || '';
+    const hasValidExtension = allowedExtensions.some(ext => fileName.endsWith(ext));
+    const hasValidMime = allowedMimeTypes.includes(fileType);
+    if (!hasValidExtension && !hasValidMime) {
+      throw new Error('Unsupported file type; please upload a PDF, TXT, or MD file');
+    }
+
     const formData = new FormData();
     formData.append('file', file);
     formData.append('purpose', 'assistants');

--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -1,0 +1,28 @@
+import { jest } from '@jest/globals';
+import openAIService from './openaiService';
+
+describe('openAIService uploadFile', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'file-id' }),
+    });
+    global.FormData = class {
+      constructor() { this.append = jest.fn(); }
+      append() {}
+    };
+  });
+
+  it('uploads supported file types', async () => {
+    const file = { name: 'doc.pdf', type: 'application/pdf' };
+    const id = await openAIService.uploadFile(file);
+    expect(id).toBe('file-id');
+    expect(fetch).toHaveBeenCalled();
+  });
+
+  it('rejects unsupported file types', async () => {
+    const file = { name: 'image.png', type: 'image/png' };
+    await expect(openAIService.uploadFile(file)).rejects.toThrow('Unsupported file type; please upload a PDF, TXT, or MD file');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- validate file type before OpenAI file uploads and reject unsupported types
- restrict document selectors to PDF, TXT, or MD files
- add tests ensuring upload validation handles valid and invalid types

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c57f737508832a8def4369dd8d67df