### PR TITLE
Fix OpenAI file search payload to remove deprecated tool_resources

### DIFF
--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -433,11 +433,12 @@ class OpenAIService {
             },
           ],
           tools: [{ type: 'file_search' }],
-          tool_resources: {
-            file_search: {
-              vector_store_ids: [vectorStoreId],
+          attachments: [
+            {
+              vector_store_id: vectorStoreId,
+              tools: [{ type: 'file_search' }],
             },
-          },
+          ],
         };
       } catch (error) {
         console.error('File upload failed:', error);

--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -254,10 +254,11 @@ describe('openAIService getChatResponse', () => {
       },
     ]);
     expect(body.tools).toEqual([{ type: 'file_search' }]);
-    expect(body.tool_resources).toEqual({
-      file_search: {
-        vector_store_ids: ['vs-456'],
+    expect(body.attachments).toEqual([
+      {
+        vector_store_id: 'vs-456',
+        tools: [{ type: 'file_search' }],
       },
-    });
+    ]);
   });
 });

--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -506,11 +506,12 @@ class RAGService {
       model: getCurrentModel(),
       input: query,
       tools: [{ type: 'file_search' }],
-      tool_resources: {
-        file_search: {
-          vector_store_ids: [vectorStoreId],
+      attachments: [
+        {
+          vector_store_id: vectorStoreId,
+          tools: [{ type: 'file_search' }],
         },
-      },
+      ],
     };
 
     const data = await openaiService.makeRequest('/responses', {


### PR DESCRIPTION
## Summary
- replace deprecated tool_resources usage with attachments when calling the OpenAI Responses API
- update the RAG service to send vector store references through attachments
- adjust unit tests to validate the new payload structure

## Testing
- CI=true npm test -- openaiService.test.js
- CI=true npm test -- ragService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c9c1dcdb60832aa0e77e5e8ad193d2