### PR TITLE
Enable deleting notebook conversations and resources

### DIFF
--- a/src/components/NotebookOverlay.js
+++ b/src/components/NotebookOverlay.js
@@ -2,6 +2,11 @@ import React, { useState } from 'react';
 import { X, Search } from 'lucide-react';
 import NotebookView from './NotebookView';
 
+const NOTEBOOK_TABS = [
+  { id: 'conversations', label: 'Conversations' },
+  { id: 'resources', label: 'Learning Resources' }
+];
+
 const NotebookOverlay = ({
   messages,
   thirtyDayMessages,
@@ -11,38 +16,74 @@ const NotebookOverlay = ({
   isGeneratingNotes,
   storedMessageCount,
   isServerAvailable,
+  onDeleteConversation,
+  onDeleteResource,
   onClose
 }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [sortOrder, setSortOrder] = useState('desc');
+  const [activeTab, setActiveTab] = useState('conversations');
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg shadow-xl max-w-6xl w-full max-h-[90vh] overflow-hidden flex flex-col">
-        <div className="flex items-center justify-between p-6 border-b border-gray-200">
-          <h2 className="text-xl font-semibold text-gray-900">Notebook</h2>
-            <div className="flex items-center space-x-2">
-              <div className="relative">
-                <Search className="h-4 w-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
-                <input
-                  type="text"
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  placeholder="Search..."
-                  className="pl-9 pr-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-500 text-sm w-48"
-                  aria-label="Search notebook"
-                />
-              </div>
-              <select
-                value={sortOrder}
-                onChange={(e) => setSortOrder(e.target.value)}
-                className="text-sm border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-gray-500"
-                aria-label="Sort conversations"
+        <div className="p-6 border-b border-gray-200">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-gray-900">Notebook</h2>
+              <nav
+                className="mt-4 flex flex-wrap items-center gap-2"
+                role="tablist"
+                aria-label="Notebook sections"
               >
-                <option value="desc">Newest first</option>
-                <option value="asc">Oldest first</option>
-              </select>
+                {NOTEBOOK_TABS.map((tab) => (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    id={`notebook-tab-${tab.id}`}
+                    role="tab"
+                    aria-selected={activeTab === tab.id}
+                    aria-controls={`notebook-panel-${tab.id}`}
+                    onClick={() => setActiveTab(tab.id)}
+                    className={`px-3 py-2 text-sm font-medium rounded-md border transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ${
+                      activeTab === tab.id
+                        ? 'bg-gray-900 text-white border-gray-900'
+                        : 'bg-white text-gray-600 border-gray-200 hover:text-gray-900 hover:border-gray-300'
+                    }`}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </nav>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 justify-end">
+              {activeTab === 'conversations' && (
+                <>
+                  <div className="relative">
+                    <Search className="h-4 w-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+                    <input
+                      type="text"
+                      value={searchTerm}
+                      onChange={(e) => setSearchTerm(e.target.value)}
+                      placeholder="Search conversations"
+                      className="pl-9 pr-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-500 text-sm w-48"
+                      aria-label="Search notebook conversations"
+                    />
+                  </div>
+                  <select
+                    value={sortOrder}
+                    onChange={(e) => setSortOrder(e.target.value)}
+                    className="text-sm border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-gray-500"
+                    aria-label="Sort conversations"
+                  >
+                    <option value="desc">Newest first</option>
+                    <option value="asc">Oldest first</option>
+                  </select>
+                </>
+              )}
               <button
+                type="button"
                 onClick={onClose}
                 className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
                 aria-label="Close notebook"
@@ -50,6 +91,7 @@ const NotebookOverlay = ({
                 <X className="h-5 w-5 text-gray-500" />
               </button>
             </div>
+          </div>
         </div>
         <div className="p-6 overflow-y-auto flex-1">
           <NotebookView
@@ -63,6 +105,9 @@ const NotebookOverlay = ({
             isServerAvailable={isServerAvailable}
             searchTerm={searchTerm}
             sortOrder={sortOrder}
+            activeTab={activeTab}
+            onDeleteConversation={onDeleteConversation}
+            onDeleteResource={onDeleteResource}
           />
         </div>
       </div>

--- a/src/components/NotebookView.js
+++ b/src/components/NotebookView.js
@@ -1,6 +1,20 @@
 import React, { memo, useMemo } from 'react';
 import { combineMessagesIntoConversations, mergeCurrentAndStoredMessages } from '../utils/messageUtils';
-import { Cloud, Smartphone } from 'lucide-react';
+import { Cloud, Smartphone, Trash2 } from 'lucide-react';
+
+const normalizeResourceValue = (value) =>
+  typeof value === 'string' ? value.trim().toLowerCase() : '';
+
+const createResourceKey = (resource, conversationId, index) => {
+  const normalizedUrl = normalizeResourceValue(resource?.url);
+  const normalizedTitle = normalizeResourceValue(resource?.title);
+
+  if (normalizedUrl || normalizedTitle) {
+    return `${normalizedUrl}|${normalizedTitle}`;
+  }
+
+  return `${conversationId || 'resource'}-${index}`;
+};
 
 const NotebookView = memo(({
   messages, // Current session messages
@@ -12,7 +26,10 @@ const NotebookView = memo(({
   storedMessageCount = 0,
   isServerAvailable = true,
   searchTerm = '',
-  sortOrder = 'desc'
+  sortOrder = 'desc',
+  activeTab = 'conversations',
+  onDeleteConversation,
+  onDeleteResource
 }) => {
   // Merge current session and stored messages
   const availableMessages = useMemo(
@@ -73,110 +90,172 @@ const NotebookView = memo(({
 
   // Separate conversations based on storage status
   const currentConversations = conversations.filter(conv => {
-    // Consider a conversation "current" if any of its messages are marked as current
-    return conv.isCurrent || 
-           (conv.originalUserMessage?.isCurrent) || 
+    return conv.isCurrent ||
+           (conv.originalUserMessage?.isCurrent) ||
            (conv.originalAiMessage?.isCurrent);
   });
-  
+
   const storedConversations = conversations.filter(conv => {
-    // Consider stored if it's not current and has stored messages
     return !conv.isCurrent &&
            (conv.originalUserMessage?.isStored || conv.originalAiMessage?.isStored);
   });
 
   const allResources = useMemo(() => {
-    const map = new Map();
-    conversations.forEach(conv => {
-      (conv.resources || []).forEach(res => {
-        if (res.url && res.title) {
-          map.set(res.url, { ...res, addedAt: res.addedAt || conv.timestamp });
+    const resourceMap = new Map();
+
+    sortedConversations.forEach((conversation) => {
+      const resources = conversation?.resources || [];
+      if (!resources.length) {
+        return;
+      }
+
+      const sourceMeta = {
+        messageId: conversation.originalAiMessage?.id || conversation.originalUserMessage?.id || conversation.id,
+        conversationId:
+          conversation.originalAiMessage?.conversationId ||
+          conversation.originalUserMessage?.conversationId ||
+          null,
+        conversationCardId: conversation.id,
+        storageStatus: conversation.isCurrent ? 'current' : conversation.isStored ? 'stored' : 'unknown',
+        isCurrent: Boolean(conversation.isCurrent),
+        isStored: Boolean(conversation.isStored),
+      };
+
+      resources.forEach((resource, index) => {
+        if (!resource) {
+          return;
+        }
+
+        const resourceKey = createResourceKey(resource, conversation.id, index);
+        const existing = resourceMap.get(resourceKey);
+
+        if (existing) {
+          const mergedSources = existing.sourceMessages ? [...existing.sourceMessages] : [];
+          const alreadyLinked = mergedSources.some(
+            (source) =>
+              source.messageId === sourceMeta.messageId &&
+              source.conversationCardId === sourceMeta.conversationCardId
+          );
+
+          if (!alreadyLinked) {
+            mergedSources.push(sourceMeta);
+          }
+
+          resourceMap.set(resourceKey, {
+            ...existing,
+            addedAt: existing.addedAt || resource.addedAt || conversation.timestamp,
+            description: existing.description || resource.description,
+            type: existing.type || resource.type,
+            sourceMessages: mergedSources,
+          });
+        } else {
+          resourceMap.set(resourceKey, {
+            ...resource,
+            key: resourceKey,
+            title: resource.title || resource.url || 'Untitled resource',
+            addedAt: resource.addedAt || conversation.timestamp,
+            sourceMessages: [sourceMeta],
+          });
         }
       });
     });
-    return Array.from(map.values());
-  }, [conversations]);
+
+    return Array.from(resourceMap.values());
+  }, [sortedConversations]);
 
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-6 h-full shadow-sm flex flex-col">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h3 className="text-lg font-bold text-gray-900">Notebook</h3>
-          <p className="text-sm text-gray-500">
-            {availableMessages.length} messages • {conversations.length} conversations
-          </p>
-          
-          {/* Storage Status Summary */}
-          <div className="flex items-center space-x-4 mt-2 text-xs">
-            {isServerAvailable ? (
-              <>
-                <div className="flex items-center space-x-1 text-green-600">
-                  <Cloud className="h-3 w-3" />
-                  <span>{storedConversations.length} saved to cloud</span>
-                </div>
-                <div className="flex items-center space-x-1 text-blue-600">
-                  <Smartphone className="h-3 w-3" />
-                  <span>{currentConversations.length} current session</span>
-                </div>
-              </>
-            ) : (
-              <div className="flex items-center space-x-1 text-orange-600">
-                <Smartphone className="h-3 w-3" />
-                <span>Session only - {conversations.length} conversations</span>
-              </div>
-            )}
-          </div>
-        </div>
-        
-        <div className="flex items-center space-x-3">
-          {selectedMessages.size > 0 && (
-            <span className="text-xs text-blue-600 font-medium bg-blue-50 px-2 py-1 rounded-full">
-              {selectedMessages.size} selected
-            </span>
-          )}
-          
-          <div className="flex items-center space-x-2">
-            <button
-              onClick={selectedMessages.size > 0 ? deselectAll : selectAllConversations}
-              className="px-3 py-1 text-xs font-medium text-gray-600 hover:text-gray-800 border border-gray-300 rounded hover:border-gray-400 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-500"
-              disabled={conversations.length === 0}
-            >
-              {selectedMessages.size > 0 ? 'Deselect All' : 'Select All'}
-            </button>
-            
-            <button
-              onClick={handleGenerateStudyNotes}
-              disabled={selectedMessages.size === 0 || isGeneratingNotes}
-              className={`px-4 py-2 text-sm font-medium rounded transition-colors focus:outline-none focus:ring-2 ${
-                selectedMessages.size > 0 && !isGeneratingNotes
-                  ? 'bg-black text-white hover:bg-gray-800 focus:ring-gray-600' 
-                  : 'bg-gray-100 text-gray-400 cursor-not-allowed focus:ring-gray-300'
-              }`}
-              aria-label="Generate study notes from selected conversations"
-            >
-              {isGeneratingNotes ? (
-                <span className="flex items-center space-x-2">
-                  <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-white" />
-                  <span>Generating...</span>
-                </span>
+      {activeTab === 'conversations' ? (
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h3 className="text-lg font-bold text-gray-900">Notebook</h3>
+            <p className="text-sm text-gray-500">
+              {availableMessages.length} messages • {conversations.length} conversations
+            </p>
+            <div className="flex items-center space-x-4 mt-2 text-xs">
+              {isServerAvailable ? (
+                <>
+                  <div className="flex items-center space-x-1 text-green-600">
+                    <Cloud className="h-3 w-3" />
+                    <span>{storedConversations.length} saved to cloud</span>
+                  </div>
+                  <div className="flex items-center space-x-1 text-blue-600">
+                    <Smartphone className="h-3 w-3" />
+                    <span>{currentConversations.length} current session</span>
+                  </div>
+                </>
               ) : (
-                'Study Notes'
+                <div className="flex items-center space-x-1 text-orange-600">
+                  <Smartphone className="h-3 w-3" />
+                  <span>Session only - {conversations.length} conversations</span>
+                </div>
               )}
-            </button>
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-3">
+            {selectedMessages.size > 0 && (
+              <span className="text-xs text-blue-600 font-medium bg-blue-50 px-2 py-1 rounded-full">
+                {selectedMessages.size} selected
+              </span>
+            )}
+
+            <div className="flex items-center space-x-2">
+              <button
+                onClick={selectedMessages.size > 0 ? deselectAll : selectAllConversations}
+                className="px-3 py-1 text-xs font-medium text-gray-600 hover:text-gray-800 border border-gray-300 rounded hover:border-gray-400 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-500"
+                disabled={conversations.length === 0}
+              >
+                {selectedMessages.size > 0 ? 'Deselect All' : 'Select All'}
+              </button>
+
+              <button
+                onClick={handleGenerateStudyNotes}
+                disabled={selectedMessages.size === 0 || isGeneratingNotes}
+                className={`px-4 py-2 text-sm font-medium rounded transition-colors focus:outline-none focus:ring-2 ${
+                  selectedMessages.size > 0 && !isGeneratingNotes
+                    ? 'bg-black text-white hover:bg-gray-800 focus:ring-gray-600'
+                    : 'bg-gray-100 text-gray-400 cursor-not-allowed focus:ring-gray-300'
+                }`}
+                aria-label="Generate study notes from selected conversations"
+              >
+                {isGeneratingNotes ? (
+                  <span className="flex items-center space-x-2">
+                    <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-white" />
+                    <span>Generating...</span>
+                  </span>
+                ) : (
+                  'Study Notes'
+                )}
+              </button>
+            </div>
           </div>
         </div>
-      </div>
+      ) : (
+        <div className="mb-6">
+          <h3 className="text-lg font-bold text-gray-900">Learning Resources</h3>
+          <p className="text-sm text-gray-500">
+            {allResources.length} {allResources.length === 1 ? 'resource' : 'resources'} collected from your recent conversations
+          </p>
+          <p className="text-xs text-gray-500 mt-2">
+            Explore saved links and materials recommended during chats.
+          </p>
+        </div>
+      )}
 
       <div className="flex-1 overflow-hidden">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 h-full">
-          {/* Conversations List */}
-          <div className="space-y-3 overflow-y-auto">
+        {activeTab === 'conversations' ? (
+          <div
+            id="notebook-panel-conversations"
+            role="tabpanel"
+            aria-labelledby="notebook-tab-conversations"
+            className="h-full overflow-y-auto pr-1"
+          >
             {conversations.length === 0 ? (
               <div className="text-center py-12">
                 <div className="text-gray-400 mb-4">
                   <svg className="w-12 h-12 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-3.582 8-8 8a8.991 8.991 0 01-4.7-1.299L3 21l2.3-5.7A7.991 7.991 0 1121 12z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c04.418-3.582 8-8 8a8.991 8.991 0 01-4.7-1.299L3 21l2.3-5.7A7.991 7.991 0 1121 12z" />
                   </svg>
                 </div>
                 {searchTerm.trim() ? (
@@ -197,8 +276,7 @@ const NotebookView = memo(({
                 )}
               </div>
             ) : (
-              <div className="space-y-6">
-                {/* Current Session Conversations */}
+              <div className="space-y-6 pb-4">
                 {currentConversations.length > 0 && (
                   <div>
                     <div className="flex items-center justify-between mb-3">
@@ -222,13 +300,13 @@ const NotebookView = memo(({
                           isCurrentSession={true}
                           debugIndex={index}
                           storageStatus="current"
+                          onDeleteConversation={onDeleteConversation}
                         />
                       ))}
                     </div>
                   </div>
                 )}
 
-                {/* Stored Conversations */}
                 {storedConversations.length > 0 && (
                   <div>
                     <div className="flex items-center justify-between mb-3">
@@ -250,6 +328,7 @@ const NotebookView = memo(({
                           isCurrentSession={false}
                           debugIndex={index + currentConversations.length}
                           storageStatus="stored"
+                          onDeleteConversation={onDeleteConversation}
                         />
                       ))}
                     </div>
@@ -258,61 +337,69 @@ const NotebookView = memo(({
               </div>
             )}
           </div>
-
-          {/* Learning Resources */}
-          <div className="space-y-3 overflow-y-auto">
-            <h4 className="text-md font-semibold text-gray-900">Learning Resources</h4>
+        ) : (
+          <div
+            id="notebook-panel-resources"
+            role="tabpanel"
+            aria-labelledby="notebook-tab-resources"
+            className="h-full overflow-y-auto pr-1"
+          >
             {allResources.length === 0 ? (
-              <p className="text-sm text-gray-500">No resources available.</p>
+              <div className="h-full flex items-center justify-center text-center text-sm text-gray-500 px-6">
+                No resources available yet. Add learning materials from your conversations to see them here.
+              </div>
             ) : (
-              allResources.map((resource, idx) => (
-                <div
-                  key={idx}
-                  className="p-3 rounded-lg border border-gray-200 hover:border-gray-300 transition-colors space-y-1">
-                  {resource.url ? (
-                    <a
-                      href={resource.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm font-medium text-blue-600 hover:text-blue-800 block truncate">
-                      {resource.title}
-                    </a>
-                  ) : (
-                    <span className="text-sm font-medium text-gray-900 block truncate">{resource.title}</span>
-                  )}
-                  <span className="text-xs text-gray-500 flex items-center justify-between">
-                    <span>
-                      {resource.type || 'Resource'}
-                      {resource.location ? ` • ${resource.location}` : ''}
-                      {resource.addedAt && (
-                        <> • {new Date(resource.addedAt).toLocaleString()}</>
-                      )}
-                    </span>
-                  </span>
-                  {resource.description && (
-                    <p className="text-xs text-gray-500 line-clamp-2">{resource.description}</p>
-                  )}
-                </div>
-              ))
+              <div className="space-y-3 pb-4">
+                {allResources.map((resource) => (
+                  <ResourceCard
+                    key={resource.key || resource.url || `${resource.title}-${resource.addedAt}`}
+                    resource={resource}
+                    onDeleteResource={onDeleteResource}
+                  />
+                ))}
+              </div>
             )}
           </div>
-        </div>
+        )}
       </div>
     </div>
   );
 });
 
 // Individual conversation card component
-const ConversationCard = memo(({ 
-  conversation, 
-  isSelected, 
-  onToggleSelection, 
-  isCurrentSession, 
-  debugIndex, 
-  storageStatus = 'unknown' 
+const ConversationCard = memo(({
+  conversation,
+  isSelected,
+  onToggleSelection,
+  isCurrentSession,
+  debugIndex,
+  storageStatus = 'unknown',
+  onDeleteConversation
 }) => {
   const handleToggle = () => {
     onToggleSelection(conversation.id);
+  };
+
+  const handleDelete = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (typeof onDeleteConversation !== 'function') {
+      return;
+    }
+
+    const timestampLabel = conversation.timestamp
+      ? new Date(conversation.timestamp).toLocaleString()
+      : 'this conversation';
+
+    const shouldDelete =
+      typeof window !== 'undefined' && typeof window.confirm === 'function'
+        ? window.confirm(`Delete the conversation saved on ${timestampLabel}?`)
+        : true;
+
+    if (shouldDelete) {
+      onDeleteConversation(conversation);
+    }
   };
 
   const getStorageStatusColor = () => {
@@ -333,8 +420,8 @@ const ConversationCard = memo(({
 
   return (
     <div className={`p-4 rounded-lg border transition-all cursor-pointer ${
-      isSelected 
-        ? 'bg-blue-50 border-blue-300 shadow-sm' 
+      isSelected
+        ? 'bg-blue-50 border-blue-300 shadow-sm'
         : getStorageStatusColor() + ' hover:border-gray-300 hover:shadow-sm'
     }`}>
       <div className="flex items-start space-x-3">
@@ -345,12 +432,12 @@ const ConversationCard = memo(({
           className="mt-1 rounded border-gray-300 text-black focus:ring-black focus:ring-2"
           aria-label={`Select conversation from ${new Date(conversation.timestamp).toLocaleDateString()}`}
         />
-        
+
         <div className="flex-1 min-w-0" onClick={handleToggle}>
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center space-x-2">
               <span className={`text-xs font-semibold uppercase tracking-wide ${
-                storageStatus === 'current' ? 'text-blue-600' : 
+                storageStatus === 'current' ? 'text-blue-600' :
                 storageStatus === 'stored' ? 'text-green-600' : 'text-purple-600'
               }`}>
                 Conversation #{debugIndex + 1}
@@ -360,14 +447,26 @@ const ConversationCard = memo(({
                 {conversation.isCurrent ? 'C' : ''}{conversation.isStored ? 'S' : ''}
               </span>
             </div>
-            <time 
-              className="text-xs text-gray-500"
-              dateTime={conversation.timestamp}
-            >
-              {new Date(conversation.timestamp).toLocaleString()}
-            </time>
+            <div className="flex items-center space-x-2">
+              <time
+                className="text-xs text-gray-500"
+                dateTime={conversation.timestamp}
+              >
+                {new Date(conversation.timestamp).toLocaleString()}
+              </time>
+              {typeof onDeleteConversation === 'function' && (
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className="p-1 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded"
+                  aria-label="Delete conversation"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+            </div>
           </div>
-          
+
           {conversation.userContent && (
             <div className="mb-3">
               <div className="text-xs font-medium text-blue-600 mb-1">QUESTION:</div>
@@ -376,7 +475,7 @@ const ConversationCard = memo(({
               </p>
             </div>
           )}
-          
+
           {conversation.aiContent && (
             <div className="mb-3">
               <div className="text-xs font-medium text-green-600 mb-1">RESPONSE:</div>
@@ -385,7 +484,7 @@ const ConversationCard = memo(({
               </p>
             </div>
           )}
-          
+
           {conversation.isStudyNotes && (
             <div className="mt-3 pt-2 border-t border-gray-200">
               <span className="text-xs bg-green-100 text-green-700 px-2 py-1 rounded-full font-medium">
@@ -401,5 +500,92 @@ const ConversationCard = memo(({
 
 ConversationCard.displayName = 'ConversationCard';
 NotebookView.displayName = 'NotebookView';
+
+const ResourceCard = memo(({ resource, onDeleteResource }) => {
+  if (!resource) {
+    return null;
+  }
+
+  const handleDelete = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (typeof onDeleteResource !== 'function') {
+      return;
+    }
+
+    const occurrences = resource.sourceMessages?.length || 1;
+    const confirmationMessage =
+      occurrences > 1
+        ? `Remove this resource from ${occurrences} saved conversations?`
+        : 'Remove this resource from your notebook?';
+
+    const shouldDelete =
+      typeof window !== 'undefined' && typeof window.confirm === 'function'
+        ? window.confirm(confirmationMessage)
+        : true;
+
+    if (shouldDelete) {
+      onDeleteResource(resource);
+    }
+  };
+
+  const addedAtLabel = resource.addedAt
+    ? new Date(resource.addedAt).toLocaleString()
+    : null;
+  const occurrencesLabel = resource.sourceMessages?.length
+    ? `${resource.sourceMessages.length} ${
+        resource.sourceMessages.length === 1 ? 'conversation' : 'conversations'
+      }`
+    : null;
+
+  return (
+    <div className="p-3 rounded-lg border border-gray-200 hover:border-gray-300 transition-colors space-y-2">
+      <div className="flex items-start justify-between gap-3">
+        {resource.url ? (
+          <a
+            href={resource.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium text-blue-600 hover:text-blue-800 block truncate"
+          >
+            {resource.title}
+          </a>
+        ) : (
+          <span className="text-sm font-medium text-gray-900 block truncate">
+            {resource.title}
+          </span>
+        )}
+        {typeof onDeleteResource === 'function' && (
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="p-1 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded"
+            aria-label="Delete resource"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+      <div className="text-xs text-gray-500 flex flex-wrap items-center gap-2">
+        <span>
+          {resource.type || 'Resource'}
+          {resource.location ? ` • ${resource.location}` : ''}
+        </span>
+        {addedAtLabel && <span>• {addedAtLabel}</span>}
+        {occurrencesLabel && (
+          <span className="uppercase tracking-wide bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">
+            {occurrencesLabel}
+          </span>
+        )}
+      </div>
+      {resource.description && (
+        <p className="text-xs text-gray-500 line-clamp-2">{resource.description}</p>
+      )}
+    </div>
+  );
+});
+
+ResourceCard.displayName = 'ResourceCard';
 
 export default NotebookView;


### PR DESCRIPTION
## Summary
- add helpers that prune removed conversations and learning resources from message history while keeping notebook selections consistent
- pass deletion callbacks through the notebook overlay so the view can surface destructive actions with confirmation prompts
- enrich the notebook view with metadata-driven resource cards and delete buttons alongside conversation entries

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cbfe3f1984832a91a0d03a7fed5581