### PR TITLE
feat: persist chat messages to storage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,7 @@ import { initializeNeonService, loadConversations as loadNeonConversations, save
 //import { initializeNeonService, loadConversations as loadNeonConversations } from './services/neonService';
 
 import { FEATURE_FLAGS } from './config/featureFlags';
+import { loadMessagesFromStorage, saveMessagesToStorage } from './utils/storageUtils';
 
 const COOLDOWN_SECONDS = 10;
 
@@ -115,6 +116,35 @@ function App() {
       }
     }
   }, [user, loadInitialLearningSuggestions]);
+
+  // Load messages from storage when user logs in
+  useEffect(() => {
+    const loadStoredMessages = async () => {
+      if (!user?.sub) return;
+      try {
+        const stored = await loadMessagesFromStorage(user.sub);
+        setMessages(stored);
+      } catch (error) {
+        console.error('Failed to load messages from storage:', error);
+      }
+    };
+
+    loadStoredMessages();
+  }, [user]);
+
+  // Persist messages to storage whenever they change
+  useEffect(() => {
+    if (!user?.sub) return;
+    const persist = async () => {
+      try {
+        await saveMessagesToStorage(user.sub, messages);
+      } catch (error) {
+        console.error('Failed to save messages to storage:', error);
+      }
+    };
+
+    persist();
+  }, [messages, user]);
 
   // Load conversations from Neon when user is available or refresh requested
   useEffect(() => {


### PR DESCRIPTION
## Summary
- load stored chat messages for the logged in user on mount
- persist messages to storage whenever they change

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c5e507f7bc832ab5803aeee9c8c3c6