### PR TITLE
Update menu terms link to new privacy URL

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -153,7 +153,7 @@ const Header = memo(({
                 </button>
 
                 <a
-                  href="/privacy-policy.html"
+                  href="https://acceleraqa-main.netlify.app/privacy"
                   onClick={() => setMenuOpen(false)}
                   className="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                   aria-label="View terms and policies"


### PR DESCRIPTION
## Summary
- update the header menu's "Terms & Policies" link to point to the external privacy page at acceleraqa-main.netlify.app

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb4b63fac4832a9cb416cea24fe087