### PR TITLE
Update RAG routing for OpenAI search

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ cp .env.example .env
 ### 3. Required Environment Variables
 ```bash
 # OpenAI (Required)
+OPENAI_API_KEY=your_openai_api_key
 REACT_APP_OPENAI_API_KEY=your_openai_api_key
 
-# Auth0 (Required)  
+# Auth0 (Required)
 REACT_APP_AUTH0_DOMAIN=your-domain.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=your_client_id
 
@@ -86,9 +87,6 @@ REACT_APP_AUTH0_CLIENT_ID=your_client_id
 REACT_APP_AUTH0_AUDIENCE=your_api_audience
 REACT_APP_AUTH0_ROLES_CLAIM=https://your-domain.com/roles
 REACT_APP_AUTH0_ORG_CLAIM=https://your-domain.com/org
-
-# Neon PostgreSQL (Required for database features)
-NEON_DATABASE_URL=postgresql://username:password@hostname/database?sslmode=require
 
 # Jira Service Desk (Optional)
 JIRA_API_EMAIL=your_atlassian_email
@@ -185,20 +183,13 @@ npm run build
 ```bash
 REACT_APP_AUTH0_DOMAIN=your-domain.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=your_client_id
+OPENAI_API_KEY=your_openai_key
 REACT_APP_OPENAI_API_KEY=your_openai_key
 REACT_APP_ENABLE_AI_SUGGESTIONS=true # optional: set to 'false' to disable AI suggestions
 JIRA_API_EMAIL=your_atlassian_email
 JIRA_API_TOKEN=your_atlassian_api_token
 JIRA_SERVICE_DESK_ID=your_service_desk_id
 JIRA_REQUEST_TYPE_ID=your_request_type_id
-```
-
-### Database Migration
-
-Run the Neon database setup script to apply the latest schema changes:
-
-```bash
-npm run setup:neon
 ```
 
 ## 🔍 Troubleshooting

--- a/netlify.toml
+++ b/netlify.toml
@@ -25,10 +25,10 @@
   to = "/index.html"
   status = 200
 
-# API routes for Neon functions
+# API routes for serverless functions
 [[redirects]]
   from = "/api/rag/*"
-  to = "/.netlify/functions/neon-rag"
+  to = "/.netlify/functions/openai-file-search"
   status = 200
 
 [[redirects]]
@@ -52,12 +52,12 @@
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
 
-# Function settings - Updated for ES Modules and Neon
+# Function settings - Updated for ES Modules
 [functions]
-  external_node_modules = ["@neondatabase/serverless", "mammoth", "jsonwebtoken", "jwks-rsa"]
+  external_node_modules = ["mammoth", "jsonwebtoken", "jwks-rsa"]
   node_bundler = "esbuild"
   directory = "netlify/functions"
 
 # Environment variables needed for functions (add these in Netlify dashboard)
-# NEON_DATABASE_URL = "postgresql://..."
+# OPENAI_API_KEY = "sk-..."
 # REACT_APP_OPENAI_API_KEY = "sk-..."

--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -978,7 +978,7 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                         <li>1. Try refreshing the page to get a new token</li>
                         <li>2. Sign out and sign back in</li>
                         <li>3. Check that your Auth0 configuration is correct</li>
-                        <li>4. Verify that NEON_DATABASE_URL is set in Netlify</li>
+                        <li>4. Verify that OPENAI_API_KEY is set in Netlify</li>
                         <li>5. Check the Network tab in browser dev tools</li>
                       </ul>
                     </div>


### PR DESCRIPTION
## Summary
- redirect `/api/rag/*` to OpenAI search function
- drop Neon serverless dependency from Netlify functions config
- remove `NEON_DATABASE_URL` hints and document required `OPENAI_API_KEY`

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'pdfjs-dist/legacy/build/pdf.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_68c6c950fb4c832a8f9ed3efb6e91d7a