### PR TITLE
Move file search attachments to user messages for responses payloads

### DIFF
--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -419,21 +419,13 @@ class OpenAIService {
           throw vsError;
         }
 
-        const userContent = this.createContentForRole('user', message || '').map((part, index) => {
-          if (index !== 0) {
-            return part;
-          }
-
-          return {
-            ...part,
-            attachments: [
-              {
-                vector_store_id: vectorStoreId,
-                tools: [{ type: 'file_search' }],
-              },
-            ],
-          };
-        });
+        const userContent = this.createContentForRole('user', message || '');
+        const vectorStoreAttachments = [
+          {
+            vector_store_id: vectorStoreId,
+            tools: [{ type: 'file_search' }],
+          },
+        ];
 
         requestBody = {
           model,
@@ -442,9 +434,15 @@ class OpenAIService {
             {
               role: 'user',
               content: userContent,
+              attachments: vectorStoreAttachments,
             },
           ],
           tools: [{ type: 'file_search' }],
+          tool_resources: {
+            file_search: {
+              vector_store_ids: [vectorStoreId],
+            },
+          },
         };
       } catch (error) {
         console.error('File upload failed:', error);

--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -240,28 +240,31 @@ describe('openAIService getChatResponse', () => {
 
     const [, options] = openAIService.makeRequest.mock.calls[0];
     const body = JSON.parse(options.body);
-    expect(body.input).toEqual([
-      {
-        role: 'system',
-        content: [{ type: 'input_text', text: OPENAI_CONFIG.SYSTEM_PROMPT }],
-      },
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'input_text',
-            text: 'hi',
-            attachments: [
-              {
-                vector_store_id: 'vs-456',
-                tools: [{ type: 'file_search' }],
-              },
-            ],
-          },
-        ],
-      },
-    ]);
+    expect(body.input[0]).toEqual({
+      role: 'system',
+      content: [{ type: 'input_text', text: OPENAI_CONFIG.SYSTEM_PROMPT }],
+    });
+    expect(body.input[1]).toEqual({
+      role: 'user',
+      content: [
+        {
+          type: 'input_text',
+          text: 'hi',
+        },
+      ],
+      attachments: [
+        {
+          vector_store_id: 'vs-456',
+          tools: [{ type: 'file_search' }],
+        },
+      ],
+    });
     expect(body.tools).toEqual([{ type: 'file_search' }]);
-    expect(body.attachments).toBeUndefined();
+    expect(body).not.toHaveProperty('attachments');
+    expect(body.tool_resources).toEqual({
+      file_search: {
+        vector_store_ids: ['vs-456'],
+      },
+    });
   });
 });

--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -507,6 +507,11 @@ class RAGService {
       throw new Error('Query is required to generate a response');
     }
 
+    const vectorStoreAttachment = {
+      vector_store_id: vectorStoreId,
+      tools: [{ type: 'file_search' }],
+    };
+
     const body = {
       model: getCurrentModel(),
       input: [
@@ -516,17 +521,17 @@ class RAGService {
             {
               type: 'input_text',
               text: trimmedQuery,
-              attachments: [
-                {
-                  vector_store_id: vectorStoreId,
-                  tools: [{ type: 'file_search' }],
-                },
-              ],
             },
           ],
+          attachments: [vectorStoreAttachment],
         },
       ],
       tools: [{ type: 'file_search' }],
+      tool_resources: {
+        file_search: {
+          vector_store_ids: [vectorStoreId],
+        },
+      },
     };
 
     const data = await openaiService.makeRequest('/responses', {


### PR DESCRIPTION
## Summary
- attach vector store metadata directly on the user message when uploading files to OpenAI responses
- mirror the user-level attachments structure in the RAG service payload
- refresh the getChatResponse unit test to verify message-level attachments and lack of top-level attachments

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68c9cfdb77a4832aba3c60eb14cfac3e