### PR TITLE
Fix assistant content payload for OpenAI responses API

### DIFF
--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -145,7 +145,7 @@ class OpenAIService {
       return [
         {
           type: 'output_text',
-          text: { value: normalizedText },
+          text: normalizedText,
         },
       ];
     }

--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -204,7 +204,7 @@ describe('openAIService getChatResponse', () => {
       },
       {
         role: 'assistant',
-        content: [{ type: 'output_text', text: { value: 'It is Good Manufacturing Practice.' } }],
+        content: [{ type: 'output_text', text: 'It is Good Manufacturing Practice.' }],
       },
       {
         role: 'user',


### PR DESCRIPTION
## Summary
- send assistant history text as a plain string when building responses payloads so the OpenAI API accepts the request
- align unit test expectations with the updated assistant content format

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68c9bda574a8832a974e9c4d0b1ce484