### PR TITLE
fix: support client OpenAI env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ cp .env.example .env
 ### 3. Required Environment Variables
 ```bash
 # OpenAI (Required)
-OPENAI_API_KEY=your_openai_api_key
+OPENAI_API_KEY=your_openai_api_key      # For serverless functions
+REACT_APP_OPENAI_API_KEY=your_openai_api_key # For client-side features
 
 # Auth0 (Required)
 REACT_APP_AUTH0_DOMAIN=your-domain.auth0.com
@@ -177,7 +178,7 @@ npm run build
 1. Connect your repository
 2. Set environment variables in Netlify dashboard
    - `OPENAI_API_KEY` for serverless calls to OpenAI
-   - `REACT_APP_OPENAI_API_KEY` for client-side features (optional)
+   - `REACT_APP_OPENAI_API_KEY` for client-side features
 3. Deploy with automatic builds. Netlify will expose the `openai-file-search` function at `/api/rag/*` to proxy requests to OpenAI's file-search API.
 
 ### Environment Variables in Netlify:
@@ -185,6 +186,7 @@ npm run build
 REACT_APP_AUTH0_DOMAIN=your-domain.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=your_client_id
 OPENAI_API_KEY=your_openai_key
+REACT_APP_OPENAI_API_KEY=your_openai_key
 REACT_APP_ENABLE_AI_SUGGESTIONS=true # optional: set to 'false' to disable AI suggestions
 JIRA_API_EMAIL=your_atlassian_email
 JIRA_API_TOKEN=your_atlassian_api_token

--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -918,9 +918,9 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                     <h4 className="font-medium text-gray-800 mb-2">Environment Check</h4>
                     <div className="p-3 bg-white border rounded-md space-y-2">
                       <p className="text-sm">
-                        <strong>OpenAI API Key:</strong> 
-                        <span className={process.env.OPENAI_API_KEY ? 'text-green-600' : 'text-red-600'}>
-                          {process.env.OPENAI_API_KEY ? ' ✓ Set' : ' ✗ Missing'}
+                        <strong>OpenAI API Key:</strong>
+                        <span className={(process.env.REACT_APP_OPENAI_API_KEY || process.env.OPENAI_API_KEY) ? 'text-green-600' : 'text-red-600'}>
+                          {(process.env.REACT_APP_OPENAI_API_KEY || process.env.OPENAI_API_KEY) ? ' ✓ Set' : ' ✗ Missing'}
                         </span>
                       </p>
                       <p className="text-sm">
@@ -978,7 +978,7 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                         <li>1. Try refreshing the page to get a new token</li>
                         <li>2. Sign out and sign back in</li>
                         <li>3. Check that your Auth0 configuration is correct</li>
-                        <li>4. Verify that OPENAI_API_KEY is set in Netlify</li>
+                        <li>4. Verify that REACT_APP_OPENAI_API_KEY is set in Netlify (OPENAI_API_KEY for serverless functions)</li>
                         <li>5. Check the Network tab in browser dev tools</li>
                       </ul>
                     </div>

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -54,7 +54,7 @@ export const FEATURE_FLAGS = {
 
 // Enhanced Error Messages with troubleshooting
 export const ERROR_MESSAGES = {
-  API_KEY_NOT_CONFIGURED: 'OpenAI API key not configured.\n\nTROUBLESHOOTING STEPS:\n1. Check that OPENAI_API_KEY is set in your environment\n2. If deploying to Netlify, add the variable in Site Settings > Environment Variables\n3. Get your API key from: https://platform.openai.com/account/api-keys\n4. Contact your administrator if you need access',
+  API_KEY_NOT_CONFIGURED: 'OpenAI API key not configured.\n\nTROUBLESHOOTING STEPS:\n1. Check that REACT_APP_OPENAI_API_KEY or OPENAI_API_KEY is set in your environment\n2. If deploying to Netlify, add the variable in Site Settings > Environment Variables\n3. Get your API key from: https://platform.openai.com/account/api-keys\n4. Contact your administrator if you need access',
 
   INVALID_API_KEY: 'Invalid OpenAI API key.\n\nTROUBLESHOOTING STEPS:\n1. Verify your API key is correct and active\n2. Check your OpenAI account billing status\n3. Generate a new API key if needed: https://platform.openai.com/account/api-keys',
 
@@ -75,7 +75,7 @@ export const validateEnvironment = () => {
   const requiredVars = [
     'REACT_APP_AUTH0_DOMAIN',
     'REACT_APP_AUTH0_CLIENT_ID',
-    'OPENAI_API_KEY'
+    'REACT_APP_OPENAI_API_KEY'
   ];
   
   const missing = requiredVars.filter(varName => {
@@ -110,7 +110,7 @@ export const validateEnvironment = () => {
   }
   
   // Validate OpenAI API key format
-  const apiKey = process.env.OPENAI_API_KEY;
+  const apiKey = process.env.REACT_APP_OPENAI_API_KEY || process.env.OPENAI_API_KEY;
   if (apiKey && !apiKey.startsWith('sk-')) {
       console.error('CONFIGURATION ERROR: Invalid OpenAI API key format');
     console.error('   Expected format: sk-proj-... or sk-...');
@@ -127,10 +127,10 @@ export const validateDeploymentEnvironment = () => {
   
   // Check if we're in a build environment
   const isBuild = process.env.NODE_ENV === 'production' || process.env.CI;
-  
+
   if (isBuild) {
     // Additional production checks
-    if (!process.env.OPENAI_API_KEY) {
+    if (!process.env.REACT_APP_OPENAI_API_KEY && !process.env.OPENAI_API_KEY) {
       issues.push('OpenAI API key not set for production build');
     }
     

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -5,7 +5,7 @@ import { recordTokenUsage } from '../utils/tokenUsage';
 
 class OpenAIService {
   constructor() {
-    this.apiKey = process.env.OPENAI_API_KEY;
+    this.apiKey = process.env.REACT_APP_OPENAI_API_KEY || process.env.OPENAI_API_KEY;
     this.baseUrl = 'https://api.openai.com/v1';
   }
 


### PR DESCRIPTION
## Summary
- allow OpenAI service to read REACT_APP_OPENAI_API_KEY
- document required client API key configuration
- update RAG configuration checks for new env var

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6e87eb830832aa5c572a0783988d1