### PR TITLE
Convert chat attachments to PDF before upload

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -1,7 +1,39 @@
 // src/components/ChatArea.js - DEPLOYMENT READY (fixes DatabaseOff issue)
 
 import React from 'react';
-import { Send, Loader2, Database, BookOpen, Paperclip } from 'lucide-react';
+import { Send, Loader2, Database, Paperclip, X } from 'lucide-react';
+
+const isPdfAttachment = (file) => {
+  if (!file) return false;
+  const name = typeof file.name === 'string' ? file.name.toLowerCase() : '';
+  const type = typeof file.type === 'string' ? file.type.toLowerCase() : '';
+  return name.endsWith('.pdf') || type === 'application/pdf';
+};
+
+const AttachmentPreview = ({ file, onRemove }) => {
+  const needsConversion = file ? !isPdfAttachment(file) : false;
+
+  return (
+    <div className="mt-2 flex items-center justify-between gap-3 rounded border border-gray-200 bg-white px-3 py-2 text-xs text-gray-600">
+      <div className="min-w-0">
+        <div className="truncate font-medium text-gray-700" title={file?.name}>
+          {file?.name || 'Attached document'}
+        </div>
+        <div className="text-[11px] text-gray-500">
+          {needsConversion ? 'Will convert to PDF before sending' : 'Ready to send to assistant'}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="flex items-center gap-1 rounded-full border border-gray-300 px-2 py-1 text-[11px] font-medium text-gray-600 transition hover:border-gray-400 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
+      >
+        <X className="h-3 w-3" aria-hidden="true" />
+        <span>Remove</span>
+      </button>
+    </div>
+  );
+};
 
 const ChatArea = ({
   messages,
@@ -162,8 +194,8 @@ const ChatArea = ({
             />
             <label
               htmlFor="chat-file-upload"
-              className="px-3 sm:px-4 py-3 sm:py-4 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 cursor-pointer flex items-center justify-center min-w-[44px]"
-              title="Attach a PDF, DOCX, TXT, or MD document"
+              className="flex min-w-[44px] cursor-pointer items-center justify-center rounded-lg bg-gray-200 px-3 py-3 text-gray-700 transition hover:bg-gray-300 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 sm:px-4 sm:py-4"
+              title="Attach a PDF, Word (.docx), Markdown (.md), or Text (.txt) document. Non-PDF files will be converted automatically."
             >
               <Paperclip className="h-4 w-4 sm:h-5 sm:w-5" />
             </label>
@@ -188,9 +220,10 @@ const ChatArea = ({
             />
           </div>
           <button
+            type="button"
             onClick={handleSendMessage}
             disabled={isLoading || cooldown > 0 || (!inputMessage.trim() && !uploadedFile)}
-            className="px-4 sm:px-6 py-3 sm:py-4 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center min-w-[44px]"
+            className="flex min-w-[44px] items-center justify-center rounded-lg bg-blue-600 px-4 py-3 text-white transition-colors hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:px-6 sm:py-4"
             title={cooldown > 0 ? `Please wait ${cooldown}s` : 'Send message'}
           >
             {isLoading ? (
@@ -202,7 +235,7 @@ const ChatArea = ({
         </div>
 
         {uploadedFile && (
-          <div className="text-xs text-gray-500 mt-2">Attached: {uploadedFile.name}</div>
+          <AttachmentPreview file={uploadedFile} onRemove={() => setUploadedFile(null)} />
         )}
 
         {/* Character/Line Count for longer messages */}

--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -17,6 +17,7 @@ let mockConvertDocxToPdfIfNeeded = async (file) => ({
   converted: false,
   originalFileName: file?.name || null,
   originalMimeType: file?.type || null,
+  conversion: null,
 });
 
 jest.mock('../utils/fileConversion', () => ({
@@ -34,6 +35,7 @@ describe('openAIService uploadFile', () => {
       converted: false,
       originalFileName: file?.name || null,
       originalMimeType: file?.type || null,
+      conversion: null,
     }));
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
@@ -59,7 +61,7 @@ describe('openAIService uploadFile', () => {
 
   it('rejects unsupported file types', async () => {
     const file = { name: 'image.png', type: 'image/png' };
-    await expect(openAIService.uploadFile(file)).rejects.toThrow('Unsupported file type; please upload a PDF, TXT, MD, or DOCX file');
+    await expect(openAIService.uploadFile(file)).rejects.toThrow('Unsupported file type; please upload a PDF, Word (.docx), Markdown (.md), or plain text (.txt) file.');
     expect(fetch).not.toHaveBeenCalled();
   });
 
@@ -79,6 +81,7 @@ describe('openAIService uploadFile', () => {
       converted: true,
       originalFileName: originalFile.name,
       originalMimeType: originalFile.type,
+      conversion: 'docx-to-pdf',
     });
 
     const id = await openAIService.uploadFile(originalFile);

--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -296,6 +296,7 @@ class RAGService {
       converted,
       originalFileName,
       originalMimeType,
+      conversion: conversionType,
     } = await this.convertDocxToPdfIfNeeded(file);
     const fileId = await openaiService.uploadFile(uploadableFile);
     const vectorStoreId = await this.getVectorStoreId(userId);
@@ -315,7 +316,7 @@ class RAGService {
           ? {
               originalFilename: originalFileName,
               originalMimeType,
-              conversion: 'docx-to-pdf',
+              conversion: conversionType || 'file-to-pdf',
             }
           : {}),
         ...sanitizedMetadata,

--- a/src/services/ragService.test.js
+++ b/src/services/ragService.test.js
@@ -104,6 +104,7 @@ const loadRagService = async ({ documentApiMock, uploadFileId = 'file_mock', vec
     converted: false,
     originalFileName: file?.name || null,
     originalMimeType: file?.type || null,
+    conversion: null,
   }));
   ragServiceInstance.convertDocxToPdfIfNeeded = convertMock;
   let documentApiSpy = null;
@@ -252,6 +253,7 @@ describe('document persistence with Neon metadata store', () => {
       converted: true,
       originalFileName: originalFile.name,
       originalMimeType: originalFile.type,
+      conversion: 'docx-to-pdf',
     });
 
     await ragService.uploadDocument(originalFile, { category: 'quality' }, 'user-456');

--- a/src/utils/fileConversion.test.js
+++ b/src/utils/fileConversion.test.js
@@ -1,0 +1,59 @@
+import { TextEncoder, TextDecoder } from 'util';
+import { convertFileToPdfIfNeeded } from './fileConversion';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+const createPdfFile = () => ({
+  name: 'example.pdf',
+  type: 'application/pdf',
+  lastModified: Date.now(),
+});
+
+const createTextFile = (name, type, content) => ({
+  name,
+  type,
+  lastModified: Date.now(),
+  text: async () => content,
+});
+
+describe('convertFileToPdfIfNeeded', () => {
+  it('returns the original PDF without conversion', async () => {
+    const pdfFile = createPdfFile();
+
+    const result = await convertFileToPdfIfNeeded(pdfFile);
+
+    expect(result.converted).toBe(false);
+    expect(result.file).toBe(pdfFile);
+    expect(result.originalFileName).toBe('example.pdf');
+    expect(result.originalMimeType).toBe('application/pdf');
+  });
+
+  it('converts plain text files to PDF', async () => {
+    const textFile = createTextFile('guidance.txt', 'text/plain', 'Quality guidance improves compliance.');
+
+    const result = await convertFileToPdfIfNeeded(textFile);
+
+    expect(result.converted).toBe(true);
+    expect(result.conversion).toBe('text-to-pdf');
+    expect(result.file.type).toBe('application/pdf');
+    expect(result.file.name).toBe('guidance.pdf');
+    expect(result.originalFileName).toBe('guidance.txt');
+    expect(result.originalMimeType).toBe('text/plain');
+    expect(typeof result.file.arrayBuffer).toBe('function');
+
+    const buffer = await result.file.arrayBuffer();
+    expect(buffer.byteLength).toBeGreaterThan(0);
+  });
+
+  it('converts markdown files to PDF', async () => {
+    const markdownFile = createTextFile('notes.md', 'text/markdown', '# Heading\n\n* bullet item\n');
+
+    const result = await convertFileToPdfIfNeeded(markdownFile);
+
+    expect(result.converted).toBe(true);
+    expect(result.conversion).toBe('markdown-to-pdf');
+    expect(result.file.type).toBe('application/pdf');
+    expect(result.file.name).toBe('notes.pdf');
+  });
+});


### PR DESCRIPTION
## Summary
- convert uploaded chat documents to PDF before sending them to the assistant and surface conversion failures to the user
- refresh the chat UI with attachment previews, removal controls, and clearer upload guidance
- expand the file conversion utility (plus new tests) to support DOCX/Markdown/plain-text PDF conversion and ensure returned files expose arrayBuffer

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68c9f6214494832a991bbf0323fc0025