### PR TITLE
Fix OpenAI responses payload attachments structure

### DIFF
--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -419,21 +419,13 @@ class OpenAIService {
           throw vsError;
         }
 
-        const userContent = this.createContentForRole('user', message || '').map((part, index) => {
-          if (index !== 0) {
-            return part;
-          }
-
-          return {
-            ...part,
-            attachments: [
-              {
-                vector_store_id: vectorStoreId,
-                tools: [{ type: 'file_search' }],
-              },
-            ],
-          };
-        });
+        const userContent = this.createContentForRole('user', message || '');
+        const attachments = [
+          {
+            vector_store_id: vectorStoreId,
+            tools: [{ type: 'file_search' }],
+          },
+        ];
 
         requestBody = {
           model,
@@ -442,6 +434,7 @@ class OpenAIService {
             {
               role: 'user',
               content: userContent,
+              attachments,
             },
           ],
           tools: [{ type: 'file_search' }],

--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -251,16 +251,17 @@ describe('openAIService getChatResponse', () => {
           {
             type: 'input_text',
             text: 'hi',
-            attachments: [
-              {
-                vector_store_id: 'vs-456',
-                tools: [{ type: 'file_search' }],
-              },
-            ],
+          },
+        ],
+        attachments: [
+          {
+            vector_store_id: 'vs-456',
+            tools: [{ type: 'file_search' }],
           },
         ],
       },
     ]);
+    expect(body.input[1].content[0]).not.toHaveProperty('attachments');
     expect(body.tools).toEqual([{ type: 'file_search' }]);
     expect(body.attachments).toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- ensure file-upload prompts attach vector store metadata at the message level when calling the responses API
- update tests covering getChatResponse to reflect the new attachment placement and guard against regressions

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68c9cfdb77a4832aba3c60eb14cfac3e