### PR TITLE
Ensure main page columns fill viewport

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -439,11 +439,11 @@ function App() {
             />
 
             {/* Main Layout */}
-            <div className="flex-1">
+            <div className="flex-1 flex flex-col min-h-0">
               {/* Mobile Layout (stacked vertically) */}
-              <div className="lg:hidden h-full flex flex-col">
+              <div className="lg:hidden flex-1 h-full flex flex-col min-h-0">
                 {/* Chat takes most space on mobile */}
-                <div className="flex-1 min-h-0 p-4">
+                <div className="flex-1 min-h-0 p-4 pb-0">
                   <ChatArea
                     messages={messages}
                     inputMessage={inputMessage}
@@ -477,9 +477,9 @@ function App() {
               </div>
 
               {/* Desktop Layout (side by side) */}
-              <div className="hidden lg:flex h-full">
+              <div className="hidden lg:flex flex-1 h-full min-h-0">
                 {/* Chat Area - Takes majority of space */}
-                <div className="flex-1 min-w-0 p-6">
+                <div className="flex-1 min-w-0 h-full p-6 pb-0">
                   <ChatArea
                     messages={messages}
                     inputMessage={inputMessage}
@@ -498,7 +498,7 @@ function App() {
                 </div>
 
                 {/* Sidebar - Fixed optimal width with enhanced learning features */}
-                <div className="w-80 xl:w-96 flex-shrink-0 border-l bg-white p-6">
+                <div className="w-80 xl:w-96 flex-shrink-0 h-full border-l bg-white p-6 pb-0">
                   <Sidebar
                     messages={messages}
                     thirtyDayMessages={thirtyDayMessages}

--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -19,7 +19,7 @@ const ChatArea = ({
   cooldown, // rate-limit cooldown (seconds)
 }) => {
   return (
-    <div className="h-full flex flex-col bg-white rounded-lg shadow-sm border border-gray-200">
+    <div className="h-full flex flex-col min-h-0 overflow-hidden bg-white rounded-lg shadow-sm border border-gray-200">
       {/* Chat Header with RAG Toggle */}
       <div className="flex-shrink-0 px-4 sm:px-6 py-3 sm:py-4 border-b border-gray-200 bg-gray-50 rounded-t-lg">
         <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- Stretch chat layout so the input touches the viewport bottom on all devices
- Keep chat messages within the panel and enable scrolling when conversations overflow

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c74cf894a0832a9f886390ee69c107