### PR TITLE
feat: add conversations tab to learning center

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,7 @@ import { initializeNeonService, loadConversations as loadNeonConversations, save
 
 import { FEATURE_FLAGS } from './config/featureFlags';
 import { loadMessagesFromStorage, saveMessagesToStorage } from './utils/storageUtils';
+import { mergeCurrentAndStoredMessages } from './utils/messageUtils';
 
 const COOLDOWN_SECONDS = 10;
 
@@ -184,6 +185,15 @@ function App() {
       console.error('Error refreshing learning suggestions:', error);
     }
   }, [user]);
+
+  // Load a previous conversation into the chat window
+  const handleConversationSelect = useCallback((conversationId) => {
+    const merged = mergeCurrentAndStoredMessages(messages, thirtyDayMessages);
+    const convMessages = merged.filter(m => m.conversationId === conversationId);
+    if (convMessages.length) {
+      setMessages(convMessages.map(m => ({ ...m, isCurrent: true })));
+    }
+  }, [messages, thirtyDayMessages]);
 
   // Auto-scroll messages
   useEffect(() => {
@@ -452,22 +462,14 @@ function App() {
                 {/* Sidebar is collapsible on mobile */}
                 <div className="flex-shrink-0 border-t bg-white max-h-60 overflow-hidden">
                   <Sidebar
-                    showNotebook={showNotebook}
                     messages={messages}
                     thirtyDayMessages={thirtyDayMessages}
-                    selectedMessages={selectedMessages}
-                    setSelectedMessages={setSelectedMessages}
-                    exportSelected={handleExportSelected}
-                    clearSelected={clearSelectedMessages}
-                    clearAllConversations={clearAllConversations}
-                    isServerAvailable={isServerAvailable}
-                    onRefresh={handleRefreshConversations}
-                    // Enhanced props for learning suggestions
                     user={user}
                     learningSuggestions={learningSuggestions}
                     isLoadingSuggestions={isLoadingSuggestions}
                     onSuggestionsUpdate={handleSuggestionsUpdate}
                     onAddResource={handleAddResourceToNotebook}
+                    onConversationSelect={handleConversationSelect}
                   />
                 </div>
               </div>
@@ -496,22 +498,14 @@ function App() {
                 {/* Sidebar - Fixed optimal width with enhanced learning features */}
                 <div className="w-80 xl:w-96 flex-shrink-0 border-l bg-white p-6">
                   <Sidebar
-                    showNotebook={showNotebook}
                     messages={messages}
                     thirtyDayMessages={thirtyDayMessages}
-                    selectedMessages={selectedMessages}
-                    setSelectedMessages={setSelectedMessages}
-                    exportSelected={handleExportSelected}
-                    clearSelected={clearSelectedMessages}
-                    clearAllConversations={clearAllConversations}
-                    isServerAvailable={isServerAvailable}
-                    onRefresh={handleRefreshConversations}
-                    // Enhanced props for learning suggestions
                     user={user}
                     learningSuggestions={learningSuggestions}
                     isLoadingSuggestions={isLoadingSuggestions}
                     onSuggestionsUpdate={handleSuggestionsUpdate}
                     onAddResource={handleAddResourceToNotebook}
+                    onConversationSelect={handleConversationSelect}
                   />
                 </div>
               </div>

--- a/src/components/ConversationList.js
+++ b/src/components/ConversationList.js
@@ -1,0 +1,51 @@
+import React, { memo } from 'react';
+import { MessageSquare } from 'lucide-react';
+
+/**
+ * Displays a list of recent conversations and notifies parent when one is selected
+ */
+const ConversationList = memo(({ conversations = [], onSelect = () => {} }) => {
+  if (!conversations.length) {
+    return (
+      <p className="text-sm text-gray-500">No conversations yet.</p>
+    );
+  }
+
+  const handleClick = (conv) => {
+    const conversationId =
+      conv.originalAiMessage?.conversationId ||
+      conv.originalUserMessage?.conversationId;
+    if (conversationId) {
+      onSelect(conversationId);
+    }
+  };
+
+  return (
+    <ul className="space-y-2" data-testid="conversation-list">
+      {conversations.map(conv => (
+        <li
+          key={conv.id}
+          className="flex items-center space-x-2 p-2 hover:bg-gray-50 rounded cursor-pointer"
+          onClick={() => handleClick(conv)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              handleClick(conv);
+            }
+          }}
+        >
+          <MessageSquare className="h-4 w-4 text-gray-400" />
+          <span className="text-sm text-gray-700 truncate">
+            {(conv.userContent || conv.aiContent || '').slice(0, 40)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+});
+
+ConversationList.displayName = 'ConversationList';
+
+export default ConversationList;

--- a/src/components/ConversationList.test.js
+++ b/src/components/ConversationList.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import ConversationList from './ConversationList';
+
+describe('ConversationList', () => {
+  it('invokes onSelect with conversation id when item clicked', async () => {
+    const conversation = {
+      id: '1-2',
+      userContent: 'Hello',
+      aiContent: 'Hi there',
+      originalUserMessage: { conversationId: 'conv1' },
+      originalAiMessage: { conversationId: 'conv1' }
+    };
+
+    const onSelect = jest.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    await act(async () => {
+      ReactDOM.render(
+        <ConversationList conversations={[conversation]} onSelect={onSelect} />,
+        container
+      );
+    });
+
+    const item = container.querySelector('li');
+    await act(async () => {
+      item.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onSelect).toHaveBeenCalledWith('conv1');
+
+    document.body.removeChild(container);
+  });
+});

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,84 +1,47 @@
 // src/components/Sidebar.js - Enhanced with learning suggestions integration
 
 import React from 'react';
-import NotebookView from './NotebookView';
 import ResourcesView from './ResourcesView';
 import { FEATURE_FLAGS } from '../config/featureFlags';
 
 const Sidebar = ({
-  showNotebook,
   messages,
   thirtyDayMessages,
-  selectedMessages,
-  setSelectedMessages,
-  exportSelected,
-  clearSelected,
-  clearAllConversations,
-  isServerAvailable,
-  onRefresh,
-  // Enhanced props for learning suggestions
   user,
   learningSuggestions = [],
   isLoadingSuggestions = false,
   onSuggestionsUpdate,
-  onAddResource
+  onAddResource,
+  onConversationSelect
 }) => {
   return (
     <div className="h-full flex flex-col bg-white rounded-lg shadow-sm border border-gray-200 lg:min-h-0">
       {/* Sidebar Header */}
         <div className="flex-shrink-0 px-4 py-3 border-b border-gray-200 bg-gray-50 rounded-t-lg">
-          <h3 className="text-base sm:text-lg font-semibold text-gray-900">
-            {showNotebook ? 'Conversation History' : 'Learning Center'}
-          </h3>
-          {showNotebook && (
-            <p className="text-xs sm:text-sm text-gray-600 mt-1">
-              Review and export your conversations
-            </p>
-          )}
+          <h3 className="text-base sm:text-lg font-semibold text-gray-900">Learning Center</h3>
         </div>
 
       {/* Sidebar Content */}
       <div className="flex-1 min-h-0 overflow-hidden">
-        {showNotebook ? (
-          <NotebookView
-            messages={messages}
-            thirtyDayMessages={thirtyDayMessages}
-            selectedMessages={selectedMessages}
-            setSelectedMessages={setSelectedMessages}
-            exportSelected={exportSelected}
-            clearSelected={clearSelected}
-            clearAllConversations={clearAllConversations}
-            isServerAvailable={isServerAvailable}
-            onRefresh={onRefresh}
-          />
-        ) : (
-          <ResourcesView
-            // Pass current resources (from message resources if any)
-            currentResources={extractResourcesFromMessages(messages)}
-            // Enhanced learning suggestions props
-            user={user}
-            learningSuggestions={learningSuggestions}
-            isLoadingSuggestions={isLoadingSuggestions}
-            onSuggestionsUpdate={onSuggestionsUpdate}
-            onAddResource={onAddResource}
-          />
-        )}
+        <ResourcesView
+          currentResources={extractResourcesFromMessages(messages)}
+          user={user}
+          messages={messages}
+          thirtyDayMessages={thirtyDayMessages}
+          onSuggestionsUpdate={onSuggestionsUpdate}
+          onAddResource={onAddResource}
+          onConversationSelect={onConversationSelect}
+        />
       </div>
 
       {/* Enhanced Footer with Learning Status */}
-      {(showNotebook || FEATURE_FLAGS.ENABLE_AI_SUGGESTIONS) && (
+      {FEATURE_FLAGS.ENABLE_AI_SUGGESTIONS && (
         <div className="flex-shrink-0 px-4 py-3 border-t border-gray-200 bg-gray-50 rounded-b-lg">
           <div className="flex items-center justify-between text-xs text-gray-500">
-            <span>
-              {showNotebook
-                ? `${thirtyDayMessages?.length || 0} conversations`
-                : `${learningSuggestions.length} AI suggestions`
-              }
-            </span>
+            <span>{`${learningSuggestions.length} AI suggestions`}</span>
 
             <div className="flex items-center space-x-2">
-              {/* Learning Status Indicator */}
-              {!showNotebook && FEATURE_FLAGS.ENABLE_AI_SUGGESTIONS && (
+              {FEATURE_FLAGS.ENABLE_AI_SUGGESTIONS && (
                 <>
                   {isLoadingSuggestions ? (
                     <div className="flex items-center space-x-1 text-purple-600">
@@ -94,16 +57,6 @@ const Sidebar = ({
                     <span className="text-gray-400">Start chatting</span>
                   )}
                 </>
-              )}
-
-              {isServerAvailable && showNotebook && (
-                <button
-                  onClick={onRefresh}
-                  className="text-blue-600 hover:text-blue-800 font-medium"
-                  title="Refresh from cloud"
-                >
-                  Refresh
-                </button>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add ConversationList component for displaying past chats
- expand ResourcesView with new "Conversations" tab
- simplify Sidebar to always show Learning Center and wire up conversation data
- enable selecting a past conversation to reload it in the chat window

## Testing
- `npm test -- --watchAll=false 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c5ea843d60832ab9716dd44aa28def