### PR TITLE
fix: anchor chat input to bottom

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -145,7 +145,7 @@ const ChatArea = ({
       </div>
 
       {/* Input Area */}
-      <div className="flex-shrink-0 p-4 sm:p-6 border-t border-gray-200 bg-gray-50 rounded-b-lg sticky bottom-0">
+      <div className="flex-shrink-0 p-4 sm:p-6 border-t border-gray-200 bg-gray-50 rounded-b-lg mt-auto">
         {cooldown > 0 && (
           <div className="mb-2 text-sm text-yellow-700 bg-yellow-100 px-3 py-2 rounded">
             You're sending messages too quickly. Please wait {cooldown}s before trying again.


### PR DESCRIPTION
## Summary
- anchor the ChatArea input form to the screen bottom with flex `mt-auto`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c755519330832ab9ddd2daf759bbef