### PR TITLE
Fix OpenAI responses payload attachments structure

### DIFF
--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -419,21 +419,13 @@ class OpenAIService {
           throw vsError;
         }
 
-        const userContent = this.createContentForRole('user', message || '').map((part, index) => {
-          if (index !== 0) {
-            return part;
-          }
-
-          return {
-            ...part,
-            attachments: [
-              {
-                vector_store_id: vectorStoreId,
-                tools: [{ type: 'file_search' }],
-              },
-            ],
-          };
-        });
+        const userContent = this.createContentForRole('user', message || '');
+        const vectorStoreAttachments = [
+          {
+            vector_store_id: vectorStoreId,
+            tools: [{ type: 'file_search' }],
+          },
+        ];
 
         requestBody = {
           model,
@@ -445,6 +437,12 @@ class OpenAIService {
             },
           ],
           tools: [{ type: 'file_search' }],
+          attachments: vectorStoreAttachments,
+          tool_resources: {
+            file_search: {
+              vector_store_ids: [vectorStoreId],
+            },
+          },
         };
       } catch (error) {
         console.error('File upload failed:', error);

--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -251,17 +251,22 @@ describe('openAIService getChatResponse', () => {
           {
             type: 'input_text',
             text: 'hi',
-            attachments: [
-              {
-                vector_store_id: 'vs-456',
-                tools: [{ type: 'file_search' }],
-              },
-            ],
           },
         ],
       },
     ]);
+    expect(body.input[1]).not.toHaveProperty('attachments');
     expect(body.tools).toEqual([{ type: 'file_search' }]);
-    expect(body.attachments).toBeUndefined();
+    expect(body.attachments).toEqual([
+      {
+        vector_store_id: 'vs-456',
+        tools: [{ type: 'file_search' }],
+      },
+    ]);
+    expect(body.tool_resources).toEqual({
+      file_search: {
+        vector_store_ids: ['vs-456'],
+      },
+    });
   });
 });

--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -516,17 +516,22 @@ class RAGService {
             {
               type: 'input_text',
               text: trimmedQuery,
-              attachments: [
-                {
-                  vector_store_id: vectorStoreId,
-                  tools: [{ type: 'file_search' }],
-                },
-              ],
             },
           ],
         },
       ],
       tools: [{ type: 'file_search' }],
+      attachments: [
+        {
+          vector_store_id: vectorStoreId,
+          tools: [{ type: 'file_search' }],
+        },
+      ],
+      tool_resources: {
+        file_search: {
+          vector_store_ids: [vectorStoreId],
+        },
+      },
     };
 
     const data = await openaiService.makeRequest('/responses', {


### PR DESCRIPTION
## Summary
- ensure responses payload uses top-level attachments and tool resources when attaching vector store metadata for file uploads
- update tests covering getChatResponse to assert the new attachment placement and tool resource wiring
- align the RAG service payload with the updated attachments structure for responses API calls

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68c9cfdb77a4832aba3c60eb14cfac3e