### PR TITLE
feat: add global document support

### DIFF
--- a/netlify/functions/neon-rag-fixed.js
+++ b/netlify/functions/neon-rag-fixed.js
@@ -327,6 +327,8 @@ async function handleUpload(userId, document) {
     }
     const text = document.text || '';
     const chunks = chunkText(text);
+    const isAdmin = (process.env.ADMIN_USER_IDS || '').split(',').includes(userId);
+    const isGlobal = isAdmin && document.isGlobal === true;
 
     const pool = await getPool();
     let client;
@@ -343,8 +345,9 @@ async function handleUpload(userId, document) {
           file_type,
           file_size,
           text_content,
-          metadata
-        ) VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING id, filename, created_at`,
+          metadata,
+          is_global
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING id, filename, created_at`,
         [
           userId,
           document.filename,
@@ -353,6 +356,7 @@ async function handleUpload(userId, document) {
           document.size || text.length,
           text,
           JSON.stringify(document.metadata || {}),
+          isGlobal,
         ]
       );
       insertedDocument = docResult.rows[0];
@@ -414,10 +418,10 @@ async function handleList(userId) {
   try {
     const sql = await getSql();
     const rows = await sql`
-      SELECT d.id, d.filename, d.file_type, d.file_size, d.created_at, d.metadata,
+      SELECT d.id, d.filename, d.file_type, d.file_size, d.created_at, d.metadata, d.is_global,
              (SELECT COUNT(*) FROM rag_document_chunks c WHERE c.document_id = d.id) AS chunk_count
       FROM rag_documents d
-      WHERE d.user_id = ${userId}
+      WHERE d.user_id = ${userId} OR d.is_global = true
       ORDER BY d.created_at DESC
     `;
 
@@ -429,6 +433,7 @@ async function handleList(userId) {
       chunks: doc.chunk_count,
       createdAt: doc.created_at,
       metadata: doc.metadata,
+      isGlobal: doc.is_global,
     }));
 
     return {
@@ -457,7 +462,7 @@ async function handleDelete(userId, documentId) {
     }
     const sql = await getSql();
     const [doc] = await sql`
-      SELECT id FROM rag_documents WHERE id = ${documentId} AND user_id = ${userId}
+      SELECT user_id, is_global FROM rag_documents WHERE id = ${documentId}
     `;
     if (!doc) {
       return {
@@ -467,8 +472,25 @@ async function handleDelete(userId, documentId) {
       };
     }
 
+    const isAdmin = (process.env.ADMIN_USER_IDS || '').split(',').includes(userId);
+    if (doc.is_global && !isAdmin) {
+      return {
+        statusCode: 403,
+        headers,
+        body: JSON.stringify({ error: 'Cannot delete global document' }),
+      };
+    }
+
+    if (doc.user_id !== userId && !isAdmin) {
+      return {
+        statusCode: 404,
+        headers,
+        body: JSON.stringify({ error: 'Document not found' }),
+      };
+    }
+
     await sql`
-      DELETE FROM rag_documents WHERE id = ${documentId} AND user_id = ${userId}
+      DELETE FROM rag_documents WHERE id = ${documentId}
     `;
 
     return {
@@ -501,7 +523,7 @@ async function handleSearch(userId, query, options = {}) {
       SELECT c.document_id, c.chunk_index, c.chunk_text, d.filename
       FROM rag_document_chunks c
       JOIN rag_documents d ON c.document_id = d.id
-      WHERE d.user_id = ${userId}
+      WHERE (d.user_id = ${userId} OR d.is_global = true)
         AND c.chunk_text ILIKE ${'%' + query + '%'}
       LIMIT ${limit}
     `;

--- a/scripts/setup-neon-database.js
+++ b/scripts/setup-neon-database.js
@@ -79,11 +79,18 @@ async function setupNeonDatabase() {
         file_size INTEGER NOT NULL,
         text_content TEXT NOT NULL,
         metadata JSONB DEFAULT '{}',
+        is_global BOOLEAN DEFAULT FALSE,
         category document_category DEFAULT 'general',
         tags TEXT[] DEFAULT '{}',
         created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
         updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
       )
+    `;
+
+    // Ensure is_global column exists for existing installations
+    await sql`
+      ALTER TABLE rag_documents
+      ADD COLUMN IF NOT EXISTS is_global BOOLEAN DEFAULT FALSE
     `;
 
     // Create rag_document_chunks table


### PR DESCRIPTION
## Summary
- add is_global flag to rag documents schema
- store isGlobal flag on upload and expose global docs in lists and search
- restrict deletion of global documents to admins

## Testing
- `npm test --silent -- --watchAll=false 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c613943d9c832abbd532019aec822d