### PR TITLE
Improve OpenAI response handling

### DIFF
--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -72,6 +72,7 @@ class OpenAIService {
     }
 
     const errorMessage = errorData.error?.message || 'Unknown error';
+    console.error('OpenAI API error response:', errorData);
 
     switch (response.status) {
       case 401:
@@ -237,15 +238,19 @@ class OpenAIService {
         tokenCount
       );
 
+      const messageItem = Array.isArray(data.output)
+        ? data.output.find(item => item.type === 'message')
+        : null;
+
       const aiResponse =
         data.output_text ||
-        data.output?.[0]?.content?.[0]?.text ||
+        messageItem?.content?.[0]?.text ||
         data.choices?.[0]?.message?.content ||
         null;
 
       if (!aiResponse) {
-        const rawData = typeof data === 'object' ? JSON.stringify(data) : String(data);
-        throw new Error(`No response generated. Raw response: ${rawData}`);
+        console.error('No text found in OpenAI response:', data);
+        throw new Error(`No text found in OpenAI response: ${JSON.stringify(data)}`);
       }
 
       const resources = generateResources(message, aiResponse);

--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -70,9 +70,22 @@ describe('openAIService getChatResponse', () => {
     expect(result.answer).toBe('response from choices');
   });
 
+  it('handles responses API payload with message output', async () => {
+    openAIService.makeRequest.mockResolvedValue({
+      output: [
+        { type: 'message', content: [{ text: 'response from message' }] },
+        { type: 'other', content: [] },
+      ],
+      usage: { total_tokens: 7 },
+    });
+
+    const result = await openAIService.getChatResponse('hey');
+    expect(result.answer).toBe('response from message');
+  });
+
   it('throws descriptive error when response has no text', async () => {
     openAIService.makeRequest.mockResolvedValue({});
 
-    await expect(openAIService.getChatResponse('hi')).rejects.toThrow(/No response generated.*Raw response/);
+    await expect(openAIService.getChatResponse('hi')).rejects.toThrow(/No text found in OpenAI response/);
   });
 });


### PR DESCRIPTION
## Summary
- Search assistant responses for the first `message` entry and use its text
- Log raw API error payloads before throwing
- Cover new response paths in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c58833358c832a9bdad3995926a0c8