### PR TITLE
Add global scope flag and index for rag documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ JIRA_SERVICE_DESK_ID=your_service_desk_id
 JIRA_REQUEST_TYPE_ID=your_request_type_id
 ```
 
+### Database Migration
+
+Run the Neon database setup script to apply the latest schema changes, including the new `is_global` flag and index:
+
+```bash
+npm run setup:neon
+```
+
 ## 🔍 Troubleshooting
 
 ### Common Issues

--- a/scripts/setup-neon-database.js
+++ b/scripts/setup-neon-database.js
@@ -81,6 +81,7 @@ async function setupNeonDatabase() {
         metadata JSONB DEFAULT '{}',
         category document_category DEFAULT 'general',
         tags TEXT[] DEFAULT '{}',
+        is_global BOOLEAN DEFAULT FALSE,
         created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
         updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
       )
@@ -141,6 +142,7 @@ async function setupNeonDatabase() {
     await sql`CREATE INDEX IF NOT EXISTS idx_rag_documents_category ON rag_documents(user_id, category)`;
     await sql`CREATE INDEX IF NOT EXISTS idx_rag_documents_created ON rag_documents(user_id, created_at DESC)`;
     await sql`CREATE INDEX IF NOT EXISTS idx_rag_documents_filename ON rag_documents(user_id, filename)`;
+    await sql`CREATE INDEX IF NOT EXISTS idx_rag_documents_global ON rag_documents(is_global)`;
     await sql`CREATE INDEX IF NOT EXISTS idx_rag_documents_tags ON rag_documents USING GIN(tags)`;
 
     // Document chunks indexes


### PR DESCRIPTION
## Summary
- add `is_global` column to `rag_documents` table
- index `is_global` for faster global document lookups
- document database migration steps in deployment guide

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c6139bd2b8832a8a648bcc35afb3f9