### PR TITLE
Integrate storage notifications for conversation persistence

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import RAGConfigurationPage from './components/RAGConfigurationPage';
 import AdminScreen from './components/AdminScreen';
 import NotebookOverlay from './components/NotebookOverlay';
 import SupportRequestOverlay from './components/SupportRequestOverlay';
+import StorageNotification, { useStorageNotifications } from './components/StorageNotification';
 
 // Utility
 import { v4 as uuidv4 } from 'uuid';
@@ -73,6 +74,10 @@ function App() {
   const messagesEndRef = useRef(null);
   const messagesLoadedRef = useRef(false);
   const isAdmin = useMemo(() => user?.roles?.includes('admin'), [user]);
+  const { StorageWelcomeModal: StorageWelcomeModalComponent } = useStorageNotifications(
+    isAuthenticated ? user : null,
+    messages.length
+  );
 
   useEffect(() => {
     if (cooldown > 0) {
@@ -598,6 +603,10 @@ function App() {
               onClose={() => setShowSupport(false)}
             />
           )}
+
+          {/* Storage notifications to highlight local persistence status */}
+          <StorageNotification user={user} messagesCount={messages.length} />
+          <StorageWelcomeModalComponent />
         </>
       )}
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- surface storage persistence status in the main app shell so users are reminded that conversations are saved locally
- wire the existing storage notification hook to show a welcome modal when eligible messages are present

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68c999b73bac832ab9e2270d98f37441