### PR TITLE
Switch conversation persistence to Neon backend

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,11 @@ import authService, { initializeAuth } from './services/authService';
 import { search as ragSearch } from './services/ragService';
 import openaiService from './services/openaiService';
 
-import { initializeConversationService, loadConversations as loadStoredConversations, saveConversation as saveStoredConversation } from './services/conversationService';
+import {
+  initializeNeonService,
+  loadConversations as loadStoredConversations,
+  saveConversation as saveStoredConversation,
+} from './services/neonService';
 
 import { FEATURE_FLAGS } from './config/featureFlags';
 import { loadMessagesFromStorage, saveMessagesToStorage } from './utils/storageUtils';
@@ -112,7 +116,7 @@ function App() {
   // Initialize backend services when user is available
   useEffect(() => {
     if (user) {
-      initializeConversationService(user);
+      initializeNeonService(user);
       if (FEATURE_FLAGS.ENABLE_AI_SUGGESTIONS) {
         loadInitialLearningSuggestions();
       }

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -27,7 +27,7 @@ import {
 } from 'lucide-react';
 
 // Import services
-import conversationService from '../services/conversationService';
+import neonService from '../services/neonService';
 import ragService from '../services/ragService';
 import { getToken, getTokenInfo } from '../services/authService';
 import { hasAdminRole } from '../utils/auth';
@@ -128,7 +128,7 @@ const AdminScreen = ({ user, onBack }) => {
   const getSystemStats = async () => {
     try {
       const [conversationStats, ragStats] = await Promise.all([
-        conversationService.getConversationStats(),
+        neonService.getConversationStats(),
         ragService.getStats(user?.sub)
       ]);
 
@@ -216,7 +216,7 @@ const AdminScreen = ({ user, onBack }) => {
 
   const checkBackendHealth = async () => {
     try {
-      const result = await conversationService.isServiceAvailable();
+      const result = await neonService.isServiceAvailable();
       if (result.ok) {
         return {
           status: 'healthy',
@@ -313,7 +313,7 @@ const AdminScreen = ({ user, onBack }) => {
       const testResults = await Promise.allSettled([
         ragService.testUpload(user?.sub),
         ragService.testSearch(user?.sub),
-        conversationService.isServiceAvailable()
+        neonService.isServiceAvailable()
       ]);
 
       const results = {

--- a/src/components/AdminScreen.test.js
+++ b/src/components/AdminScreen.test.js
@@ -16,7 +16,7 @@ jest.mock('../services/ragService', () => ({
   }
 }));
 
-jest.mock('../services/conversationService', () => ({
+jest.mock('../services/neonService', () => ({
   __esModule: true,
   default: {
     getConversationStats: jest.fn().mockResolvedValue({}),

--- a/src/services/learningSuggestionsService.js
+++ b/src/services/learningSuggestionsService.js
@@ -1,5 +1,5 @@
 // src/services/learningSuggestionsService.js
-import conversationService from './conversationService';
+import neonService from './neonService';
 import openaiService from './openaiService';
 import { FEATURE_FLAGS } from '../config/featureFlags';
 import { OPENAI_CONFIG } from '../config/constants';
@@ -66,7 +66,7 @@ class LearningSuggestionsService {
       return [];
     }
     try {
-      const conversations = await conversationService.loadConversations();
+      const conversations = await neonService.loadConversations();
       return conversations.slice(-10).reverse();
     } catch (error) {
       console.error('Error fetching recent conversations:', error);


### PR DESCRIPTION
## Summary
- update the main app flow to initialize and use the Neon conversation service for saving and loading chats
- point the admin dashboard and unit tests to the Neon-backed conversation APIs
- fetch recent conversations for learning suggestions from the Neon service to keep notebook data in sync

## Testing
- npm test -- --runTestsByPath src/components/AdminScreen.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c84c8e1c6c832a97a7a403c1ff4d71