### PR TITLE
Handle undefined document types in RAG configuration

### DIFF
--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -401,9 +401,10 @@ const RAGConfigurationPage = ({ user, onClose }) => {
   };
 
   const getFileTypeIcon = (type) => {
-    if (type.includes('pdf')) return '📄';
-    if (type.includes('word')) return '📝';
-    if (type.includes('text')) return '📃';
+    const lowerType = type?.toLowerCase() || '';
+    if (lowerType.includes('pdf')) return '📄';
+    if (lowerType.includes('word')) return '📝';
+    if (lowerType.includes('text')) return '📃';
     return '📄';
   };
 


### PR DESCRIPTION
## Summary
- avoid `.includes` errors when document type is missing in RAGConfigurationPage

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c6ebed53d4832aa11948dbed63d55a