### PR TITLE
Enable multi-turn chat context for OpenAI responses

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,7 +28,7 @@ import {
 
 import { FEATURE_FLAGS } from './config/featureFlags';
 import { loadMessagesFromStorage, saveMessagesToStorage } from './utils/storageUtils';
-import { mergeCurrentAndStoredMessages } from './utils/messageUtils';
+import { mergeCurrentAndStoredMessages, buildChatHistory } from './utils/messageUtils';
 import {
   detectDocumentExportIntent,
   exportMessagesToExcel,
@@ -252,6 +252,8 @@ function App() {
 
     setIsLoading(true);
 
+    const conversationHistory = buildChatHistory(messages);
+
     const displayContent = uploadedFile
       ? `${rawInput}\n[Attached: ${uploadedFile.name}]`
       : rawInput;
@@ -319,7 +321,7 @@ function App() {
     try {
       const response = ragEnabled && !fileToSend
         ? await ragSearch(rawInput, user?.sub)
-        : await openaiService.getChatResponse(rawInput, fileToSend);
+        : await openaiService.getChatResponse(rawInput, fileToSend, conversationHistory);
 
       const assistantMessage = {
         id: uuidv4(),

--- a/src/services/learningSuggestionsService.js
+++ b/src/services/learningSuggestionsService.js
@@ -124,7 +124,8 @@ class LearningSuggestionsService {
       // Get suggestions from ChatGPT using a lighter model
       const response = await openaiService.getChatResponse(
         prompt,
-        '',
+        null,
+        [],
         OPENAI_CONFIG.SUGGESTIONS_MODEL
       );
       

--- a/src/services/neonService.js
+++ b/src/services/neonService.js
@@ -157,10 +157,15 @@ class NeonService {
           msg.content &&
           msg.timestamp
         )
-        .map(msg => ({
-          ...msg,
-          type: msg.type || (msg.role === 'assistant' ? 'ai' : msg.role),
-        }));
+        .map(msg => {
+          const normalizedType = msg.type || (msg.role === 'assistant' ? 'ai' : msg.role);
+          const normalizedRole = msg.role || (normalizedType === 'ai' ? 'assistant' : 'user');
+          return {
+            ...msg,
+            type: normalizedType,
+            role: normalizedRole,
+          };
+        });
 
       if (validMessages.length === 0) {
         console.warn('No valid messages to save');
@@ -183,6 +188,7 @@ class NeonService {
           messages: validMessages.map(msg => ({
             id: msg.id,
             type: msg.type,
+            role: msg.role || (msg.type === 'ai' ? 'assistant' : 'user'),
             content: msg.content,
             timestamp: msg.timestamp,
             resources: msg.resources || [],
@@ -337,6 +343,7 @@ class NeonService {
       (conversation.messages || []).map(msg => ({
         ...msg,
         type: msg.type === 'assistant' ? 'ai' : msg.type,
+        role: msg.role || (msg.type === 'assistant' || msg.type === 'ai' ? 'assistant' : 'user'),
         isStored: true,
         isCurrent: false,
         conversationId: conversation.id,

--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -24,6 +24,7 @@ jest.mock('../utils/fileConversion', () => ({
 }));
 
 import openAIService from './openaiService';
+import { OPENAI_CONFIG } from '../config/constants';
 
 describe('openAIService uploadFile', () => {
   beforeEach(() => {
@@ -109,6 +110,19 @@ describe('openAIService getChatResponse', () => {
 
     const result = await openAIService.getChatResponse('hello');
     expect(result.answer).toBe('response from output_text');
+
+    const [, options] = openAIService.makeRequest.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.input).toEqual([
+      {
+        role: 'system',
+        content: [{ type: 'input_text', text: OPENAI_CONFIG.SYSTEM_PROMPT }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'input_text', text: 'hello' }],
+      },
+    ]);
   });
 
   it('handles responses API payload with output array not first element', async () => {
@@ -132,6 +146,42 @@ describe('openAIService getChatResponse', () => {
 
     const result = await openAIService.getChatResponse('hi');
     expect(result.answer).toBe('response from choices');
+  });
+
+  it('includes prior messages in payload when history is provided', async () => {
+    openAIService.makeRequest.mockResolvedValue({
+      output_text: 'response with history',
+      usage: { total_tokens: 12 },
+    });
+
+    const history = [
+      { role: 'user', content: 'What is GMP?' },
+      { role: 'assistant', content: 'It is Good Manufacturing Practice.' },
+    ];
+
+    const result = await openAIService.getChatResponse('Explain validation steps', null, history);
+    expect(result.answer).toBe('response with history');
+
+    const [, options] = openAIService.makeRequest.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.input).toEqual([
+      {
+        role: 'system',
+        content: [{ type: 'input_text', text: OPENAI_CONFIG.SYSTEM_PROMPT }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'input_text', text: 'What is GMP?' }],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'input_text', text: 'It is Good Manufacturing Practice.' }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Explain validation steps' }],
+      },
+    ]);
   });
 
   it('throws descriptive error when response has no text', async () => {
@@ -158,5 +208,22 @@ describe('openAIService getChatResponse', () => {
     expect(openAIService.createVectorStore).toHaveBeenCalled();
     expect(openAIService.attachFileToVectorStore).toHaveBeenCalledWith('vs-456', 'file-123');
     expect(result.answer).toBe('response from file');
+
+    const [, options] = openAIService.makeRequest.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.input).toEqual([
+      {
+        role: 'system',
+        content: [{ type: 'input_text', text: OPENAI_CONFIG.SYSTEM_PROMPT }],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'hi' },
+          { type: 'input_file', file_id: 'file-123' },
+        ],
+      },
+    ]);
+    expect(body.tools).toEqual([{ type: 'file_search', vector_store_ids: ['vs-456'] }]);
   });
 });

--- a/src/utils/messageUtils.test.js
+++ b/src/utils/messageUtils.test.js
@@ -1,0 +1,29 @@
+import { buildChatHistory } from './messageUtils';
+
+describe('buildChatHistory', () => {
+  it('filters conversation to user and assistant roles in order', () => {
+    const messages = [
+      { id: '1', type: 'user', content: 'Hello there', timestamp: 1 },
+      { id: '2', type: 'ai', content: 'Hi! How can I help?', timestamp: 2 },
+      { id: '3', role: 'assistant', type: 'ai', content: 'Not for chat', isResource: true, timestamp: 3 },
+      { id: '4', type: 'user', content: 'Walk me through GMP validation.', timestamp: 4 },
+      { id: '5', role: 'assistant', type: 'ai', content: 'Validation follows IQ/OQ/PQ phases.', timestamp: 5 },
+      { id: '6', type: 'ai', content: '   ', timestamp: 6 },
+    ];
+
+    const history = buildChatHistory(messages);
+
+    expect(history).toEqual([
+      { role: 'user', content: 'Hello there' },
+      { role: 'assistant', content: 'Hi! How can I help?' },
+      { role: 'user', content: 'Walk me through GMP validation.' },
+      { role: 'assistant', content: 'Validation follows IQ/OQ/PQ phases.' },
+    ]);
+  });
+
+  it('returns an empty array for invalid inputs', () => {
+    expect(buildChatHistory(null)).toEqual([]);
+    expect(buildChatHistory(undefined)).toEqual([]);
+    expect(buildChatHistory([{ id: '1', type: 'ai', content: '   ' }])).toEqual([]);
+  });
+});

--- a/src/utils/storageUtils.js
+++ b/src/utils/storageUtils.js
@@ -206,10 +206,11 @@ export async function loadMessagesFromStorage(userId) {
         console.log(`Skipping invalid message at index ${index}:`, msg);
         return;
       }
-      
+
       if (validateMessage(msg)) {
         validMessages.push({
           ...msg,
+          role: msg.role || (msg.type === 'ai' ? 'assistant' : 'user'),
           isStored: true,
           isCurrent: false
         });
@@ -220,6 +221,7 @@ export async function loadMessagesFromStorage(userId) {
           console.log(`Successfully repaired message at index ${index}`);
           validMessages.push({
             ...repairedMessage,
+            role: repairedMessage.role || (repairedMessage.type === 'ai' ? 'assistant' : 'user'),
             isStored: true,
             isCurrent: false
           });
@@ -298,7 +300,10 @@ function validateMessagesForStorage(messages) {
     content: m.content.substring(0, 50) + '...'
   })));
   
-  return validMessages;
+  return validMessages.map(msg => ({
+    ...msg,
+    role: msg.role || (msg.type === 'ai' ? 'assistant' : 'user'),
+  }));
 }
 
 /**


### PR DESCRIPTION
## Summary
- capture prior user and assistant messages in the app and send them with each prompt
- add chat history sanitization utilities plus ensure stored and synced messages persist consistent role metadata
- refactor the OpenAI service to build full Responses API payloads (including history and files) and expand tests for history-aware conversations

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68c9a9a23868832ab28e02eb0eab9c8b