### PR TITLE
fix: persist session after refresh

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -76,11 +76,11 @@ function App() {
   useEffect(() => {
     const initAuth = async () => {
       setLoading(true);
-      await initializeAuth(
+      const authUser = await initializeAuth(
         (authUser) => setUser(authUser),
         () => {}
       );
-      const authStatus = await authService.isAuthenticated();
+      const authStatus = !!authUser;
       setIsAuthenticated(authStatus);
       if (!authStatus) {
         setUser(null);

--- a/src/services/authService.test.js
+++ b/src/services/authService.test.js
@@ -34,6 +34,32 @@ describe('AuthService getUser', () => {
       organization: 'Acme Corp'
     });
   });
+
+  it('attempts silent authentication when user data is initially missing', async () => {
+    const authService = require('./authService').default;
+
+    const getUserMock = jest
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ sub: 'user456', name: 'Another User' });
+
+    authService.auth0Client = {
+      getUser: getUserMock,
+      getIdTokenClaims: jest.fn().mockResolvedValue({}),
+      getTokenSilently: jest.fn().mockResolvedValue('fake-token')
+    };
+
+    const result = await authService.getUser();
+
+    expect(authService.auth0Client.getTokenSilently).toHaveBeenCalled();
+    expect(getUserMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      sub: 'user456',
+      name: 'Another User',
+      roles: [],
+      organization: null
+    });
+  });
 });
 
 describe('hasAdminRole', () => {


### PR DESCRIPTION
## Summary
- attempt silent auth when no user is returned to keep users logged in after refresh
- test that getUser triggers token renewal when initial call returns null

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c816ee3cb4832a99bc7f059ccb9623