### PR TITLE
Show loading screen during authentication

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -365,10 +365,10 @@ function App() {
 
   return (
     <ErrorBoundary>
-      {!isAuthenticated ? (
-        <AuthScreen />
-      ) : loading ? (
+      {loading ? (
         <LoadingScreen />
+      ) : !isAuthenticated ? (
+        <AuthScreen />
       ) : showRAGConfig ? (
         <RAGConfigurationPage onClose={handleCloseRAGConfig} user={user} />
       ) : showAdmin ? (


### PR DESCRIPTION
## Summary
- Ensure loading state is evaluated before authentication check
- Display `LoadingScreen` while auth initializes and show `AuthScreen` only after loading completes

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5e50c34fc832a814b95ed5fabf9d1