### PR TITLE
Gracefully handle missing Neon RAG tables

### DIFF
--- a/netlify/functions/neon-rag-fixed.js
+++ b/netlify/functions/neon-rag-fixed.js
@@ -443,10 +443,23 @@ async function handleList(userId) {
     };
   } catch (error) {
     console.error('List error:', error);
+    // Return an empty list for common database errors so the client
+    // can continue to function even if the backing store is unavailable.
+    const message = error.message || '';
+    const isMissingTable = /rag_documents/i.test(message) || /relation/i.test(message);
+    const isConfigError = message.includes('NEON_DATABASE_URL');
+    if (isMissingTable || isConfigError) {
+      console.warn('Returning empty document list due to database configuration issue');
+      return {
+        statusCode: 200,
+        headers,
+        body: JSON.stringify({ documents: [], total: 0, warning: 'database unavailable' }),
+      };
+    }
     return {
       statusCode: 500,
       headers,
-      body: JSON.stringify({ error: 'Failed to list documents', message: error.message }),
+      body: JSON.stringify({ error: 'Failed to list documents', message: message }),
     };
   }
 }


### PR DESCRIPTION
## Summary
- Avoid 500 errors when Neon RAG tables are misconfigured or absent
- Return empty document list with warning when database is unavailable

## Testing
- `npm test -- --watchAll=false --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c6a7bf84f4832a9dae7b2c63d7f408