### PR TITLE
Persist RAG documents and vector store metadata in Neon

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ REACT_APP_AUTH0_AUDIENCE=your_api_audience
 REACT_APP_AUTH0_ROLES_CLAIM=https://your-domain.com/roles
 REACT_APP_AUTH0_ORG_CLAIM=https://your-domain.com/org
 
+# Neon PostgreSQL (Document Metadata Persistence)
+NEON_DATABASE_URL=postgres://user:password@host:port/dbname
+REACT_APP_RAG_DOCS_FUNCTION=/.netlify/functions/rag-documents # optional override
+
 # Jira Service Desk (Optional)
 JIRA_API_EMAIL=your_atlassian_email
 JIRA_API_TOKEN=your_atlassian_api_token
@@ -157,6 +161,7 @@ npm run build
 - OpenAI GPT-4 integration
 - Pharmaceutical-specific prompts
 - File uploads via Files API with in-message file references
+- Document metadata and vector store IDs persisted in Neon PostgreSQL for cross-device access while files remain in OpenAI's File Assistant
 - Error handling and rate limiting
 - Usage tracking
 

--- a/netlify/functions/rag-documents.js
+++ b/netlify/functions/rag-documents.js
@@ -1,0 +1,315 @@
+import { neon } from '@neondatabase/serverless';
+import { randomUUID } from 'crypto';
+
+const headers = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-user-id',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Content-Type': 'application/json',
+};
+
+let sqlClient = null;
+let schemaPromise = null;
+
+const getSqlClient = () => {
+  if (!sqlClient) {
+    const connectionString = process.env.NEON_DATABASE_URL;
+    if (!connectionString) {
+      throw new Error('NEON_DATABASE_URL environment variable is not set');
+    }
+    sqlClient = neon(connectionString);
+  }
+  return sqlClient;
+};
+
+const ensureSchema = async (sql) => {
+  if (!schemaPromise) {
+    schemaPromise = (async () => {
+      await sql`
+        CREATE TABLE IF NOT EXISTS rag_user_vector_stores (
+          user_id TEXT PRIMARY KEY,
+          vector_store_id TEXT NOT NULL,
+          metadata JSONB DEFAULT '{}'::jsonb,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+      `;
+
+      await sql`
+        CREATE TABLE IF NOT EXISTS rag_user_documents (
+          document_id TEXT PRIMARY KEY,
+          user_id TEXT NOT NULL,
+          file_id TEXT NOT NULL,
+          filename TEXT NOT NULL,
+          content_type TEXT,
+          size BIGINT,
+          metadata JSONB DEFAULT '{}'::jsonb,
+          chunks INTEGER DEFAULT 0,
+          vector_store_id TEXT,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+      `;
+
+      await sql`
+        CREATE INDEX IF NOT EXISTS idx_rag_user_documents_user_id
+        ON rag_user_documents(user_id)
+      `;
+    })();
+  }
+
+  return schemaPromise;
+};
+
+const getHeaderValue = (headersMap, key) => {
+  if (!headersMap) return null;
+  const direct = headersMap[key];
+  if (direct) return direct;
+
+  const lower = key.toLowerCase();
+  if (headersMap[lower]) return headersMap[lower];
+
+  const upper = key.toUpperCase();
+  if (headersMap[upper]) return headersMap[upper];
+
+  return null;
+};
+
+const extractUserId = (event, context) => {
+  const headerUserId =
+    getHeaderValue(event.headers, 'x-user-id') ||
+    getHeaderValue(event.headers, 'x-userid') ||
+    getHeaderValue(event.headers, 'x_user_id');
+
+  if (headerUserId) {
+    return { userId: headerUserId, source: 'header' };
+  }
+
+  const contextUser = context?.clientContext?.user?.sub;
+  if (contextUser) {
+    return { userId: contextUser, source: 'netlify-context' };
+  }
+
+  if (process.env.NODE_ENV === 'development' || process.env.NETLIFY_DEV === 'true') {
+    return { userId: `dev-user-${Date.now()}`, source: 'development-fallback' };
+  }
+
+  return { userId: null, source: 'unknown' };
+};
+
+const createResponse = (statusCode, body) => ({
+  statusCode,
+  headers,
+  body: JSON.stringify(body),
+});
+
+const mapDocumentRow = (row) => ({
+  id: row.document_id,
+  fileId: row.file_id,
+  filename: row.filename,
+  type: row.content_type,
+  size: row.size == null ? 0 : Number(row.size),
+  metadata: row.metadata || {},
+  chunks: row.chunks == null ? 0 : Number(row.chunks),
+  vectorStoreId: row.vector_store_id || null,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+const handleHealth = async (sql) => {
+  await sql`SELECT 1`;
+  return createResponse(200, {
+    status: 'ok',
+    message: 'Document metadata service reachable',
+    timestamp: new Date().toISOString(),
+  });
+};
+
+const handleGetVectorStore = async (sql, userId) => {
+  const rows = await sql`
+    SELECT vector_store_id, metadata, created_at, updated_at
+    FROM rag_user_vector_stores
+    WHERE user_id = ${userId}
+    LIMIT 1
+  `;
+
+  const record = rows[0];
+  return createResponse(200, {
+    vectorStoreId: record?.vector_store_id || null,
+    metadata: record?.metadata || {},
+    createdAt: record?.created_at || null,
+    updatedAt: record?.updated_at || null,
+  });
+};
+
+const handleSetVectorStore = async (sql, userId, payload) => {
+  const { vectorStoreId, metadata = {} } = payload || {};
+
+  if (!vectorStoreId) {
+    return createResponse(400, { error: 'vectorStoreId is required' });
+  }
+
+  const rows = await sql`
+    INSERT INTO rag_user_vector_stores (user_id, vector_store_id, metadata)
+    VALUES (${userId}, ${vectorStoreId}, ${metadata})
+    ON CONFLICT (user_id) DO UPDATE
+    SET vector_store_id = EXCLUDED.vector_store_id,
+        metadata = EXCLUDED.metadata,
+        updated_at = CURRENT_TIMESTAMP
+    RETURNING vector_store_id, metadata, created_at, updated_at
+  `;
+
+  const record = rows[0];
+  return createResponse(200, {
+    vectorStoreId: record.vector_store_id,
+    metadata: record.metadata || {},
+    createdAt: record.created_at,
+    updatedAt: record.updated_at,
+  });
+};
+
+const handleListDocuments = async (sql, userId) => {
+  const rows = await sql`
+    SELECT document_id, file_id, filename, content_type, size, metadata, chunks, vector_store_id, created_at, updated_at
+    FROM rag_user_documents
+    WHERE user_id = ${userId}
+    ORDER BY created_at DESC
+  `;
+
+  return createResponse(200, {
+    documents: rows.map(mapDocumentRow),
+    total: rows.length,
+  });
+};
+
+const handleSaveDocument = async (sql, userId, payload) => {
+  const document = payload?.document;
+  const vectorStoreId = payload?.vectorStoreId || document?.vectorStoreId || null;
+
+  if (!document) {
+    return createResponse(400, { error: 'Document payload is required' });
+  }
+
+  const documentId = document.id || document.documentId || document.fileId || randomUUID();
+  const normalizedMetadata = document.metadata && typeof document.metadata === 'object'
+    ? document.metadata
+    : {};
+
+  const rows = await sql`
+    INSERT INTO rag_user_documents (
+      document_id,
+      user_id,
+      file_id,
+      filename,
+      content_type,
+      size,
+      metadata,
+      chunks,
+      vector_store_id
+    ) VALUES (
+      ${documentId},
+      ${userId},
+      ${document.fileId || documentId},
+      ${document.filename || document.name || 'Uploaded Document'},
+      ${document.type || document.contentType || null},
+      ${document.size ?? 0},
+      ${normalizedMetadata},
+      ${document.chunks ?? 0},
+      ${vectorStoreId}
+    )
+    ON CONFLICT (document_id) DO UPDATE
+    SET user_id = EXCLUDED.user_id,
+        file_id = EXCLUDED.file_id,
+        filename = EXCLUDED.filename,
+        content_type = EXCLUDED.content_type,
+        size = EXCLUDED.size,
+        metadata = EXCLUDED.metadata,
+        chunks = EXCLUDED.chunks,
+        vector_store_id = EXCLUDED.vector_store_id,
+        updated_at = CURRENT_TIMESTAMP
+    RETURNING document_id, file_id, filename, content_type, size, metadata, chunks, vector_store_id, created_at, updated_at
+  `;
+
+  return createResponse(200, {
+    document: mapDocumentRow(rows[0]),
+  });
+};
+
+const handleDeleteDocument = async (sql, userId, payload) => {
+  const { documentId } = payload || {};
+
+  if (!documentId) {
+    return createResponse(400, { error: 'documentId is required' });
+  }
+
+  await sql`
+    DELETE FROM rag_user_documents
+    WHERE user_id = ${userId}
+      AND document_id = ${documentId}
+  `;
+
+  return createResponse(200, { success: true });
+};
+
+export const handler = async (event, context) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({ message: 'ok' }),
+    };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return createResponse(405, { error: 'Method not allowed' });
+  }
+
+  try {
+    const sql = getSqlClient();
+    await ensureSchema(sql);
+
+    const { userId } = extractUserId(event, context);
+    if (!userId) {
+      return createResponse(401, {
+        error: 'User authentication required',
+        message: 'Missing x-user-id header or authenticated context.',
+      });
+    }
+
+    let payload;
+    try {
+      payload = JSON.parse(event.body || '{}');
+    } catch (parseError) {
+      return createResponse(400, { error: 'Invalid JSON payload', message: parseError.message });
+    }
+
+    const { action, ...data } = payload;
+    if (!action) {
+      return createResponse(400, { error: 'Action is required' });
+    }
+
+    switch (action) {
+      case 'health':
+        return await handleHealth(sql);
+      case 'get_vector_store':
+        return await handleGetVectorStore(sql, userId);
+      case 'set_vector_store':
+        return await handleSetVectorStore(sql, userId, data);
+      case 'list_documents':
+        return await handleListDocuments(sql, userId);
+      case 'save_document':
+        return await handleSaveDocument(sql, userId, data);
+      case 'delete_document':
+        return await handleDeleteDocument(sql, userId, data);
+      default:
+        return createResponse(400, { error: `Unsupported action: ${action}` });
+    }
+  } catch (error) {
+    console.error('Document metadata handler error:', error);
+    return createResponse(500, {
+      error: 'Internal server error',
+      message: error.message,
+      timestamp: new Date().toISOString(),
+    });
+  }
+};

--- a/src/config/ragConfig.js
+++ b/src/config/ragConfig.js
@@ -10,9 +10,11 @@ export const RAG_BACKEND = Object.values(RAG_BACKENDS).includes(backendEnv)
 
 const DEFAULT_NEON_FUNCTION = '/.netlify/functions/neon-rag-fixed';
 const DEFAULT_NEON_DB_FUNCTION = '/.netlify/functions/neon-db';
+const DEFAULT_RAG_DOCS_FUNCTION = '/.netlify/functions/rag-documents';
 
 export const NEON_RAG_FUNCTION = process.env.REACT_APP_NEON_RAG_FUNCTION || DEFAULT_NEON_FUNCTION;
 export const NEON_DB_FUNCTION = process.env.REACT_APP_NEON_DB_FUNCTION || DEFAULT_NEON_DB_FUNCTION;
+export const RAG_DOCS_FUNCTION = process.env.REACT_APP_RAG_DOCS_FUNCTION || DEFAULT_RAG_DOCS_FUNCTION;
 
 export const isNeonBackend = () => RAG_BACKEND === RAG_BACKENDS.NEON;
 

--- a/src/services/ragService.test.js
+++ b/src/services/ragService.test.js
@@ -1,15 +1,10 @@
 import { jest } from '@jest/globals';
 import { TextEncoder, TextDecoder } from 'util';
+
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
-const mockGetToken = jest.fn();
-const mockGetUserId = jest.fn().mockResolvedValue('test-user');
-let RAGService;
-let pdfSupported = false;
-beforeAll(async () => {
-  await jest.unstable_mockModule('./authService', () => ({ getToken: mockGetToken, getUserId: mockGetUserId, default: {} }));
-  ({ default: RAGService } = await import('./ragService'));
-});
+
+const pdfSupported = false;
 
 function createPdfFile() {
   const pdfContent = `%PDF-1.3\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj\n3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 144]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj\n4 0 obj<</Length 44>>stream\nBT\n/F1 24 Tf\n72 96 Td\n(Hello PDF) Tj\nET\nendstream\nendobj\n5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\nxref\n0 6\n0000000000 65535 f \n0000000010 00000 n \n0000000061 00000 n \n0000000112 00000 n \n0000000221 00000 n \n0000000332 00000 n \ntrailer<</Size 6/Root 1 0 R>>\nstartxref\n383\n%%EOF`;
@@ -23,20 +18,124 @@ function createPdfFile() {
   };
 }
 
+const createDocumentApiMock = (userStore) => {
+  const calls = [];
+  const handler = async (action, userId, payload = {}) => {
+    calls.push([action, userId, payload]);
+    if (!userStore.has(userId)) {
+      userStore.set(userId, { vectorStoreId: null, documents: [] });
+    }
+    const state = userStore.get(userId);
+
+    switch (action) {
+      case 'health':
+        return { status: 'ok' };
+      case 'get_vector_store':
+        return { vectorStoreId: state.vectorStoreId };
+      case 'set_vector_store':
+        state.vectorStoreId = payload.vectorStoreId;
+        return { vectorStoreId: state.vectorStoreId };
+      case 'list_documents':
+        return { documents: state.documents };
+      case 'save_document': {
+        const incoming = payload.document || {};
+        const id = incoming.id || incoming.fileId;
+        const stored = {
+          ...incoming,
+          id,
+          fileId: incoming.fileId || id,
+          createdAt: incoming.createdAt || new Date().toISOString(),
+        };
+        const existingIndex = state.documents.findIndex(doc => doc.id === id);
+        if (existingIndex >= 0) {
+          state.documents[existingIndex] = stored;
+        } else {
+          state.documents.push(stored);
+        }
+        return { document: stored };
+      }
+      case 'delete_document':
+        state.documents = state.documents.filter(doc => doc.id !== payload.documentId);
+        return { success: true };
+      default:
+        return { error: `unsupported action: ${action}` };
+    }
+  };
+
+  handler.calls = calls;
+  handler.clear = () => {
+    calls.length = 0;
+  };
+
+  return handler;
+};
+
+const loadRagService = async ({ documentApiMock, uploadFileId = 'file_mock', vectorStoreId = 'vs_mock' } = {}) => {
+  jest.resetModules();
+
+  process.env.REACT_APP_OPENAI_API_KEY = 'test-key';
+  process.env.REACT_APP_RAG_BACKEND = 'openai';
+
+  const authModule = await import('./authService.js');
+  const getTokenSpy = jest.spyOn(authModule, 'getToken').mockResolvedValue('test-token');
+  const getUserIdSpy = jest.spyOn(authModule, 'getUserId').mockResolvedValue('test-user');
+
+  const openaiModule = await import('./openaiService.js');
+  const uploadFileSpy = jest.spyOn(openaiModule.default, 'uploadFile').mockResolvedValue(uploadFileId);
+  const createVectorStoreSpy = jest
+    .spyOn(openaiModule.default, 'createVectorStore')
+    .mockResolvedValue(vectorStoreId);
+  const attachFileSpy = jest
+    .spyOn(openaiModule.default, 'attachFileToVectorStore')
+    .mockResolvedValue({});
+  const makeRequestSpy = jest
+    .spyOn(openaiModule.default, 'makeRequest')
+    .mockImplementation(async (endpoint) => {
+      if (endpoint === '/files') {
+        return { data: [{ id: uploadFileId }] };
+      }
+      return { success: true };
+    });
+
+  const module = await import('./ragService.js');
+  const ragServiceInstance = module.default;
+  let documentApiSpy = null;
+  if (documentApiMock) {
+    documentApiSpy = jest
+      .spyOn(ragServiceInstance, 'makeDocumentMetadataRequest')
+      .mockImplementation((action, userId, payload = {}) => documentApiMock(action, userId, payload));
+  }
+
+  return {
+    ragService: ragServiceInstance,
+    mocks: {
+      getToken: getTokenSpy,
+      getUserId: getUserIdSpy,
+      openai: {
+        uploadFile: uploadFileSpy,
+        createVectorStore: createVectorStoreSpy,
+        attachFileToVectorStore: attachFileSpy,
+        makeRequest: makeRequestSpy,
+      },
+      documentApi: documentApiSpy,
+    },
+  };
+};
+
 describe('ragService PDF extraction', () => {
   (pdfSupported ? test : test.skip)('extracts text from a PDF', async () => {
-    const rag = RAGService;
+    const { ragService } = await loadRagService();
     const file = createPdfFile();
-    const text = await rag.extractTextFromFile(file);
+    const text = await ragService.extractTextFromFile(file);
     expect(text).toContain('Hello PDF');
   });
 });
 
 describe('neon-rag-fixed upload chunking', () => {
   (pdfSupported ? test : test.skip)('stores PDF text chunks', async () => {
-    const rag = RAGService;
+    const { ragService } = await loadRagService();
     const file = createPdfFile();
-    const text = await rag.extractTextFromFile(file);
+    const text = await ragService.extractTextFromFile(file);
 
     process.env.NEON_DATABASE_URL = 'postgres://user:pass@localhost/db';
     process.env.REACT_APP_AUTH0_DOMAIN = 'example.com';
@@ -71,5 +170,56 @@ describe('neon-rag-fixed upload chunking', () => {
     expect(body.chunks).toBeGreaterThan(0);
     const chunkCalls = client.query.mock.calls.filter(([q]) => q.includes('rag_document_chunks'));
     expect(chunkCalls.length).toBe(body.chunks);
+  });
+});
+
+describe('document persistence with Neon metadata store', () => {
+  const userStore = new Map();
+  const documentApiMock = createDocumentApiMock(userStore);
+
+  beforeEach(() => {
+    userStore.clear();
+    documentApiMock.clear();
+  });
+
+  test('documents uploaded in one session are available in a fresh session', async () => {
+    const uploadOptions = { documentApiMock, uploadFileId: 'file_doc_1', vectorStoreId: 'vs_persist_1' };
+    const { ragService: firstSession, mocks: firstMocks } = await loadRagService(uploadOptions);
+
+    const file = { name: 'SOP.pdf', type: 'application/pdf', size: 2048 };
+    await firstSession.uploadDocument(file, { category: 'quality' }, 'user-123');
+
+    expect(firstMocks.openai.uploadFile).toHaveBeenCalledTimes(1);
+    expect(firstMocks.openai.createVectorStore).toHaveBeenCalledTimes(1);
+
+    const callSummary = documentApiMock.calls.map(([action, user]) => [action, user]);
+    expect(callSummary).toEqual([
+      ['get_vector_store', 'user-123'],
+      ['set_vector_store', 'user-123'],
+      ['save_document', 'user-123'],
+    ]);
+    expect([...userStore.keys()]).toEqual(['user-123']);
+
+    const persistedAfterUpload = userStore.get('user-123');
+    expect(persistedAfterUpload.documents).toHaveLength(1);
+
+    const sessionOneDocs = await firstSession.getDocuments('user-123');
+    expect(sessionOneDocs).toHaveLength(1);
+    expect(sessionOneDocs[0].filename).toBe('SOP.pdf');
+
+    const { ragService: secondSession, mocks: secondMocks } = await loadRagService(uploadOptions);
+    const sessionTwoDocs = await secondSession.getDocuments('user-123');
+    expect(sessionTwoDocs).toHaveLength(1);
+    expect(sessionTwoDocs[0].id).toBe('file_doc_1');
+    expect(sessionTwoDocs[0].filename).toBe('SOP.pdf');
+
+    const vectorStoreId = await secondSession.getVectorStoreId('user-123');
+    expect(vectorStoreId).toBe('vs_persist_1');
+    expect(secondMocks.openai.createVectorStore).not.toHaveBeenCalled();
+
+    const persistedState = userStore.get('user-123');
+    expect(persistedState.vectorStoreId).toBe('vs_persist_1');
+    expect(persistedState.documents).toHaveLength(1);
+    expect(persistedState.documents[0].id).toBe('file_doc_1');
   });
 });


### PR DESCRIPTION
## Summary
- add a Netlify function that stores document metadata and per-user vector store IDs in Neon
- update ragService to read/write metadata via the Neon API and remove localStorage persistence
- document the new persistence flow and add tests that ensure uploads appear in new sessions

## Testing
- CI=true npm test -- --runTestsByPath src/services/ragService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c87959f474832abacf30f673cc3ce1