### PR TITLE
Handle chat completion responses and improve error handling

### DIFF
--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -240,10 +240,12 @@ class OpenAIService {
       const aiResponse =
         data.output_text ||
         data.output?.[0]?.content?.[0]?.text ||
+        data.choices?.[0]?.message?.content ||
         null;
 
       if (!aiResponse) {
-        throw new Error('No response generated');
+        const rawData = typeof data === 'object' ? JSON.stringify(data) : String(data);
+        throw new Error(`No response generated. Raw response: ${rawData}`);
       }
 
       const resources = generateResources(message, aiResponse);

--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -1,4 +1,17 @@
 import { jest } from '@jest/globals';
+
+jest.mock('../utils/resourceGenerator', () => ({
+  generateResources: () => [],
+}));
+
+jest.mock('../utils/tokenUsage', () => ({
+  recordTokenUsage: () => {},
+}));
+
+jest.mock('../config/modelConfig', () => ({
+  getCurrentModel: () => 'test-model',
+}));
+
 import openAIService from './openaiService';
 
 describe('openAIService uploadFile', () => {
@@ -24,5 +37,42 @@ describe('openAIService uploadFile', () => {
     const file = { name: 'image.png', type: 'image/png' };
     await expect(openAIService.uploadFile(file)).rejects.toThrow('Unsupported file type; please upload a PDF, TXT, or MD file');
     expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('openAIService getChatResponse', () => {
+  beforeEach(() => {
+    openAIService.apiKey = 'test-key';
+    jest.spyOn(openAIService, 'makeRequest');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('handles responses API payload with output_text', async () => {
+    openAIService.makeRequest.mockResolvedValue({
+      output_text: 'response from output_text',
+      usage: { total_tokens: 10 },
+    });
+
+    const result = await openAIService.getChatResponse('hello');
+    expect(result.answer).toBe('response from output_text');
+  });
+
+  it('handles chat/completions payload with choices message content', async () => {
+    openAIService.makeRequest.mockResolvedValue({
+      choices: [{ message: { content: 'response from choices' } }],
+      usage: { total_tokens: 5 },
+    });
+
+    const result = await openAIService.getChatResponse('hi');
+    expect(result.answer).toBe('response from choices');
+  });
+
+  it('throws descriptive error when response has no text', async () => {
+    openAIService.makeRequest.mockResolvedValue({});
+
+    await expect(openAIService.getChatResponse('hi')).rejects.toThrow(/No response generated.*Raw response/);
   });
 });


### PR DESCRIPTION
## Summary
- Parse chat completion responses via `choices[0].message.content` in `getChatResponse`
- Include raw API output when no text is returned for easier debugging
- Add unit tests for responses API, chat/completions API, and empty payload cases

## Testing
- `npm test src/services/openaiService.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c58498cacc832aa3487ee77f0729c8