### PR TITLE
Fix OpenAI file search payload to use message attachments

### DIFF
--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -425,19 +425,16 @@ class OpenAIService {
             ...baseInput,
             {
               role: 'user',
-              content: [
-                ...this.createContentForRole('user', message || ''),
-
-                { type: 'input_file', file_id: fileId },
+              content: this.createContentForRole('user', message || ''),
+              attachments: [
+                {
+                  vector_store_id: vectorStoreId,
+                  tools: [{ type: 'file_search' }],
+                },
               ],
             },
           ],
           tools: [{ type: 'file_search' }],
-          tool_resources: {
-            file_search: {
-              vector_store_ids: [vectorStoreId],
-            },
-          },
         };
       } catch (error) {
         console.error('File upload failed:', error);

--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -247,17 +247,16 @@ describe('openAIService getChatResponse', () => {
       },
       {
         role: 'user',
-        content: [
-          { type: 'input_text', text: 'hi' },
-          { type: 'input_file', file_id: 'file-123' },
+        content: [{ type: 'input_text', text: 'hi' }],
+        attachments: [
+          {
+            vector_store_id: 'vs-456',
+            tools: [{ type: 'file_search' }],
+          },
         ],
       },
     ]);
     expect(body.tools).toEqual([{ type: 'file_search' }]);
-    expect(body.tool_resources).toEqual({
-      file_search: {
-        vector_store_ids: ['vs-456'],
-      },
-    });
+    expect(body.attachments).toBeUndefined();
   });
 });

--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -502,15 +502,26 @@ class RAGService {
 
     const vectorStoreId = await this.getVectorStoreId(userId);
 
+    const trimmedQuery = typeof query === 'string' ? query.trim() : '';
+    if (!trimmedQuery) {
+      throw new Error('Query is required to generate a response');
+    }
+
     const body = {
       model: getCurrentModel(),
-      input: query,
-      tools: [{ type: 'file_search' }],
-      tool_resources: {
-        file_search: {
-          vector_store_ids: [vectorStoreId],
+      input: [
+        {
+          role: 'user',
+          content: [{ type: 'input_text', text: trimmedQuery }],
+          attachments: [
+            {
+              vector_store_id: vectorStoreId,
+              tools: [{ type: 'file_search' }],
+            },
+          ],
         },
-      },
+      ],
+      tools: [{ type: 'file_search' }],
     };
 
     const data = await openaiService.makeRequest('/responses', {


### PR DESCRIPTION
## Summary
- move vector store references to the user message attachments so OpenAI responses requests no longer reject the payload
- update the RAG service to send message-based input with vector store attachments and guard against empty queries
- adjust unit tests to assert the message-level attachment structure

## Testing
- CI=true npm test -- openaiService.test.js
- CI=true npm test -- ragService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c9c1dcdb60832aa0e77e5e8ad193d2