### PR TITLE
Rename RAG Configuration screen to My Documents

### DIFF
--- a/scripts/setup-rag-fauna.js
+++ b/scripts/setup-rag-fauna.js
@@ -240,7 +240,7 @@ For Netlify deployment:
 
 5. Test the functionality:
    - Open your deployed app
-   - Click "RAG Config" in the header
+   - Click "My Documents" in the header
    - Upload a test document
    - Try searching and testing RAG responses
 

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -435,7 +435,7 @@ const AdminScreen = ({ user, onBack }) => {
               { id: 'users', label: 'Users & Auth', icon: Users },
               { id: 'backend', label: 'Backend', icon: Database },
               { id: 'rag', label: 'RAG System', icon: FileText },
-              { id: 'ragConfig', label: 'RAG Config', icon: Search },
+              { id: 'ragConfig', label: 'My Documents', icon: Search },
               { id: 'system', label: 'System Health', icon: Activity },
               { id: 'usage', label: 'Token Usage', icon: BarChart3 },
               { id: 'training', label: 'Training Resources', icon: BookOpen },
@@ -711,7 +711,7 @@ const AdminScreen = ({ user, onBack }) => {
             </div>
           )}
 
-          {/* RAG Configuration Tab */}
+          {/* My Documents Tab */}
           {activeTab === 'ragConfig' && (
             <div className="space-y-6">
               <RAGConfigurationPage user={user} onClose={() => setActiveTab('overview')} />

--- a/src/components/AdminScreen.test.js
+++ b/src/components/AdminScreen.test.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import AdminScreen, { checkStorageHealth } from './AdminScreen';
 
-jest.mock('./RAGConfigurationPage', () => () => <h2>RAG Configuration</h2>);
+jest.mock('./RAGConfigurationPage', () => () => <h2>My Documents</h2>);
 
 jest.mock('../services/ragService', () => ({
   __esModule: true,
@@ -59,7 +59,7 @@ describe('AdminScreen navigation', () => {
     container = null;
   });
 
-  it('renders RAG Configuration page when RAG Config tab is selected', async () => {
+  it('renders My Documents page when My Documents tab is selected', async () => {
     const user = { roles: ['admin'] };
 
     await act(async () => {
@@ -67,7 +67,7 @@ describe('AdminScreen navigation', () => {
     });
 
     const ragButton = Array.from(container.querySelectorAll('button')).find(btn =>
-      btn.textContent && btn.textContent.includes('RAG Config')
+      btn.textContent && btn.textContent.includes('My Documents')
     );
 
     await act(async () => {
@@ -75,7 +75,7 @@ describe('AdminScreen navigation', () => {
     });
 
     const heading = container.querySelector('h2');
-    expect(heading && heading.textContent).toMatch(/RAG Configuration/i);
+    expect(heading && heading.textContent).toMatch(/My Documents/i);
   });
 
   it('calls onBack when back button is clicked', async () => {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -147,7 +147,7 @@ const Header = memo(({
                   aria-label="Manage personal documents"
                 >
                   <FileText className="h-4 w-4 mr-2" />
-                  My Docs
+                  My Documents
                 </button>
 
                 <button

--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -426,36 +426,28 @@ const RAGConfigurationPage = ({ user, onClose }) => {
           <div className="flex items-center space-x-3">
             <Database className="h-6 w-6 text-blue-600" />
             <div>
-              <h2 className="text-xl font-semibold text-gray-900">RAG Configuration</h2>
+              <h2 className="text-xl font-semibold text-gray-900">My Documents</h2>
               <p className="text-sm text-gray-500">Upload documents and configure search with OpenAI File Search</p>
             </div>
           </div>
           <button
             onClick={onClose}
             className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
-            aria-label="Close RAG configuration"
+            aria-label="Close My Documents"
           >
             <X className="h-5 w-5 text-gray-500" />
           </button>
         </div>
 
         {/* Enhanced Debug Info */}
-        {debugInfo && (
-          <div className={`p-4 border-b ${debugInfo.success ? 'bg-green-50 border-green-200' : 'bg-red-50 border-red-200'}`}>
+        {debugInfo && !debugInfo.success && (
+          <div className="p-4 border-b bg-red-50 border-red-200">
             <div className="flex items-center space-x-2">
-              {debugInfo.success ? (
-                <CheckCircle className="h-4 w-4 text-green-600" />
-              ) : (
-                <AlertCircle className="h-4 w-4 text-red-600" />
-              )}
-              <span className={`text-sm font-medium ${debugInfo.success ? 'text-green-800' : 'text-red-800'}`}>
-                Function Status: {debugInfo.success ? 'Connected' : 'Error'}
-              </span>
+              <AlertCircle className="h-4 w-4 text-red-600" />
+              <span className="text-sm font-medium text-red-800">Function Status: Error</span>
             </div>
-            {!debugInfo.success && (
-              <p className="text-sm text-red-700 mt-1">Error: {debugInfo.error}</p>
-            )}
-            
+            <p className="text-sm text-red-700 mt-1">Error: {debugInfo.error}</p>
+
             {/* Authentication Status */}
             {authDebug && (
               <div className="mt-2 text-xs">


### PR DESCRIPTION
## Summary
- rename RAG Configuration screen and related navigation to My Documents
- display error banner only on RAG page

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c740332628832aa79aec4e356c0cd5