### PR TITLE
Use file_search tool instead of attachments for Responses API

### DIFF
--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -508,9 +508,9 @@ class RAGService {
       throw new Error('Query is required to generate a response');
     }
 
-    const vectorStoreAttachment = {
-      vector_store_id: vectorStoreId,
-      tools: [{ type: 'file_search' }],
+    const fileSearchTool = {
+      type: 'file_search',
+      vector_store_ids: [vectorStoreId],
     };
 
     const body = {
@@ -525,20 +525,12 @@ class RAGService {
 
             },
           ],
-          attachments: [vectorStoreAttachment],
         },
       ],
-      attachments: [vectorStoreAttachment],
-      tools: [{ type: 'file_search' }],
-      tool_resources: {
-        file_search: {
-          vector_store_ids: [vectorStoreId],
-        },
-      },
+      tools: [fileSearchTool],
     };
 
     const data = await openaiService.makeRequest('/responses', {
-      headers: { 'OpenAI-Beta': 'assistants=v2' },
       body: JSON.stringify(body),
     });
 


### PR DESCRIPTION
## Summary
- update the Responses API payloads to attach vector stores through the `file_search` tool instead of unsupported top-level attachments
- sanitize outgoing Responses requests by stripping attachment metadata at every level while keeping other fields intact
- align the RAG service call path and unit tests with the new payload structure

## Testing
- CI=true npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68caa8ec6810832a9c87711ca2be93de