### PR TITLE
Enable RAG search to include recent uploads

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -484,8 +484,12 @@ function App() {
     const vectorStoreIdToUse = preparedFile ? null : activeDocument?.vectorStoreId || null;
 
     try {
+      const ragSearchOptions = activeDocument?.vectorStoreId
+        ? { vectorStoreIds: [activeDocument.vectorStoreId] }
+        : undefined;
+
       const response = ragEnabled && !preparedFile
-        ? await ragSearch(rawInput, user?.sub)
+        ? await ragSearch(rawInput, user?.sub, ragSearchOptions)
         : await openaiService.getChatResponse(
             rawInput,
             preparedFile,


### PR DESCRIPTION
## Summary
- update the chat send flow to forward the active conversation vector store when invoking RAG search so recent uploads stay searchable
- allow the OpenAI RAG service to merge optional vector store identifiers with the user default and guard against missing stores
- cover the new vector store merge path with a unit test that verifies the search payload contains both default and uploaded stores

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cc74a0fa6c832ab98fbff6ce17f434