### PR TITLE
Add file name field to document upload form

### DIFF
--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -42,6 +42,7 @@ const RAGConfigurationPage = ({ user, onClose }) => {
   const [debugInfo, setDebugInfo] = useState(null);
   const [authDebug, setAuthDebug] = useState(null);
   const [uploadMetadata, setUploadMetadata] = useState({
+    fileName: '',
     title: '',
     description: '',
     tags: '',
@@ -205,7 +206,8 @@ const RAGConfigurationPage = ({ user, onClose }) => {
       setSelectedFile(file);
       setUploadMetadata(prev => ({
         ...prev,
-        title: file.name.replace(/\.[^/.]+$/, '')
+        fileName: file.name,
+        title: ''
       }));
     }
   };
@@ -230,6 +232,7 @@ const RAGConfigurationPage = ({ user, onClose }) => {
     try {
       const metadata = {
         ...uploadMetadata,
+        fileName: uploadMetadata.fileName || selectedFile.name,
         tags: uploadMetadata.tags
           .split(',')
           .map(tag => tag.trim())
@@ -272,9 +275,10 @@ const RAGConfigurationPage = ({ user, onClose }) => {
         type: 'success',
         message: successMessage
       });
-      
+
       setSelectedFile(null);
       setUploadMetadata({
+        fileName: '',
         title: '',
         description: '',
         tags: '',
@@ -481,6 +485,19 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                   </div>
 
                   <div className="space-y-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-900 mb-1">
+                        File Name
+                      </label>
+                      <input
+                        type="text"
+                        value={uploadMetadata.fileName}
+                        readOnly
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md bg-gray-100 text-gray-900 placeholder-gray-500"
+                        placeholder="Select a file to populate the file name"
+                      />
+                    </div>
+
                     <div>
                       <label className="block text-sm font-medium text-gray-900 mb-1">
                         Title

--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -49,7 +49,7 @@ class RAGService {
       }
     }
 
-    ['title', 'description', 'category', 'version'].forEach(field => {
+    ['fileName', 'title', 'description', 'category', 'version'].forEach(field => {
       if (typeof sanitized[field] === 'string') {
         sanitized[field] = sanitized[field].trim();
         if (!sanitized[field]) {


### PR DESCRIPTION
## Summary
- add a read-only File Name input that captures the selected document name while leaving Title available for a friendly label
- include the captured file name in upload metadata and sanitization logic

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cc55055b10832a9583c2ec452a5788