### PR TITLE
Fix responses attachments structure

### DIFF
--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -507,6 +507,11 @@ class RAGService {
       throw new Error('Query is required to generate a response');
     }
 
+    const vectorStoreAttachment = {
+      vector_store_id: vectorStoreId,
+      tools: [{ type: 'file_search' }],
+    };
+
     const body = {
       model: getCurrentModel(),
       input: [
@@ -516,16 +521,11 @@ class RAGService {
             {
               type: 'input_text',
               text: trimmedQuery,
-              attachments: [
-                {
-                  vector_store_id: vectorStoreId,
-                  tools: [{ type: 'file_search' }],
-                },
-              ],
             },
           ],
         },
       ],
+      attachments: [vectorStoreAttachment],
       tools: [{ type: 'file_search' }],
     };
 


### PR DESCRIPTION
## Summary
- move `/responses` attachments to the root payload while removing unsupported tool_resources entries and consolidating message-level data
- update the file-upload chat and RAG flows to send vector store attachments through the top-level attachments array required by OpenAI
- refresh the OpenAI service tests to assert the new root-level attachment placement and sanitization behavior

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68c9cfdb77a4832aba3c60eb14cfac3e