### PR TITLE
Add footer with privacy policy link

### DIFF
--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Policy</title>
+  <link rel="icon" href="/AceleraQA_logo.png" />
+  <style>
+    body { font-family: sans-serif; margin: 2rem; line-height: 1.6; }
+    h1 { font-size: 2rem; margin-bottom: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <p>This is the privacy policy for AcceleraQA, LLC.</p>
+</body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import RAGConfigurationPage from './components/RAGConfigurationPage';
 import AdminScreen from './components/AdminScreen';
 import NotebookOverlay from './components/NotebookOverlay';
 import SupportRequestOverlay from './components/SupportRequestOverlay';
+import Footer from './components/Footer';
 
 // Utility
 import { v4 as uuidv4 } from 'uuid';
@@ -427,7 +428,7 @@ function App() {
         <AdminScreen onBack={handleCloseAdmin} user={user} />
       ) : (
         <>
-          <div className="min-h-screen bg-gray-50">
+          <div className="min-h-screen bg-gray-50 flex flex-col">
             {/* Header remains the same */}
             <Header
               user={user}
@@ -441,7 +442,7 @@ function App() {
             />
 
             {/* Main Layout */}
-            <div className="h-[calc(100vh-64px)]">
+            <div className="flex-1">
               {/* Mobile Layout (stacked vertically) */}
               <div className="lg:hidden h-full flex flex-col">
                 {/* Chat takes most space on mobile */}
@@ -514,6 +515,7 @@ function App() {
                 </div>
               </div>
             </div>
+            <Footer />
           </div>
 
           {/* Notebook Overlay */}

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const Footer = () => {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="bg-gray-50 border-t border-gray-200 text-center py-4 text-sm text-gray-600">
+      <p>
+        &copy; {year} AcceleraQA, LLC.{' '}
+        <a href="/privacy-policy.html" className="text-blue-600 hover:underline">
+          Privacy Policy
+        </a>
+      </p>
+    </footer>
+  );
+};
+
+export default Footer;


### PR DESCRIPTION
## Summary
- add reusable footer component with dynamic year and privacy policy link
- integrate footer into main app layout
- provide static privacy policy page

## Testing
- `CI=true npm test -- --watchAll=false 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c61693811c832a912e46dabf8ea903