### PR TITLE
Support CSV and XLSX uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "jwks-rsa": "^2.1.5",
     "lucide-react": "^0.263.1",
     "mammoth": "^1.6.0",
+    "jszip": "^3.10.1",
     "pdfjs-dist": "^3.10.111",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -273,7 +273,7 @@ function App() {
             type: 'ai',
             content:
               conversionError.message ||
-              'I was unable to process the attached document. Please upload a PDF, Word (.docx), Markdown (.md), or text (.txt) file.',
+              'I was unable to process the attached document. Please upload a PDF, Word (.docx), Markdown (.md), text (.txt), CSV (.csv), or Excel (.xlsx) file.',
             timestamp: Date.now(),
             sources: [],
             resources: [],

--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -242,14 +242,14 @@ const ChatArea = ({
             <input
               type="file"
               id="chat-file-upload"
-              accept=".pdf,.txt,.md,.docx"
+              accept=".pdf,.txt,.md,.docx,.csv,.xlsx"
               className="hidden"
               onChange={(e) => setUploadedFile(e.target.files[0] || null)}
             />
             <label
               htmlFor="chat-file-upload"
               className="flex min-w-[44px] cursor-pointer items-center justify-center rounded-lg bg-gray-200 px-3 py-3 text-gray-700 transition hover:bg-gray-300 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 sm:px-4 sm:py-4"
-              title="Attach a PDF, Word (.docx), Markdown (.md), or Text (.txt) document. Non-PDF files will be converted automatically."
+              title="Attach a PDF, Word (.docx), Markdown (.md), Text (.txt), CSV (.csv), or Excel (.xlsx) document. Non-PDF files will be converted automatically."
             >
               <Paperclip className="h-4 w-4 sm:h-5 sm:w-5" />
             </label>

--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -28,6 +28,22 @@ import {
   NEON_RAG_FUNCTION,
 } from '../config/ragConfig';
 
+const describeConversionSource = (conversion) => {
+  if (!conversion) {
+    return null;
+  }
+
+  const conversionLabels = {
+    'docx-to-pdf': 'DOCX',
+    'markdown-to-pdf': 'Markdown',
+    'text-to-pdf': 'text',
+    'csv-to-pdf': 'CSV',
+    'xlsx-to-pdf': 'Excel',
+  };
+
+  return conversionLabels[conversion] || null;
+};
+
 const RAGConfigurationPage = ({ user, onClose }) => {
   const [documents, setDocuments] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -638,17 +654,17 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Select File (PDF, DOCX, TXT, or MD)
+                      Select File (PDF, DOCX, TXT, MD, CSV, or XLSX)
                     </label>
                       <input
                         id="file-upload"
                         type="file"
-                        accept=".pdf,.txt,.md,.docx"
+                        accept=".pdf,.txt,.md,.docx,.csv,.xlsx"
                         onChange={handleFileSelect}
                         className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
                       />
                     <p className="text-xs text-gray-500 mt-1">
-                      DOCX files are automatically converted to PDF before upload. Persistent storage with the {ragBackendLabel} backend.
+                      DOCX, CSV, and XLSX files are automatically converted to PDF before upload. Persistent storage with the {ragBackendLabel} backend.
                     </p>
                   </div>
 
@@ -786,9 +802,9 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                           {doc.metadata?.version && (
                             <p><span className="font-medium">Version:</span> {doc.metadata.version}</p>
                           )}
-                          {doc.metadata?.conversion === 'docx-to-pdf' && doc.metadata?.originalFilename && (
+                          {doc.metadata?.conversion && doc.metadata?.originalFilename && (
                             <p className="text-sm text-gray-600">
-                              <span className="font-medium text-gray-700">Original:</span> {doc.metadata.originalFilename} (converted from DOCX)
+                              <span className="font-medium text-gray-700">Original:</span> {doc.metadata.originalFilename} (converted from {describeConversionSource(doc.metadata.conversion) || 'the uploaded format'})
                             </p>
                           )}
                           <p><span className="font-medium">Uploaded:</span> {new Date(doc.createdAt).toLocaleDateString()}</p>

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -435,7 +435,7 @@ class OpenAIService {
     const fileName = preparedFile?.name?.toLowerCase() || '';
     const fileType = preparedFile?.type?.toLowerCase() || '';
     const isPdf = fileName.endsWith('.pdf') || fileType === 'application/pdf';
-    const supportedDescription = 'PDF, Word (.docx), Markdown (.md), or plain text (.txt) file.';
+    const supportedDescription = 'PDF, Word (.docx), Markdown (.md), plain text (.txt), CSV (.csv), or Excel (.xlsx) file.';
 
     if (!isPdf) {
       if (converted) {

--- a/src/services/openaiService.test.js
+++ b/src/services/openaiService.test.js
@@ -61,7 +61,7 @@ describe('openAIService uploadFile', () => {
 
   it('rejects unsupported file types', async () => {
     const file = { name: 'image.png', type: 'image/png' };
-    await expect(openAIService.uploadFile(file)).rejects.toThrow('Unsupported file type; please upload a PDF, Word (.docx), Markdown (.md), or plain text (.txt) file.');
+    await expect(openAIService.uploadFile(file)).rejects.toThrow('Unsupported file type; please upload a PDF, Word (.docx), Markdown (.md), plain text (.txt), CSV (.csv), or Excel (.xlsx) file.');
     expect(fetch).not.toHaveBeenCalled();
   });
 

--- a/src/utils/fileConversion.js
+++ b/src/utils/fileConversion.js
@@ -1,7 +1,9 @@
 export const DOCX_MIME_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+export const XLSX_MIME_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 
 const MARKDOWN_MIME_TYPES = ['text/markdown', 'text/x-markdown'];
 const TEXT_MIME_TYPES = ['text/plain'];
+const CSV_MIME_TYPES = ['text/csv', 'application/csv', 'text/x-csv', 'application/vnd.ms-excel'];
 
 const MAX_CHARS_PER_LINE = 90;
 const PDF_LINE_HEIGHT = 16;
@@ -47,6 +49,26 @@ export const isPdfFile = (file) => {
   const name = toLowerCase(file.name);
   const type = toLowerCase(file.type);
   return hasExtension(name, '.pdf') || type === 'application/pdf';
+};
+
+const isCsvFile = (file) => {
+  if (!file) return false;
+  const name = toLowerCase(file.name);
+  const type = toLowerCase(file.type);
+
+  if (hasExtension(name, '.csv')) {
+    return true;
+  }
+
+  return CSV_MIME_TYPES.includes(type);
+};
+
+const isXlsxFile = (file) => {
+  if (!file) return false;
+  const name = toLowerCase(file.name);
+  const type = toLowerCase(file.type);
+
+  return hasExtension(name, '.xlsx') || type === toLowerCase(XLSX_MIME_TYPE);
 };
 
 const isMarkdownFile = (file) => {
@@ -214,6 +236,393 @@ const buildSimplePdf = (pages) => {
   return encoder.encode(pdfString);
 };
 
+const decodeXmlEntities = (text = '') => {
+  if (!text) {
+    return '';
+  }
+
+  return text
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => {
+      const code = parseInt(hex, 16);
+      return Number.isFinite(code) ? String.fromCharCode(code) : '';
+    })
+    .replace(/&#([0-9]+);/g, (_, dec) => {
+      const code = parseInt(dec, 10);
+      return Number.isFinite(code) ? String.fromCharCode(code) : '';
+    });
+};
+
+const extractTextNodes = (xmlSegment = '') => {
+  const matches = xmlSegment.match(/<t[^>]*>[\s\S]*?<\/t>/g);
+
+  if (!matches) {
+    return '';
+  }
+
+  return matches
+    .map((match) => {
+      const inner = match.replace(/<t[^>]*>|<\/t>/g, '');
+      return decodeXmlEntities(inner);
+    })
+    .join('');
+};
+
+const normalizeCellValue = (value) => {
+  if (value == null) {
+    return '';
+  }
+
+  const stringValue = typeof value === 'string' ? value : String(value);
+
+  return stringValue
+    .replace(/\uFEFF/g, '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(/\t/g, ' ')
+    .split('\n')
+    .map((line) => line.trim())
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+const columnLettersToIndex = (letters = '') => {
+  if (!letters) {
+    return 0;
+  }
+
+  let index = 0;
+  for (let i = 0; i < letters.length; i += 1) {
+    index *= 26;
+    index += letters.charCodeAt(i) - 64;
+  }
+  return Math.max(0, index - 1);
+};
+
+const parseSharedStringsXml = (xml = '') => {
+  if (!xml) {
+    return [];
+  }
+
+  const stringItems = xml.match(/<si[\s\S]*?<\/si>/g);
+  if (!stringItems) {
+    return [];
+  }
+
+  return stringItems.map((item) => normalizeCellValue(extractTextNodes(item)));
+};
+
+const parseSheetXml = (xml = '', sharedStrings = []) => {
+  if (!xml) {
+    return [];
+  }
+
+  const sheetDataMatch = xml.match(/<sheetData[\s\S]*?<\/sheetData>/);
+  const sheetData = sheetDataMatch ? sheetDataMatch[0] : xml;
+  const rowMatches = sheetData.match(/<row\b[^>]*>[\s\S]*?<\/row>/g);
+
+  if (!rowMatches) {
+    return [];
+  }
+
+  const rows = [];
+
+  rowMatches.forEach((rowXml) => {
+    const cellMatches = rowXml.match(/<c\b[^>]*>[\s\S]*?<\/c>/g);
+    if (!cellMatches) {
+      return;
+    }
+
+    const rowValues = [];
+
+    cellMatches.forEach((cellXml) => {
+      const referenceMatch = cellXml.match(/r="([A-Z]+)(\d+)"/);
+      let columnIndex = rowValues.length;
+
+      if (referenceMatch) {
+        columnIndex = columnLettersToIndex(referenceMatch[1]);
+      }
+
+      while (rowValues.length < columnIndex) {
+        rowValues.push('');
+      }
+
+      const typeMatch = cellXml.match(/t="([^"']+)"/);
+      const type = typeMatch ? typeMatch[1] : null;
+      let cellValue = '';
+
+      if (type === 's') {
+        const valueMatch = cellXml.match(/<v>([\s\S]*?)<\/v>/);
+        if (valueMatch) {
+          const sharedIndex = parseInt(valueMatch[1], 10);
+          if (!Number.isNaN(sharedIndex) && sharedStrings[sharedIndex] != null) {
+            cellValue = sharedStrings[sharedIndex];
+          }
+        }
+      } else if (type === 'inlineStr') {
+        cellValue = extractTextNodes(cellXml);
+      } else if (type === 'b') {
+        const valueMatch = cellXml.match(/<v>([\s\S]*?)<\/v>/);
+        cellValue = valueMatch && valueMatch[1] === '1' ? 'TRUE' : 'FALSE';
+      } else {
+        const valueMatch = cellXml.match(/<v>([\s\S]*?)<\/v>/);
+        if (valueMatch) {
+          cellValue = decodeXmlEntities(valueMatch[1]);
+        } else {
+          cellValue = extractTextNodes(cellXml);
+        }
+      }
+
+      rowValues[columnIndex] = normalizeCellValue(cellValue);
+    });
+
+    while (rowValues.length > 0 && rowValues[rowValues.length - 1] === '') {
+      rowValues.pop();
+    }
+
+    if (rowValues.length > 0) {
+      rows.push(rowValues);
+    }
+  });
+
+  return rows;
+};
+
+const parseWorkbookDefinition = (workbookXml = '') => {
+  if (!workbookXml) {
+    return [];
+  }
+
+  const sheetMatches = workbookXml.match(/<sheet\b[^>]*>/g);
+  if (!sheetMatches) {
+    return [];
+  }
+
+  return sheetMatches
+    .map((sheetTag) => {
+      const nameMatch = sheetTag.match(/name="([^"]+)"/);
+      const relationshipMatch = sheetTag.match(/r:id="([^"]+)"/);
+
+      if (!relationshipMatch) {
+        return null;
+      }
+
+      return {
+        name: nameMatch ? nameMatch[1] : null,
+        relationshipId: relationshipMatch[1],
+      };
+    })
+    .filter(Boolean);
+};
+
+const parseWorkbookRelationships = (relsXml = '') => {
+  const relationships = new Map();
+
+  if (!relsXml) {
+    return relationships;
+  }
+
+  const relMatches = relsXml.match(/<Relationship\b[^>]*>/g);
+  if (!relMatches) {
+    return relationships;
+  }
+
+  relMatches.forEach((relTag) => {
+    const idMatch = relTag.match(/Id="([^"]+)"/);
+    const targetMatch = relTag.match(/Target="([^"]+)"/);
+
+    if (idMatch && targetMatch) {
+      relationships.set(idMatch[1], targetMatch[1]);
+    }
+  });
+
+  return relationships;
+};
+
+const normalizeSheetTarget = (target = '') => {
+  if (!target) {
+    return null;
+  }
+
+  let normalized = target;
+
+  while (normalized.startsWith('../')) {
+    normalized = normalized.slice(3);
+  }
+
+  normalized = normalized.replace(/^\.\//, '').replace(/^\//, '');
+
+  if (!normalized.startsWith('xl/')) {
+    normalized = `xl/${normalized}`;
+  }
+
+  return normalized;
+};
+
+const loadXlsxSheets = async (file) => {
+  const jszipModule = await import('jszip');
+  const JSZipClass = jszipModule.default || jszipModule;
+
+  const arrayBuffer = await file.arrayBuffer();
+  const zip = await JSZipClass.loadAsync(arrayBuffer);
+
+  const workbookXmlFile = zip.file('xl/workbook.xml');
+  if (!workbookXmlFile) {
+    throw new Error('Workbook definition is missing.');
+  }
+
+  const workbookXml = await workbookXmlFile.async('string');
+  const sheetDefinitions = parseWorkbookDefinition(workbookXml);
+
+  if (sheetDefinitions.length === 0) {
+    throw new Error('No worksheets were found in the Excel file.');
+  }
+
+  const relationshipsXml = await zip.file('xl/_rels/workbook.xml.rels')?.async('string');
+  const relationships = parseWorkbookRelationships(relationshipsXml);
+
+  const sharedStringsXml = await zip.file('xl/sharedStrings.xml')?.async('string');
+  const sharedStrings = sharedStringsXml ? parseSharedStringsXml(sharedStringsXml) : [];
+
+  const sheets = [];
+
+  for (let index = 0; index < sheetDefinitions.length; index += 1) {
+    const definition = sheetDefinitions[index];
+    const target = normalizeSheetTarget(
+      relationships.get(definition.relationshipId) || `worksheets/sheet${index + 1}.xml`
+    );
+
+    if (!target) {
+      continue;
+    }
+
+    const sheetFile = zip.file(target);
+    if (!sheetFile) {
+      continue;
+    }
+
+    const sheetXml = await sheetFile.async('string');
+    const rows = parseSheetXml(sheetXml, sharedStrings);
+
+    sheets.push({
+      name: definition.name || `Sheet ${index + 1}`,
+      rows,
+    });
+  }
+
+  return sheets;
+};
+
+const convertSheetsToText = (sheets = []) => {
+  if (!Array.isArray(sheets) || sheets.length === 0) {
+    return '';
+  }
+
+  const lines = [];
+
+  sheets.forEach((sheet, index) => {
+    const rows = Array.isArray(sheet?.rows) ? sheet.rows : [];
+    const formattedRows = rows
+      .map((row) => (Array.isArray(row) ? row : []))
+      .map((row) => row.map((cell) => normalizeCellValue(cell)))
+      .map((row) => row.join(' | '))
+      .filter((line) => line.trim().length > 0);
+
+    if (formattedRows.length === 0) {
+      return;
+    }
+
+    if (lines.length > 0) {
+      lines.push('');
+    }
+
+    const sheetName = typeof sheet?.name === 'string' && sheet.name.trim().length > 0
+      ? sheet.name.trim()
+      : `Sheet ${index + 1}`;
+
+    lines.push(`Sheet: ${sheetName}`);
+    lines.push(...formattedRows);
+  });
+
+  return lines.join('\n').trim();
+};
+
+const parseCsvContent = (content = '') => {
+  const rows = [];
+  let currentRow = [];
+  let currentValue = '';
+  let inQuotes = false;
+
+  const pushValue = () => {
+    currentRow.push(currentValue);
+    currentValue = '';
+  };
+
+  const finalizeRow = () => {
+    pushValue();
+    const normalizedRow = currentRow.map((value) => normalizeCellValue(value));
+    if (normalizedRow.some((value) => value.length > 0)) {
+      rows.push(normalizedRow);
+    }
+    currentRow = [];
+  };
+
+  for (let index = 0; index < content.length; index += 1) {
+    const char = content[index];
+
+    if (char === '"') {
+      if (inQuotes && content[index + 1] === '"') {
+        currentValue += '"';
+        index += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === ',' && !inQuotes) {
+      pushValue();
+      continue;
+    }
+
+    if ((char === '\n' || char === '\r') && !inQuotes) {
+      finalizeRow();
+      if (char === '\r' && content[index + 1] === '\n') {
+        index += 1;
+      }
+      continue;
+    }
+
+    currentValue += char;
+  }
+
+  pushValue();
+  const normalizedRow = currentRow.map((value) => normalizeCellValue(value));
+  if (normalizedRow.some((value) => value.length > 0)) {
+    rows.push(normalizedRow);
+  }
+
+  return rows;
+};
+
+const convertCsvRowsToText = (rows) => {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return '';
+  }
+
+  return rows
+    .map((row) => (Array.isArray(row) ? row : []))
+    .map((row) => row.join(' | '))
+    .filter((line) => line.trim().length > 0)
+    .join('\n')
+    .trim();
+};
+
 const readFileAsText = async (file) => {
   if (file && typeof file.text === 'function') {
     return file.text();
@@ -334,6 +743,62 @@ export const convertFileToPdfIfNeeded = async (file) => {
     } catch (error) {
       console.error('Failed to convert DOCX to PDF:', error);
       throw new Error(`Failed to convert DOCX to PDF: ${error.message}`);
+    }
+  }
+
+  if (isCsvFile(file)) {
+    if (typeof file.text !== 'function' && typeof file.arrayBuffer !== 'function') {
+      throw new Error('CSV conversion requires text() or arrayBuffer support on the provided file.');
+    }
+
+    try {
+      const rawContent = await readFileAsText(file);
+      const sanitized = rawContent.replace(/^\uFEFF/, '');
+      const rows = parseCsvContent(sanitized);
+      const textContent = convertCsvRowsToText(rows);
+      const convertedFile = buildPdfFromText(
+        textContent,
+        file,
+        'This spreadsheet was converted from CSV but contained no extractable cells.'
+      );
+
+      return {
+        file: convertedFile,
+        converted: true,
+        originalFileName: file.name || null,
+        originalMimeType: file.type || CSV_MIME_TYPES[0],
+        conversion: 'csv-to-pdf',
+      };
+    } catch (error) {
+      console.error('Failed to convert CSV to PDF:', error);
+      throw new Error(`Failed to convert CSV file to PDF: ${error.message}`);
+    }
+  }
+
+  if (isXlsxFile(file)) {
+    if (typeof file.arrayBuffer !== 'function') {
+      throw new Error('Excel conversion requires arrayBuffer support on the provided file.');
+    }
+
+    try {
+      const sheets = await loadXlsxSheets(file);
+      const textContent = convertSheetsToText(sheets);
+      const convertedFile = buildPdfFromText(
+        textContent,
+        file,
+        'This spreadsheet was converted from Excel but contained no extractable cells.'
+      );
+
+      return {
+        file: convertedFile,
+        converted: true,
+        originalFileName: file.name || null,
+        originalMimeType: file.type || XLSX_MIME_TYPE,
+        conversion: 'xlsx-to-pdf',
+      };
+    } catch (error) {
+      console.error('Failed to convert XLSX to PDF:', error);
+      throw new Error(`Failed to convert Excel file to PDF: ${error.message}`);
     }
   }
 

--- a/src/utils/fileConversion.test.js
+++ b/src/utils/fileConversion.test.js
@@ -17,6 +17,78 @@ const createTextFile = (name, type, content) => ({
   text: async () => content,
 });
 
+const createXlsxTestFile = async () => {
+  const { default: JSZip } = await import('jszip');
+
+  const zip = new JSZip();
+
+  const contentTypesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+</Types>`;
+
+  const rootRelsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId0" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`;
+
+  const workbookXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Data" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>`;
+
+  const workbookRelsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>
+</Relationships>`;
+
+  const sharedStringsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="3" uniqueCount="3">
+  <si><t>Name</t></si>
+  <si><t>Value</t></si>
+  <si><t>Metric</t></si>
+</sst>`;
+
+  const sheetXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1">
+      <c r="A1" t="s"><v>0</v></c>
+      <c r="B1" t="s"><v>1</v></c>
+    </row>
+    <row r="2">
+      <c r="A2" t="s"><v>2</v></c>
+      <c r="B2"><v>42</v></c>
+    </row>
+  </sheetData>
+</worksheet>`;
+
+  zip.file('[Content_Types].xml', contentTypesXml);
+  zip.folder('_rels').file('.rels', rootRelsXml);
+
+  const xlFolder = zip.folder('xl');
+  xlFolder.file('workbook.xml', workbookXml);
+  xlFolder.folder('_rels').file('workbook.xml.rels', workbookRelsXml);
+  xlFolder.file('sharedStrings.xml', sharedStringsXml);
+  xlFolder.folder('worksheets').file('sheet1.xml', sheetXml);
+
+  const arrayBuffer = await zip.generateAsync({ type: 'arraybuffer' });
+
+  return {
+    name: 'metrics.xlsx',
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    lastModified: Date.now(),
+    arrayBuffer: async () => arrayBuffer.slice(0),
+  };
+};
+
 describe('convertFileToPdfIfNeeded', () => {
   it('returns the original PDF without conversion', async () => {
     const pdfFile = createPdfFile();
@@ -55,5 +127,37 @@ describe('convertFileToPdfIfNeeded', () => {
     expect(result.conversion).toBe('markdown-to-pdf');
     expect(result.file.type).toBe('application/pdf');
     expect(result.file.name).toBe('notes.pdf');
+  });
+
+  it('converts CSV files to PDF', async () => {
+    const csvFile = createTextFile('report.csv', 'text/csv', 'Name,Value\nAlpha,10\nBeta,20');
+
+    const result = await convertFileToPdfIfNeeded(csvFile);
+
+    expect(result.converted).toBe(true);
+    expect(result.conversion).toBe('csv-to-pdf');
+    expect(result.file.type).toBe('application/pdf');
+    expect(result.file.name).toBe('report.pdf');
+    expect(result.originalFileName).toBe('report.csv');
+    expect(result.originalMimeType).toBe('text/csv');
+
+    const buffer = await result.file.arrayBuffer();
+    expect(buffer.byteLength).toBeGreaterThan(0);
+  });
+
+  it('converts XLSX files to PDF', async () => {
+    const xlsxFile = await createXlsxTestFile();
+
+    const result = await convertFileToPdfIfNeeded(xlsxFile);
+
+    expect(result.converted).toBe(true);
+    expect(result.conversion).toBe('xlsx-to-pdf');
+    expect(result.file.type).toBe('application/pdf');
+    expect(result.file.name).toBe('metrics.pdf');
+    expect(result.originalFileName).toBe('metrics.xlsx');
+    expect(result.originalMimeType).toBe('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+
+    const buffer = await result.file.arrayBuffer();
+    expect(buffer.byteLength).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- add jszip-based spreadsheet parsing so CSV and XLSX uploads are converted to PDF alongside existing formats
- update upload controls and messaging to allow selecting CSV/XLSX files and show conversion metadata in document listings
- extend conversion unit tests with synthetic CSV/XLSX fixtures to ensure the new formats are processed correctly

## Testing
- CI=true npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cad8312ab8832aa3052beaa6f0630e