### PR TITLE
fix: persist session after refresh

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -76,11 +76,11 @@ function App() {
   useEffect(() => {
     const initAuth = async () => {
       setLoading(true);
-      await initializeAuth(
+      const authUser = await initializeAuth(
         (authUser) => setUser(authUser),
         () => {}
       );
-      const authStatus = await authService.isAuthenticated();
+      const authStatus = !!authUser;
       setIsAuthenticated(authStatus);
       if (!authStatus) {
         setUser(null);

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -36,7 +36,7 @@ export const AUTH0_CONFIG = {
   ORG_CLAIM: process.env.REACT_APP_AUTH0_ORG_CLAIM,
   REDIRECT_URI: window.location.origin,
   LOGOUT_URI: window.location.origin,
-  SCOPE: 'openid profile email'
+  SCOPE: 'openid profile email offline_access'
 };
 
 // UI Constants

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -28,7 +28,10 @@ class AuthService {
           redirect_uri: AUTH0_CONFIG.REDIRECT_URI,
           audience: AUTH0_CONFIG.AUDIENCE,
           scope: AUTH0_CONFIG.SCOPE
-        }
+        },
+        cacheLocation: 'localstorage',
+        useRefreshTokens: true,
+        useRefreshTokensFallback: true
       });
 
       this.isInitialized = true;
@@ -74,11 +77,28 @@ class AuthService {
     }
 
     try {
-      const isAuth = await this.isAuthenticated();
-      if (!isAuth) {
+      let user = await this.auth0Client.getUser();
+
+      if (!user) {
+        try {
+          // Attempt silent authentication to restore session on refresh
+          await this.auth0Client.getTokenSilently({
+            authorizationParams: {
+              audience: AUTH0_CONFIG.AUDIENCE,
+              scope: AUTH0_CONFIG.SCOPE
+            }
+          });
+          user = await this.auth0Client.getUser();
+        } catch (silentError) {
+          console.warn('Silent authentication failed:', silentError);
+          return null;
+        }
+      }
+
+      if (!user) {
         return null;
       }
-      const user = await this.auth0Client.getUser();
+
       const claims = await this.auth0Client.getIdTokenClaims();
       const roles = claims?.[AUTH0_CONFIG.ROLES_CLAIM] || [];
       const organization = claims?.[AUTH0_CONFIG.ORG_CLAIM] || null;
@@ -289,16 +309,16 @@ export default authService;
 export const initializeAuth = async (setUser, setIsLoadingAuth, initializeWelcomeMessage) => {
   try {
     await authService.initialize();
-    
+
     // Check if user is returning from redirect
     const query = window.location.search;
     if (query.includes("code=") && query.includes("state=")) {
       await authService.handleRedirectCallback();
     }
 
-    // Check if user is authenticated
+    // Attempt to retrieve the user; this triggers session restoration if possible
     const user = await authService.getUser();
-    
+
     if (user) {
       setUser(user);
       // Only call initializeWelcomeMessage if it's provided
@@ -306,11 +326,13 @@ export const initializeAuth = async (setUser, setIsLoadingAuth, initializeWelcom
         initializeWelcomeMessage();
       }
     }
-    
+
     setIsLoadingAuth(false);
+    return user;
   } catch (error) {
     console.error('Auth initialization error:', error);
     setIsLoadingAuth(false);
+    return null;
   }
 };
 

--- a/src/services/authService.test.js
+++ b/src/services/authService.test.js
@@ -5,6 +5,35 @@ import { hasAdminRole } from '../utils/auth';
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 
+describe('AuthService initialize', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+  afterEach(() => {
+    jest.dontMock('@auth0/auth0-spa-js');
+  });
+
+  it('stores tokens in local storage with refresh support', async () => {
+    process.env.REACT_APP_AUTH0_DOMAIN = 'test.auth0.com';
+    process.env.REACT_APP_AUTH0_CLIENT_ID = 'abc123';
+
+    const createAuth0Client = jest.fn().mockResolvedValue({});
+    jest.doMock('@auth0/auth0-spa-js', () => ({ createAuth0Client }));
+
+    const authService = (await import('./authService')).default;
+
+    await authService.initialize();
+
+    expect(createAuth0Client).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cacheLocation: 'localstorage',
+        useRefreshTokens: true,
+        useRefreshTokensFallback: true
+      })
+    );
+  });
+});
+
 describe('AuthService getUser', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -32,6 +61,32 @@ describe('AuthService getUser', () => {
       name: 'Test User',
       roles: ['admin', 'editor'],
       organization: 'Acme Corp'
+    });
+  });
+
+  it('attempts silent authentication when user data is initially missing', async () => {
+    const authService = require('./authService').default;
+
+    const getUserMock = jest
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ sub: 'user456', name: 'Another User' });
+
+    authService.auth0Client = {
+      getUser: getUserMock,
+      getIdTokenClaims: jest.fn().mockResolvedValue({}),
+      getTokenSilently: jest.fn().mockResolvedValue('fake-token')
+    };
+
+    const result = await authService.getUser();
+
+    expect(authService.auth0Client.getTokenSilently).toHaveBeenCalled();
+    expect(getUserMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      sub: 'user456',
+      name: 'Another User',
+      roles: [],
+      organization: null
     });
   });
 });


### PR DESCRIPTION
## Summary
- enable refresh tokens and local storage caching to restore Auth0 sessions after reload
- request offline access scope to receive refresh tokens
- allow fallback to iframe-based token retrieval when no refresh token is available
- test that AuthService initialization configures refresh tokens, local storage, and fallback mode

## Testing
- `CI=1 npm test -- --watchAll=false 2>&1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68c816ee3cb4832a99bc7f059ccb9623