### PR TITLE
Remove onboarding text from chat area

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -81,26 +81,6 @@ const ChatArea = ({
               <h3 className="text-lg sm:text-xl font-semibold text-gray-900 mb-2">
                 What can I help you with today?
               </h3>
-              <!-- <p className="text-sm sm:text-base text-gray-600 mb-6">
-                Your AI-powered learning assistant for pharmaceutical quality and compliance. 
-                Ask questions about GMP, validation, CAPA, or upload documents for personalized guidance.
-              </p> -->
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-                <div className="bg-blue-50 p-3 rounded-lg">
-                  <div className="font-medium text-blue-900 mb-1 flex items-center space-x-1">
-                    <BookOpen className="h-3 w-3" />
-                    <span>Quick Start</span>
-                  </div>
-                  <div className="text-blue-700">Ask about GMP requirements, validation protocols, or regulatory guidelines</div>
-                </div>
-                <div className="bg-purple-50 p-3 rounded-lg">
-                  <div className="font-medium text-purple-900 mb-1 flex items-center space-x-1">
-                    <Database className="h-3 w-3" />
-                    <span>Upload Documents</span>
-                  </div>
-                  <div className="text-purple-700">Enable document search and upload your company's SOPs or industry documents</div>
-                </div>
-              </div>
             </div>
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- remove marketing blurb and quick-action cards from empty chat area

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c74b39e410832a81ff083f30aa1639