### PR TITLE
refactor: route OpenAI calls through serverless function

### DIFF
--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -42,7 +42,6 @@ describe('openAIService uploadFile', () => {
 
 describe('openAIService getChatResponse', () => {
   beforeEach(() => {
-    openAIService.apiKey = 'test-key';
     jest.spyOn(openAIService, 'makeRequest');
   });
 


### PR DESCRIPTION
## Summary
- remove client-side OpenAI API key usage and send requests via `/.netlify/functions/openai-file-search`
- handle serverless errors and rate limits gracefully
- adjust tests for new OpenAI service interface

## Testing
- `CI=true npm test src/services/openaiService.test.js src/components/AdminScreen.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c6d8c51c08832abd1930ff8436d6cf