### PR TITLE
Move file search attachments to user messages for responses payloads

### DIFF
--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -29,6 +29,14 @@ class OpenAIService {
       },
     };
 
+    if (
+      endpoint === '/responses' &&
+      defaultOptions.body &&
+      typeof defaultOptions.body !== 'undefined'
+    ) {
+      defaultOptions.body = this.sanitizeResponsesRequestBody(defaultOptions.body);
+    }
+
     const maxRetries = 3;
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
@@ -62,6 +70,134 @@ class OpenAIService {
       : ERROR_MESSAGES.RATE_LIMIT_EXCEEDED;
 
     throw new Error(finalMsg);
+  }
+
+  sanitizeResponsesRequestBody(body) {
+    if (!body) {
+      return body;
+    }
+
+    if (typeof body === 'string') {
+      try {
+        const parsed = JSON.parse(body);
+        const sanitized = this.sanitizeResponsesPayload(parsed);
+        return JSON.stringify(sanitized);
+      } catch {
+        return body;
+      }
+    }
+
+    if (typeof body === 'object') {
+      // Avoid mutating shared references
+      const cloned = Array.isArray(body) ? [...body] : { ...body };
+      const sanitized = this.sanitizeResponsesPayload(cloned);
+      return JSON.stringify(sanitized);
+    }
+
+    return body;
+  }
+
+  sanitizeResponsesPayload(payload) {
+    if (!payload || typeof payload !== 'object') {
+      return payload;
+    }
+
+    if (Array.isArray(payload)) {
+      return payload.map(item => this.sanitizeResponsesPayload(item));
+    }
+
+    const sanitized = { ...payload };
+
+    if ('tool_resources' in sanitized) {
+      delete sanitized.tool_resources;
+    }
+
+    const rootAttachments = Array.isArray(sanitized.attachments)
+      ? sanitized.attachments.map(item => this.sanitizeResponsesPayload(item))
+      : [];
+
+    if (rootAttachments.length > 0) {
+      delete sanitized.attachments;
+    }
+
+    if (Array.isArray(sanitized.input)) {
+      sanitized.input = sanitized.input.map(message => this.normalizeResponseMessage(message));
+
+      if (rootAttachments.length > 0) {
+        const userIndex = this.findLastUserMessageIndex(sanitized.input);
+        if (userIndex !== -1) {
+          const targetMessage = sanitized.input[userIndex];
+          const existingAttachments = Array.isArray(targetMessage.attachments)
+            ? targetMessage.attachments
+            : [];
+          sanitized.input[userIndex] = {
+            ...targetMessage,
+            attachments: [...existingAttachments, ...rootAttachments],
+          };
+        } else {
+          sanitized.attachments = rootAttachments;
+        }
+      }
+    }
+
+    return sanitized;
+  }
+
+  normalizeResponseMessage(message) {
+    if (!message || typeof message !== 'object') {
+      return message;
+    }
+
+    const normalized = { ...message };
+
+    if ('tool_resources' in normalized) {
+      delete normalized.tool_resources;
+    }
+
+    const aggregatedAttachments = Array.isArray(normalized.attachments)
+      ? normalized.attachments.map(item => this.sanitizeResponsesPayload(item))
+      : [];
+
+    if (Array.isArray(normalized.content)) {
+      const normalizedContent = normalized.content.map(part => {
+        if (!part || typeof part !== 'object') {
+          return part;
+        }
+
+        const { attachments: partAttachments, ...rest } = part;
+        if (Array.isArray(partAttachments) && partAttachments.length > 0) {
+          aggregatedAttachments.push(
+            ...partAttachments.map(item => this.sanitizeResponsesPayload(item))
+          );
+        }
+
+        return this.sanitizeResponsesPayload(rest);
+      });
+
+      normalized.content = normalizedContent;
+    }
+
+    if (aggregatedAttachments.length > 0) {
+      normalized.attachments = aggregatedAttachments;
+    } else {
+      delete normalized.attachments;
+    }
+
+    return normalized;
+  }
+
+  findLastUserMessageIndex(messages) {
+    if (!Array.isArray(messages)) {
+      return -1;
+    }
+
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      if (messages[index] && messages[index].role === 'user') {
+        return index;
+      }
+    }
+
+    return -1;
   }
 
   async handleApiError(response, tokenCount = 0) {
@@ -419,21 +555,13 @@ class OpenAIService {
           throw vsError;
         }
 
-        const userContent = this.createContentForRole('user', message || '').map((part, index) => {
-          if (index !== 0) {
-            return part;
-          }
-
-          return {
-            ...part,
-            attachments: [
-              {
-                vector_store_id: vectorStoreId,
-                tools: [{ type: 'file_search' }],
-              },
-            ],
-          };
-        });
+        const userContent = this.createContentForRole('user', message || '');
+        const vectorStoreAttachments = [
+          {
+            vector_store_id: vectorStoreId,
+            tools: [{ type: 'file_search' }],
+          },
+        ];
 
         requestBody = {
           model,
@@ -442,6 +570,7 @@ class OpenAIService {
             {
               role: 'user',
               content: userContent,
+              attachments: vectorStoreAttachments,
             },
           ],
           tools: [{ type: 'file_search' }],

--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -240,28 +240,96 @@ describe('openAIService getChatResponse', () => {
 
     const [, options] = openAIService.makeRequest.mock.calls[0];
     const body = JSON.parse(options.body);
-    expect(body.input).toEqual([
-      {
-        role: 'system',
-        content: [{ type: 'input_text', text: OPENAI_CONFIG.SYSTEM_PROMPT }],
-      },
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'input_text',
-            text: 'hi',
-            attachments: [
-              {
-                vector_store_id: 'vs-456',
-                tools: [{ type: 'file_search' }],
-              },
-            ],
-          },
-        ],
-      },
-    ]);
+    expect(body.input[0]).toEqual({
+      role: 'system',
+      content: [{ type: 'input_text', text: OPENAI_CONFIG.SYSTEM_PROMPT }],
+    });
+    expect(body.input[1]).toEqual({
+      role: 'user',
+      content: [
+        {
+          type: 'input_text',
+          text: 'hi',
+        },
+      ],
+      attachments: [
+        {
+          vector_store_id: 'vs-456',
+          tools: [{ type: 'file_search' }],
+        },
+      ],
+    });
     expect(body.tools).toEqual([{ type: 'file_search' }]);
-    expect(body.attachments).toBeUndefined();
+    expect(body).not.toHaveProperty('attachments');
+    expect(body).not.toHaveProperty('tool_resources');
+  });
+});
+
+describe('openAIService makeRequest sanitization', () => {
+  beforeEach(() => {
+    openAIService.apiKey = 'test-key';
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('removes tool_resources and hoists attachments for responses payloads', async () => {
+    const payload = {
+      model: 'test-model',
+      input: [
+        {
+          role: 'system',
+          content: [{ type: 'input_text', text: 'system prompt' }],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_text',
+              text: 'hello',
+              attachments: [
+                { vector_store_id: 'content-vs', tool_resources: { example: true } },
+              ],
+            },
+          ],
+          attachments: [{ vector_store_id: 'message-vs' }],
+        },
+      ],
+      tool_resources: {
+        file_search: { vector_store_ids: ['root-vs'] },
+      },
+      attachments: [{ vector_store_id: 'root-vs' }],
+    };
+
+    await openAIService.makeRequest('/responses', {
+      body: JSON.stringify(payload),
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [, options] = fetch.mock.calls[0];
+    const sanitized = JSON.parse(options.body);
+
+    expect(sanitized.tool_resources).toBeUndefined();
+    expect(sanitized.attachments).toBeUndefined();
+
+    expect(Array.isArray(sanitized.input)).toBe(true);
+    const userMessage = sanitized.input.find(msg => msg.role === 'user');
+    expect(userMessage).toBeDefined();
+    expect(userMessage.attachments).toEqual([
+      { vector_store_id: 'message-vs' },
+      { vector_store_id: 'content-vs' },
+      { vector_store_id: 'root-vs' },
+    ]);
+
+    userMessage.content.forEach(part => {
+      if (part && typeof part === 'object') {
+        expect(part.attachments).toBeUndefined();
+      }
+    });
   });
 });

--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -507,6 +507,11 @@ class RAGService {
       throw new Error('Query is required to generate a response');
     }
 
+    const vectorStoreAttachment = {
+      vector_store_id: vectorStoreId,
+      tools: [{ type: 'file_search' }],
+    };
+
     const body = {
       model: getCurrentModel(),
       input: [
@@ -516,14 +521,9 @@ class RAGService {
             {
               type: 'input_text',
               text: trimmedQuery,
-              attachments: [
-                {
-                  vector_store_id: vectorStoreId,
-                  tools: [{ type: 'file_search' }],
-                },
-              ],
             },
           ],
+          attachments: [vectorStoreAttachment],
         },
       ],
       tools: [{ type: 'file_search' }],


### PR DESCRIPTION
## Summary
- attach vector store metadata directly on the user message when uploading files to OpenAI responses
- mirror the user-level attachments structure in the RAG service payload
- refresh the getChatResponse unit test to verify message-level attachments and lack of top-level attachments
- remove unsupported tool_resources parameter from responses payloads and adjust tests accordingly
- sanitize responses requests before sending to OpenAI so lingering tool_resources fields and misplaced attachments are removed, with a new test covering the behavior

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68c9cfdb77a4832aba3c60eb14cfac3e