### PR TITLE
Add Jira service desk support request

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ REACT_APP_AUTH0_ROLES_CLAIM=https://your-domain.com/roles
 # Neon PostgreSQL (Required for database features)
 NEON_DATABASE_URL=postgresql://username:password@hostname/database?sslmode=require
 
+# Jira Service Desk (Optional)
+JIRA_API_EMAIL=your_atlassian_email
+JIRA_API_TOKEN=your_atlassian_api_token
+JIRA_SERVICE_DESK_ID=your_service_desk_id
+JIRA_REQUEST_TYPE_ID=your_request_type_id
+
 # Feature Flags (Optional)
 REACT_APP_ENABLE_AI_SUGGESTIONS=true # set to 'false' to disable AI suggestions
 ```
@@ -180,6 +186,10 @@ REACT_APP_AUTH0_DOMAIN=your-domain.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=your_client_id
 REACT_APP_OPENAI_API_KEY=your_openai_key
 REACT_APP_ENABLE_AI_SUGGESTIONS=true # optional: set to 'false' to disable AI suggestions
+JIRA_API_EMAIL=your_atlassian_email
+JIRA_API_TOKEN=your_atlassian_api_token
+JIRA_SERVICE_DESK_ID=your_service_desk_id
+JIRA_REQUEST_TYPE_ID=your_request_type_id
 ```
 
 ## 🔍 Troubleshooting

--- a/netlify/functions/support-request.js
+++ b/netlify/functions/support-request.js
@@ -1,0 +1,85 @@
+// netlify/functions/support-request.js - Create Jira Service Desk request
+
+const headers = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-user-id',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'Content-Type': 'application/json',
+};
+
+exports.handler = async (event, context) => {
+  console.log('Support request function called', { method: event.httpMethod });
+
+  // Handle CORS preflight
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({ message: 'CORS preflight successful' }),
+    };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers,
+      body: JSON.stringify({ error: 'Method not allowed' }),
+    };
+  }
+
+  try {
+    const { email, message } = JSON.parse(event.body || '{}');
+
+    if (!email || !message) {
+      return {
+        statusCode: 400,
+        headers,
+        body: JSON.stringify({ error: 'Missing email or message' }),
+      };
+    }
+
+    const jiraAuth = Buffer.from(`${process.env.JIRA_API_EMAIL}:${process.env.JIRA_API_TOKEN}`).toString('base64');
+
+    const jiraResponse = await fetch('https://acceleraqa.atlassian.net/rest/servicedeskapi/request', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Basic ${jiraAuth}`,
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        serviceDeskId: process.env.JIRA_SERVICE_DESK_ID,
+        requestTypeId: process.env.JIRA_REQUEST_TYPE_ID,
+        requestFieldValues: {
+          summary: `Support request from ${email}`,
+          description: message,
+        },
+        raiseOnBehalfOf: email,
+      }),
+    });
+
+    const data = await jiraResponse.json();
+
+    if (!jiraResponse.ok) {
+      console.error('Jira API error', data);
+      return {
+        statusCode: jiraResponse.status,
+        headers,
+        body: JSON.stringify({ error: 'Failed to create support request', details: data }),
+      };
+    }
+
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({ message: 'Support request created', key: data.key }),
+    };
+  } catch (error) {
+    console.error('Support request error:', error);
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: 'Internal server error', message: error.message }),
+    };
+  }
+};

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,6 +1,6 @@
 // src/components/Header.js - UPDATED VERSION with cloud status and clear all button removed
 import React, { memo, useMemo } from 'react';
-import { LogOut, User, Shield } from 'lucide-react';
+import { LogOut, User, Shield, LifeBuoy } from 'lucide-react';
 import { handleLogout } from '../services/authService';
 import { hasAdminRole } from '../utils/auth';
 
@@ -51,6 +51,29 @@ const Header = memo(({
     } else {
       console.error('onShowAdmin function not provided to Header component');
       alert('Admin function not available. Check console for details.');
+    }
+  };
+
+  const handleSupportClick = async () => {
+    const message = window.prompt('Describe your issue:');
+    if (!message) return;
+
+    try {
+      const response = await fetch('/.netlify/functions/support-request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user?.email, message }),
+      });
+
+      if (response.ok) {
+        alert('Support request submitted');
+      } else {
+        console.error('Support request failed', await response.text());
+        alert('Failed to submit support request');
+      }
+    } catch (error) {
+      console.error('Support request error:', error);
+      alert('Failed to submit support request');
     }
   };
 
@@ -111,6 +134,16 @@ const Header = memo(({
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
               </svg>
               <span>Open Notebook</span>
+            </button>
+
+            {/* Support */}
+            <button
+              onClick={handleSupportClick}
+              className="flex items-center space-x-2 px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label="Raise support request"
+            >
+              <LifeBuoy className="h-4 w-4" />
+              <span className="hidden sm:block">Support</span>
             </button>
 
             {/* Logout */}


### PR DESCRIPTION
## Summary
- add header button that posts support requests
to Jira Service Desk
- implement Netlify function to call Jira API
- document required Jira environment variables

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c5c4c27788832aacc87992c30097dc