### PR TITLE
feat: isolate rag documents by user

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -257,7 +257,7 @@ function App() {
 
     try {
       const response = ragEnabled && !fileToSend
-        ? await ragSearch(inputMessage)
+        ? await ragSearch(inputMessage, user?.sub)
         : await openaiService.getChatResponse(inputMessage, fileToSend);
 
       const assistantMessage = {
@@ -311,7 +311,7 @@ function App() {
       setIsLoading(false);
       setUploadedFile(null);
     }
-  }, [inputMessage, uploadedFile, ragEnabled, messages.length, refreshLearningSuggestions, cooldown]);
+  }, [inputMessage, uploadedFile, ragEnabled, messages.length, refreshLearningSuggestions, cooldown, user?.sub]);
 
   const handleKeyPress = useCallback(
     (e) => {

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -311,8 +311,8 @@ const AdminScreen = ({ user, onBack }) => {
     setIsLoading(true);
     try {
       const testResults = await Promise.allSettled([
-        ragService.testUpload(),
-        ragService.testSearch(),
+        ragService.testUpload(user?.sub),
+        ragService.testSearch(user?.sub),
         conversationService.isServiceAvailable()
       ]);
 

--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -298,10 +298,14 @@ const RAGConfigurationPage = ({ user, onClose }) => {
 
     try {
       console.log('Searching with query:', searchQuery);
-      const results = await ragService.searchDocuments(searchQuery, {
-        limit: 20,
-        threshold: 0.3
-      });
+      const results = await ragService.searchDocuments(
+        searchQuery,
+        {
+          limit: 20,
+          threshold: 0.3,
+        },
+        user?.sub
+      );
       
       console.log('Search results:', results);
       setSearchResults(results.results || []);
@@ -333,17 +337,21 @@ const RAGConfigurationPage = ({ user, onClose }) => {
     setError(null);
 
     try {
-      const searchResults = await ragService.searchDocuments(searchQuery, {
-        limit: 5,
-        threshold: 0.4
-      });
+      const searchResults = await ragService.searchDocuments(
+        searchQuery,
+        {
+          limit: 5,
+          threshold: 0.4,
+        },
+        user?.sub
+      );
 
       if (!searchResults.results || searchResults.results.length === 0) {
         setError('No relevant documents found to generate response');
         return;
       }
 
-      const ragResponse = await ragService.generateRAGResponse(searchQuery, searchResults.results);
+      const ragResponse = await ragService.generateRAGResponse(searchQuery, user?.sub);
       
       const newWindow = window.open('', '_blank');
       newWindow.document.write(`


### PR DESCRIPTION
## Summary
- separate OpenAI vector store for each user
- pass user ID to RAG search and admin tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7112710e8832a980a7e9d4e852800