### PR TITLE
Log ChatGPT request payload for debugging

### DIFF
--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -667,6 +667,12 @@ class OpenAIService {
     const sanitizedRequestBody = this.sanitizeResponsesPayload(requestBody);
 
     try {
+      console.info('Sending ChatGPT request payload:', {
+        endpoint: '/responses',
+        tokenCount,
+        body: sanitizedRequestBody,
+      });
+
       const data = await this.makeRequest(
         '/responses',
         {
@@ -712,7 +718,12 @@ class OpenAIService {
         usage: data.usage || null,
       };
     } catch (error) {
-      console.error('OpenAI API Error:', error);
+      console.error('OpenAI API Error. Payload sent to ChatGPT:', {
+        endpoint: '/responses',
+        tokenCount,
+        body: sanitizedRequestBody,
+        error,
+      });
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- log the sanitized payload information before sending a request to OpenAI
- include the request payload details when reporting OpenAI API errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca91cf0ae0832a813eeee17bdcc384