### PR TITLE
feat: add upload scope control

### DIFF
--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -1,12 +1,12 @@
 // src/components/RAGConfigurationPage.js - Fixed authentication for Neon
 import React, { useState, useEffect, useCallback } from 'react';
-import { 
-  Upload, 
-  FileText, 
-  Trash2, 
-  Search, 
-  AlertCircle, 
-  CheckCircle, 
+import {
+  Upload,
+  FileText,
+  Trash2,
+  Search,
+  AlertCircle,
+  CheckCircle,
   Download,
   Settings,
   Database,
@@ -16,10 +16,12 @@ import {
   BarChart3,
   Bug,
   User,
+  Users,
   Key
 } from 'lucide-react';
 import ragService from '../services/ragService';
 import { getToken } from '../services/authService';
+import { hasAdminRole } from '../utils/auth';
 
 const RAGConfigurationPage = ({ user, onClose }) => {
   const [documents, setDocuments] = useState([]);
@@ -39,6 +41,9 @@ const RAGConfigurationPage = ({ user, onClose }) => {
     tags: '',
     category: 'general'
   });
+  const [isGlobal, setIsGlobal] = useState(false);
+
+  const isAdmin = hasAdminRole(user);
 
   // Enhanced authentication debugging
   const checkAuthentication = useCallback(async () => {
@@ -218,8 +223,8 @@ const RAGConfigurationPage = ({ user, onClose }) => {
         tags: uploadMetadata.tags.split(',').map(tag => tag.trim()).filter(tag => tag)
       };
 
-      console.log('Uploading document with metadata:', metadata);
-      const result = await ragService.uploadDocument(selectedFile, metadata);
+      console.log('Uploading document with metadata:', metadata, 'isGlobal:', isGlobal);
+      const result = await ragService.uploadDocument(selectedFile, metadata, isGlobal);
       console.log('Upload result:', result);
       
       setUploadStatus({ 
@@ -234,6 +239,7 @@ const RAGConfigurationPage = ({ user, onClose }) => {
         tags: '',
         category: 'general'
       });
+      setIsGlobal(false);
       
       const fileInput = document.getElementById('file-upload');
       if (fileInput) fileInput.value = '';
@@ -635,6 +641,22 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                         <option value="training">Training</option>
                       </select>
                     </div>
+
+                    {isAdmin && (
+                      <div>
+                        <label className="block text-sm font-medium text-gray-900 mb-1">
+                          Visibility
+                        </label>
+                        <select
+                          value={isGlobal ? 'global' : 'private'}
+                          onChange={(e) => setIsGlobal(e.target.value === 'global')}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
+                        >
+                          <option value="private">Only me</option>
+                          <option value="global">All users</option>
+                        </select>
+                      </div>
+                    )}
                   </div>
                 </div>
 
@@ -719,6 +741,16 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                           <p><span className="font-medium">Uploaded:</span> {new Date(doc.createdAt).toLocaleDateString()}</p>
                           <p><span className="font-medium">Storage:</span> Neon PostgreSQL</p>
                           <p><span className="font-medium">Search:</span> Full-text indexed</p>
+                          {isAdmin && (
+                            <p className="flex items-center space-x-1">
+                              {(doc.isGlobal ?? doc.metadata?.isGlobal) ? (
+                                <Users className="h-3 w-3 text-blue-600" />
+                              ) : (
+                                <User className="h-3 w-3 text-gray-600" />
+                              )}
+                              <span>{(doc.isGlobal ?? doc.metadata?.isGlobal) ? 'All users' : 'Only me'}</span>
+                            </p>
+                          )}
                           {doc.metadata?.tags && doc.metadata.tags.length > 0 && (
                             <div className="flex items-center space-x-1 mt-2">
                               <span className="font-medium">Tags:</span>

--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -187,15 +187,15 @@ class RAGService {
     }
   }
 
-  async uploadDocument(file, metadata = {}) {
+  async uploadDocument(file, metadata = {}, isGlobal = false) {
     try {
       if (!file) {
         throw new Error('File is required');
       }
 
-      console.log('Uploading document:', file.name);
+      console.log('Uploading document:', file.name, 'isGlobal:', isGlobal);
       const text = await this.extractTextFromFile(file);
-      
+
       const result = await this.makeAuthenticatedRequest(this.apiUrl, {
         action: 'upload',
         document: {
@@ -210,7 +210,8 @@ class RAGService {
             processingMode: 'neon-postgresql',
             ...metadata
           }
-        }
+        },
+        isGlobal
       });
 
       return result;
@@ -582,7 +583,7 @@ const ragService = new RAGService();
 export default ragService;
 
 // Export convenience functions
-export const uploadDocument = (file, metadata) => ragService.uploadDocument(file, metadata);
+export const uploadDocument = (file, metadata, isGlobal) => ragService.uploadDocument(file, metadata, isGlobal);
 export const search = (query, options) => ragService.search(query, options);
 export const searchDocuments = (query, options) => ragService.searchDocuments(query, options);
 export const getDocuments = () => ragService.getDocuments();


### PR DESCRIPTION
## Summary
- allow admins to mark uploaded documents as personal or global
- send chosen scope to RAG upload service via `isGlobal`
- show scope indicators so admins can see shared vs personal documents

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c613983780832aae203da0aae0b252