### PR TITLE
style: restyle privacy policy page

### DIFF
--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -5,157 +5,159 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Privacy Policy</title>
   <link rel="icon" href="/AceleraQA_logo.png" />
-  <style>
-    body { font-family: sans-serif; margin: 2rem; line-height: 1.6; }
-    h1 { font-size: 2rem; margin-bottom: 1rem; }
-  </style>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 </head>
-<body>
-  <h1>Privacy Policy</h1>
- 
-# Privacy & Cookie Policy
+<body class="bg-slate-50 text-slate-900">
+  <header class="bg-gray-50 border-b border-gray-200">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
+      <a href="/" class="flex-shrink-0">
+        <img src="/AceleraQA_logo.png" alt="AcceleraQA logo" width="180" height="20" />
+      </a>
+    </div>
+  </header>
+  <main class="max-w-4xl mx-auto px-4 py-10 prose">
+    <h1>Privacy & Cookie Policy</h1>
+    <p><strong>Effective Date:</strong> 14 Sep 2025</p>
+    <p><strong>Last Updated:</strong> 14 Sep 2025</p>
 
-**Effective Date:** 14 Sep 2025
-**Last Updated:** 14 Sep 2025
+    <p>AcceleraQA, LLC (“AcceleraQA,” “we,” “our,” or “us”) respects your privacy and is committed to protecting your personal data. This Privacy & Cookie Policy explains how we collect, use, and safeguard information when you use the AcceleraQA Quality Assurance Assistant (“Application”).</p>
 
-AcceleraQA, LLC (“AcceleraQA,” “we,” “our,” or “us”) respects your privacy and is committed to protecting your personal data. This Privacy & Cookie Policy explains how we collect, use, and safeguard information when you use the AcceleraQA Quality Assurance Assistant (“Application”).
+    <p>For any questions about this policy, please contact us at: <strong><a href="mailto:privacy@acceleraqa.com">privacy@acceleraqa.com</a></strong>.</p>
 
-For any questions about this policy, please contact us at: **[privacy@acceleraqa.com](mailto:privacy@acceleraqa.com)**.
+    <hr />
 
----
+    <h2>1. Data Controller</h2>
+    <p>For the purposes of the General Data Protection Regulation (EU) 2016/679 (“GDPR”), the data controller is:</p>
+    <p><strong>AcceleraQA, LLC</strong><br />
+    [Insert Business Address]<br />
+    Email: <a href="mailto:privacy@acceleraqa.com">privacy@acceleraqa.com</a></p>
 
-## 1. Data Controller
+    <hr />
 
-For the purposes of the General Data Protection Regulation (EU) 2016/679 (“GDPR”), the data controller is:
+    <h2>2. Information We Collect</h2>
+    <p>We may collect and process the following categories of data:</p>
+    <ul>
+      <li><strong>Account Information:</strong> Name, email address, and login credentials collected via Auth0 authentication.</li>
+      <li><strong>User Inputs and Documents:</strong> Data you upload or enter into the Application for AI analysis and search.</li>
+      <li><strong>Technical Information:</strong> IP address, device type, browser version, operating system, and usage patterns.</li>
+      <li><strong>Derived/Analytical Data:</strong> AI-generated outputs, aggregated usage statistics, and deidentified data.</li>
+    </ul>
 
-**AcceleraQA, LLC**
-\[Insert Business Address]
-Email: [privacy@acceleraqa.com](mailto:privacy@acceleraqa.com)
+    <hr />
 
----
+    <h2>3. How We Use Your Data</h2>
+    <p>We process your data for the following purposes:</p>
+    <ul>
+      <li>To provide access to and operate the Application.</li>
+      <li>To authenticate and secure accounts (via Auth0).</li>
+      <li>To improve the system and develop new features.</li>
+      <li>To produce deidentified, aggregated statistics for research and marketing.</li>
+      <li>To comply with legal and regulatory obligations.</li>
+    </ul>
+    <p>We <strong>do not sell your personal data</strong> to any third party.</p>
 
-## 2. Information We Collect
+    <hr />
 
-We may collect and process the following categories of data:
+    <h2>4. Legal Basis for Processing</h2>
+    <ul>
+      <li><strong>Performance of a Contract (Art. 6(1)(b)):</strong> To deliver the Application’s services.</li>
+      <li><strong>Legitimate Interests (Art. 6(1)(f)):</strong> To ensure security, improve functionality, and monitor usage.</li>
+      <li><strong>Consent (Art. 6(1)(a)):</strong> For optional analytics or cookies requiring user permission.</li>
+      <li><strong>Legal Obligation (Art. 6(1)(c)):</strong> To comply with applicable laws.</li>
+    </ul>
 
-* **Account Information:** Name, email address, and login credentials collected via Auth0 authentication.
-* **User Inputs and Documents:** Data you upload or enter into the Application for AI analysis and search.
-* **Technical Information:** IP address, device type, browser version, operating system, and usage patterns.
-* **Derived/Analytical Data:** AI-generated outputs, aggregated usage statistics, and deidentified data.
+    <hr />
 
----
+    <h2>5. Data Sharing</h2>
+    <p>We only share data with trusted providers who support our services:</p>
+    <ul>
+      <li><strong>Auth0</strong> – authentication and security.</li>
+      <li><strong>OpenAI (ChatGPT API)</strong> – AI search and analysis.</li>
+      <li><strong>Other service providers</strong> – for hosting, analytics, or support.</li>
+    </ul>
+    <p>All providers operate under GDPR-compliant contracts.</p>
 
-## 3. How We Use Your Data
+    <hr />
 
-We process your data for the following purposes:
+    <h2>6. Cookies and Tracking</h2>
+    <h3>What are cookies?</h3>
+    <p>Cookies are small text files stored on your device. They help us operate the site, improve performance, and understand usage.</p>
 
-* To provide access to and operate the Application.
-* To authenticate and secure accounts (via Auth0).
-* To improve the system and develop new features.
-* To produce deidentified, aggregated statistics for research and marketing.
-* To comply with legal and regulatory obligations.
+    <h3>Types of cookies we use</h3>
+    <ol>
+      <li><strong>Strictly Necessary Cookies</strong> – Required for authentication and security. These cannot be disabled.</li>
+      <li><strong>Functional Cookies</strong> – Remember preferences and settings (e.g., keeping you logged in).</li>
+      <li><strong>Analytics Cookies</strong> – Help us improve the system by understanding user interactions.</li>
+      <li><strong>Marketing/Statistics Cookies</strong> – Used only in deidentified form to produce usage statistics for marketing.</li>
+    </ol>
 
-We **do not sell your personal data** to any third party.
+    <h3>Cookie choices</h3>
+    <ul>
+      <li>On your first visit, you will see a cookie banner. You can accept all, reject non-essential cookies, or manage your preferences.</li>
+      <li>You may also disable cookies via your browser settings.</li>
+    </ul>
 
----
+    <h3>Legal basis for cookies</h3>
+    <ul>
+      <li>Strictly necessary: Legitimate interest.</li>
+      <li>Functional, analytics, and marketing/statistics: Consent.</li>
+    </ul>
 
-## 4. Legal Basis for Processing
+    <h3>Cookie retention</h3>
+    <ul>
+      <li>Session cookies: deleted when you close your browser.</li>
+      <li>Persistent cookies: stored for up to 12 months (unless you clear them sooner).</li>
+    </ul>
 
-* **Performance of a Contract (Art. 6(1)(b)):** To deliver the Application’s services.
-* **Legitimate Interests (Art. 6(1)(f)):** To ensure security, improve functionality, and monitor usage.
-* **Consent (Art. 6(1)(a)):** For optional analytics or cookies requiring user permission.
-* **Legal Obligation (Art. 6(1)(c)):** To comply with applicable laws.
+    <hr />
 
----
+    <h2>7. Data Retention</h2>
+    <ul>
+      <li>Account data: kept as long as you maintain an account.</li>
+      <li>Documents and user inputs: stored only as long as needed to provide the service.</li>
+      <li>Deidentified/aggregated data: may be retained indefinitely, as it cannot identify you.</li>
+    </ul>
 
-## 5. Data Sharing
+    <hr />
 
-We only share data with trusted providers who support our services:
+    <h2>8. International Data Transfers</h2>
+    <p>Where data is transferred outside the EEA, we apply GDPR-approved safeguards (e.g., Standard Contractual Clauses).</p>
 
-* **Auth0** – authentication and security.
-* **OpenAI (ChatGPT API)** – AI search and analysis.
-* **Other service providers** – for hosting, analytics, or support.
+    <hr />
 
-All providers operate under GDPR-compliant contracts.
+    <h2>9. Data Security</h2>
+    <p>We use technical and organizational measures to protect your data, including:</p>
+    <ul>
+      <li>Encryption in transit and at rest.</li>
+      <li>Authentication via Auth0.</li>
+      <li>Regular monitoring and access controls.</li>
+    </ul>
 
----
+    <hr />
 
-## 6. Cookies and Tracking
+    <h2>10. Your GDPR Rights</h2>
+    <p>You have the right to:</p>
+    <ul>
+      <li>Access your personal data.</li>
+      <li>Request correction of inaccuracies.</li>
+      <li>Request deletion (“right to be forgotten”).</li>
+      <li>Restrict or object to processing.</li>
+      <li>Request data portability.</li>
+      <li>Withdraw consent at any time.</li>
+    </ul>
+    <p>To exercise these rights, email <strong><a href="mailto:privacy@acceleraqa.com">privacy@acceleraqa.com</a></strong>.<br />
+    You may also contact your local Data Protection Authority in the EU.</p>
 
-### What are cookies?
+    <hr />
 
-Cookies are small text files stored on your device. They help us operate the site, improve performance, and understand usage.
+    <h2>11. Children’s Privacy</h2>
+    <p>Our Application is not intended for children under 16. We do not knowingly collect data from children.</p>
 
-### Types of cookies we use
+    <hr />
 
-1. **Strictly Necessary Cookies** – Required for authentication and security. These cannot be disabled.
-2. **Functional Cookies** – Remember preferences and settings (e.g., keeping you logged in).
-3. **Analytics Cookies** – Help us improve the system by understanding user interactions.
-4. **Marketing/Statistics Cookies** – Used only in deidentified form to produce usage statistics for marketing.
-
-### Cookie choices
-
-* On your first visit, you will see a cookie banner. You can accept all, reject non-essential cookies, or manage your preferences.
-* You may also disable cookies via your browser settings.
-
-### Legal basis for cookies
-
-* Strictly necessary: Legitimate interest.
-* Functional, analytics, and marketing/statistics: Consent.
-
-### Cookie retention
-
-* Session cookies: deleted when you close your browser.
-* Persistent cookies: stored for up to 12 months (unless you clear them sooner).
-
----
-
-## 7. Data Retention
-
-* Account data: kept as long as you maintain an account.
-* Documents and user inputs: stored only as long as needed to provide the service.
-* Deidentified/aggregated data: may be retained indefinitely, as it cannot identify you.
-
----
-
-## 8. International Data Transfers
-
-Where data is transferred outside the EEA, we apply GDPR-approved safeguards (e.g., Standard Contractual Clauses).
-
----
-
-## 9. Data Security
-
-We use technical and organizational measures to protect your data, including:
-
-* Encryption in transit and at rest.
-* Authentication via Auth0.
-* Regular monitoring and access controls.
-
----
-
-## 10. Your GDPR Rights
-
-You have the right to:
-
-* Access your personal data.
-* Request correction of inaccuracies.
-* Request deletion (“right to be forgotten”).
-* Restrict or object to processing.
-* Request data portability.
-* Withdraw consent at any time.
-
-To exercise these rights, email **[privacy@acceleraqa.com](mailto:privacy@acceleraqa.com)**.
-You may also contact your local Data Protection Authority in the EU.
-
----
-## 11. Children’s Privacy
-
-Our Application is not intended for children under 16. We do not knowingly collect data from children.
----
-## 12. Updates to this Policy
-
-We may update this Privacy & Cookie Policy from time to time. The “Last Updated” date will always indicate the latest version.
-
+    <h2>12. Updates to this Policy</h2>
+    <p>We may update this Privacy & Cookie Policy from time to time. The “Last Updated” date will always indicate the latest version.</p>
+  </main>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- apply Tailwind styling and header to privacy policy page for consistent site appearance
- replace Markdown with semantic HTML structure

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c75b3baa48832aa3047be883d79d0b