### PR TITLE
Use server-side OPENAI_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ cp .env.example .env
 ```bash
 # OpenAI (Required)
 OPENAI_API_KEY=your_openai_api_key
-REACT_APP_OPENAI_API_KEY=your_openai_api_key
 
 # Auth0 (Required)
 REACT_APP_AUTH0_DOMAIN=your-domain.auth0.com
@@ -184,7 +183,6 @@ npm run build
 REACT_APP_AUTH0_DOMAIN=your-domain.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=your_client_id
 OPENAI_API_KEY=your_openai_key
-REACT_APP_OPENAI_API_KEY=your_openai_key
 REACT_APP_ENABLE_AI_SUGGESTIONS=true # optional: set to 'false' to disable AI suggestions
 JIRA_API_EMAIL=your_atlassian_email
 JIRA_API_TOKEN=your_atlassian_api_token

--- a/netlify.toml
+++ b/netlify.toml
@@ -60,4 +60,3 @@
 
 # Environment variables needed for functions (add these in Netlify dashboard)
 # OPENAI_API_KEY = "sk-..."
-# REACT_APP_OPENAI_API_KEY = "sk-..."

--- a/netlify/functions/connection-test.js
+++ b/netlify/functions/connection-test.js
@@ -28,8 +28,8 @@ export const handler = async (event, context) => {
   console.log('📋 Testing environment variables...');
   try {
     const neonUrl = process.env.NEON_DATABASE_URL;
-    const openaiKey = process.env.REACT_APP_OPENAI_API_KEY;
-    const auth0Domain = process.env.REACT_APP_AUTH0_DOMAIN;
+    const openaiKey = process.env.OPENAI_API_KEY;
+    const auth0Domain = process.env.AUTH0_DOMAIN || process.env.REACT_APP_AUTH0_DOMAIN;
     
     testResults.tests.environmentVariables = {
       success: true,
@@ -41,12 +41,12 @@ export const handler = async (event, context) => {
           hasSslMode: neonUrl ? neonUrl.includes('sslmode=require') : false,
           hostExtracted: neonUrl ? extractHostFromUrl(neonUrl) : null
         },
-        REACT_APP_OPENAI_API_KEY: {
+        OPENAI_API_KEY: {
           present: !!openaiKey,
           length: openaiKey ? openaiKey.length : 0,
           startsWithSk: openaiKey ? openaiKey.startsWith('sk-') : false
         },
-        REACT_APP_AUTH0_DOMAIN: {
+        AUTH0_DOMAIN: {
           present: !!auth0Domain,
           length: auth0Domain ? auth0Domain.length : 0,
           isAuth0Format: auth0Domain ? auth0Domain.includes('.auth0.com') : false

--- a/netlify/functions/rag-enhanced.js
+++ b/netlify/functions/rag-enhanced.js
@@ -269,7 +269,7 @@ async function handleUpload(userId, document) {
  */
 async function generateEmbedding(text) {
   try {
-    const apiKey = process.env.REACT_APP_OPENAI_API_KEY;
+    const apiKey = process.env.OPENAI_API_KEY;
     
     if (!apiKey) {
       throw new Error('OpenAI API key not configured');

--- a/scripts/setup-rag-fauna.js
+++ b/scripts/setup-rag-fauna.js
@@ -198,7 +198,7 @@ Add this to your existing netlify.toml file:
 Add these environment variables to your .env file and Netlify dashboard:
 
 # Existing variables
-REACT_APP_OPENAI_API_KEY=your_openai_api_key
+OPENAI_API_KEY=your_openai_api_key
 REACT_APP_AUTH0_DOMAIN=your-domain.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=your_client_id
 

--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -919,8 +919,8 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                     <div className="p-3 bg-white border rounded-md space-y-2">
                       <p className="text-sm">
                         <strong>OpenAI API Key:</strong> 
-                        <span className={process.env.REACT_APP_OPENAI_API_KEY ? 'text-green-600' : 'text-red-600'}>
-                          {process.env.REACT_APP_OPENAI_API_KEY ? ' ✓ Set' : ' ✗ Missing'}
+                        <span className={process.env.OPENAI_API_KEY ? 'text-green-600' : 'text-red-600'}>
+                          {process.env.OPENAI_API_KEY ? ' ✓ Set' : ' ✗ Missing'}
                         </span>
                       </p>
                       <p className="text-sm">

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -54,7 +54,7 @@ export const FEATURE_FLAGS = {
 
 // Enhanced Error Messages with troubleshooting
 export const ERROR_MESSAGES = {
-  API_KEY_NOT_CONFIGURED: 'OpenAI API key not configured.\n\nTROUBLESHOOTING STEPS:\n1. Check that REACT_APP_OPENAI_API_KEY is set in your environment\n2. If deploying to Netlify, add the variable in Site Settings > Environment Variables\n3. Get your API key from: https://platform.openai.com/account/api-keys\n4. Contact your administrator if you need access',
+  API_KEY_NOT_CONFIGURED: 'OpenAI API key not configured.\n\nTROUBLESHOOTING STEPS:\n1. Check that OPENAI_API_KEY is set in your environment\n2. If deploying to Netlify, add the variable in Site Settings > Environment Variables\n3. Get your API key from: https://platform.openai.com/account/api-keys\n4. Contact your administrator if you need access',
 
   INVALID_API_KEY: 'Invalid OpenAI API key.\n\nTROUBLESHOOTING STEPS:\n1. Verify your API key is correct and active\n2. Check your OpenAI account billing status\n3. Generate a new API key if needed: https://platform.openai.com/account/api-keys',
 
@@ -74,8 +74,8 @@ export const ERROR_MESSAGES = {
 export const validateEnvironment = () => {
   const requiredVars = [
     'REACT_APP_AUTH0_DOMAIN',
-    'REACT_APP_AUTH0_CLIENT_ID', 
-    'REACT_APP_OPENAI_API_KEY'
+    'REACT_APP_AUTH0_CLIENT_ID',
+    'OPENAI_API_KEY'
   ];
   
   const missing = requiredVars.filter(varName => {
@@ -93,7 +93,7 @@ export const validateEnvironment = () => {
     console.error('1. Copy .env.example to .env');
     console.error('2. Replace placeholder values with real credentials');
     console.error('3. For Netlify: Add variables in Site Settings > Environment Variables');
-    console.error('4. Ensure variable names start with REACT_APP_');
+    console.error('4. Ensure environment variable names are correct');
     console.error('\nHELPFUL LINKS:');
       console.error('OpenAI API Keys: https://platform.openai.com/account/api-keys');
       console.error('Auth0 Dashboard: https://manage.auth0.com/');
@@ -110,7 +110,7 @@ export const validateEnvironment = () => {
   }
   
   // Validate OpenAI API key format
-  const apiKey = process.env.REACT_APP_OPENAI_API_KEY;
+  const apiKey = process.env.OPENAI_API_KEY;
   if (apiKey && !apiKey.startsWith('sk-')) {
       console.error('CONFIGURATION ERROR: Invalid OpenAI API key format');
     console.error('   Expected format: sk-proj-... or sk-...');
@@ -130,7 +130,7 @@ export const validateDeploymentEnvironment = () => {
   
   if (isBuild) {
     // Additional production checks
-    if (!process.env.REACT_APP_OPENAI_API_KEY) {
+    if (!process.env.OPENAI_API_KEY) {
       issues.push('OpenAI API key not set for production build');
     }
     

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -5,7 +5,7 @@ import { recordTokenUsage } from '../utils/tokenUsage';
 
 class OpenAIService {
   constructor() {
-    this.apiKey = process.env.REACT_APP_OPENAI_API_KEY;
+    this.apiKey = process.env.OPENAI_API_KEY;
     this.baseUrl = 'https://api.openai.com/v1';
   }
 


### PR DESCRIPTION
## Summary
- replace client-only `REACT_APP_OPENAI_API_KEY` with server-side `OPENAI_API_KEY`
- adjust environment tests to avoid reporting client-prefixed variables
- update deployment docs to require only server-side OpenAI key

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68c6d8c3d494832aa2dccb0fcfe78c29