### PR TITLE
Default chat RAG toggle to document search

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -61,7 +61,7 @@ function App() {
   const [messages, setMessages] = useState([]);
   const [inputMessage, setInputMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const [ragEnabled, setRAGEnabled] = useState(false);
+  const [ragEnabled, setRAGEnabled] = useState(true);
   const [uploadedFile, setUploadedFile] = useState(null);
   const [activeDocument, setActiveDocument] = useState(null);
   const [cooldown, setCooldown] = useState(0);


### PR DESCRIPTION
## Summary
- default the chat screen RAG toggle to the document search state by initializing `ragEnabled` to true

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cb2063ffe4832ab851639f3904b823