### PR TITLE
Retitle training resources surfaces as external resources

### DIFF
--- a/netlify/functions/neon-db.js
+++ b/netlify/functions/neon-db.js
@@ -707,7 +707,7 @@ async function handleAnalyzeConversationsForLearning(sql, userId, data) {
 }
 
 
-// Training resources handlers
+// External resources handlers
 async function ensureTrainingResourcesTable(sql) {
   await sql`
     CREATE TABLE IF NOT EXISTS training_resources (
@@ -748,7 +748,7 @@ export async function handleAddTrainingResource(sql, userId, data) {
       body: JSON.stringify({ resource }),
     };
   } catch (error) {
-    console.error('❌ Error adding training resource:', error);
+    console.error('❌ Error adding external resource:', error);
     if (error.code === '42P01') {
       return {
         statusCode: 500,
@@ -773,7 +773,7 @@ export async function handleAddTrainingResource(sql, userId, data) {
       statusCode: 500,
       headers,
       body: JSON.stringify({
-        error: 'Failed to add training resource',
+        error: 'Failed to add external resource',
         message: error.message,
       }),
     };
@@ -796,7 +796,7 @@ export async function handleGetTrainingResources(sql, userId) {
       body: JSON.stringify({ resources }),
     };
   } catch (error) {
-    console.error('❌ Error loading training resources:', error);
+    console.error('❌ Error loading external resources:', error);
     if (error.code === '42P01') {
       return {
         statusCode: 500,
@@ -821,7 +821,7 @@ export async function handleGetTrainingResources(sql, userId) {
       statusCode: 500,
       headers,
       body: JSON.stringify({
-        error: 'Failed to load training resources',
+        error: 'Failed to load external resources',
         message: error.message,
       }),
     };

--- a/scripts/setup-rag-fauna.js
+++ b/scripts/setup-rag-fauna.js
@@ -240,7 +240,7 @@ For Netlify deployment:
 
 5. Test the functionality:
    - Open your deployed app
-   - Click "My Documents" in the header
+   - Click "My Resources" in the header
    - Upload a test document
    - Try searching and testing RAG responses
 

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -438,10 +438,10 @@ const AdminScreen = ({ user, onBack }) => {
               { id: 'users', label: 'Users & Auth', icon: Users },
               { id: 'backend', label: 'Backend', icon: Database },
               { id: 'rag', label: 'RAG System', icon: FileText },
-              { id: 'ragConfig', label: 'My Documents', icon: Search },
+              { id: 'ragConfig', label: 'My Resources', icon: Search },
               { id: 'system', label: 'System Health', icon: Activity },
               { id: 'usage', label: 'Token Usage', icon: BarChart3 },
-              { id: 'training', label: 'Training Resources', icon: BookOpen },
+              { id: 'training', label: 'External Resources', icon: BookOpen },
               { id: 'tools', label: 'Admin Tools', icon: Settings }
             ].map(tab => {
               const Icon = tab.icon;
@@ -724,7 +724,7 @@ const AdminScreen = ({ user, onBack }) => {
             </div>
           )}
 
-          {/* My Documents Tab */}
+          {/* My Resources Tab */}
           {activeTab === 'ragConfig' && (
             <div className="space-y-6">
               <RAGConfigurationPage user={user} onClose={() => setActiveTab('overview')} />
@@ -824,11 +824,11 @@ const AdminScreen = ({ user, onBack }) => {
             </div>
           )}
 
-          {/* Training Resources Tab */}
+          {/* External Resources Tab */}
           {activeTab === 'training' && (
             <div className="space-y-6">
               <div className="bg-white rounded-lg shadow p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Training Resources</h3>
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">External Resources</h3>
                 <TrainingResourcesAdmin />
               </div>
             </div>

--- a/src/components/AdminScreen.test.js
+++ b/src/components/AdminScreen.test.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import AdminScreen, { checkStorageHealth } from './AdminScreen';
 
-jest.mock('./RAGConfigurationPage', () => () => <h2>My Documents</h2>);
+jest.mock('./RAGConfigurationPage', () => () => <h2>My Resources</h2>);
 
 jest.mock('../services/ragService', () => ({
   __esModule: true,
@@ -68,7 +68,7 @@ describe('AdminScreen navigation', () => {
     });
 
     const ragButton = Array.from(container.querySelectorAll('button')).find(btn =>
-      btn.textContent && btn.textContent.includes('My Documents')
+      btn.textContent && btn.textContent.includes('My Resources')
     );
 
     await act(async () => {
@@ -76,7 +76,7 @@ describe('AdminScreen navigation', () => {
     });
 
     const heading = container.querySelector('h2');
-    expect(heading && heading.textContent).toMatch(/My Documents/i);
+    expect(heading && heading.textContent).toMatch(/My Resources/i);
   });
 
   it('calls onBack when back button is clicked', async () => {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -146,10 +146,10 @@ const Header = memo(({
                     setMenuOpen(false);
                   }}
                   className="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                  aria-label="Manage personal documents"
+                  aria-label="Manage personal resources"
                 >
                   <FileText className="h-4 w-4 mr-2" />
-                  My Documents
+                  My Resources
                 </button>
 
                 <a

--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -1,5 +1,5 @@
 // src/components/RAGConfigurationPage.js - Document management screen for the knowledge base
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Upload,
   FileText,
@@ -11,11 +11,15 @@ import {
   Loader,
   X,
   User,
-  Key
+  Key,
+  BookOpen,
+  RefreshCw,
+  ExternalLink
 } from 'lucide-react';
 import ragService from '../services/ragService';
 import { getToken } from '../services/authService';
 import { hasAdminRole } from '../utils/auth';
+import trainingResourceService from '../services/trainingResourceService';
 
 const describeConversionSource = (conversion) => {
   if (!conversion) {
@@ -50,6 +54,7 @@ const getDocumentTitle = (doc) => {
 const USER_DOCUMENT_LIMIT = 20;
 
 const RAGConfigurationPage = ({ user, onClose }) => {
+  const [activeTab, setActiveTab] = useState('documents');
   const [documents, setDocuments] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [uploadStatus, setUploadStatus] = useState(null);
@@ -65,6 +70,17 @@ const RAGConfigurationPage = ({ user, onClose }) => {
     category: 'general',
     version: ''
   });
+  const [trainingResources, setTrainingResources] = useState([]);
+  const [isLoadingTraining, setIsLoadingTraining] = useState(false);
+  const [trainingError, setTrainingError] = useState(null);
+  const isMountedRef = useRef(false);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const isAdmin = hasAdminRole(user);
   const hasReachedDocumentLimit = !isAdmin && documents.length >= USER_DOCUMENT_LIMIT;
@@ -155,6 +171,47 @@ const RAGConfigurationPage = ({ user, onClose }) => {
       setIsLoading(false);
     }
   }, [user, checkAuthentication]);
+
+  const loadTrainingResources = useCallback(async () => {
+    if (typeof localStorage === 'undefined') {
+      if (isMountedRef.current) {
+        setTrainingResources([]);
+      }
+      return;
+    }
+
+    if (isMountedRef.current) {
+      setIsLoadingTraining(true);
+      setTrainingError(null);
+    }
+
+    try {
+      const resources = await trainingResourceService.getTrainingResources();
+      if (isMountedRef.current) {
+        setTrainingResources(Array.isArray(resources) ? resources : []);
+      }
+    } catch (resourceError) {
+      console.error('Failed to load external resources:', resourceError);
+      if (isMountedRef.current) {
+        setTrainingResources([]);
+        setTrainingError('Failed to load external resources. Please try again.');
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setIsLoadingTraining(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    loadTrainingResources();
+  }, [loadTrainingResources]);
+
+  useEffect(() => {
+    if (activeTab === 'training') {
+      loadTrainingResources();
+    }
+  }, [activeTab, loadTrainingResources]);
 
 
   const testConnection = async () => {
@@ -372,14 +429,14 @@ const RAGConfigurationPage = ({ user, onClose }) => {
           <div className="flex items-center space-x-3">
             <Database className="h-6 w-6 text-blue-600" />
             <div>
-              <h2 className="text-xl font-semibold text-gray-900">My Documents</h2>
+              <h2 className="text-xl font-semibold text-gray-900">My Resources</h2>
               <p className="text-sm text-gray-500">Upload documents to power your workspace knowledge base</p>
             </div>
           </div>
           <button
             onClick={onClose}
             className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
-            aria-label="Close My Documents"
+            aria-label="Close My Resources"
           >
             <X className="h-5 w-5 text-gray-500" />
           </button>
@@ -414,6 +471,42 @@ const RAGConfigurationPage = ({ user, onClose }) => {
 
         {/* Content */}
         <div className="p-6 overflow-y-auto max-h-[calc(90vh-220px)]">
+          <div className="mb-6 border-b border-gray-200">
+            <nav className="flex space-x-4" aria-label="Document and external resource tabs">
+              <button
+                type="button"
+                onClick={() => setActiveTab('documents')}
+                className={`flex items-center space-x-2 py-2 px-1 border-b-2 text-sm font-medium ${
+                  activeTab === 'documents'
+                    ? 'border-blue-600 text-blue-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }`}
+              >
+                <span>My Resources</span>
+                <span className="inline-flex items-center justify-center px-2 py-0.5 text-xs rounded-full bg-blue-50 text-blue-600">
+                  {documents.length}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab('training')}
+                className={`flex items-center space-x-2 py-2 px-1 border-b-2 text-sm font-medium ${
+                  activeTab === 'training'
+                    ? 'border-purple-600 text-purple-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }`}
+              >
+                <span>External Resources</span>
+                {trainingResources.length > 0 && (
+                  <span className="inline-flex items-center justify-center px-2 py-0.5 text-xs rounded-full bg-purple-50 text-purple-600">
+                    {trainingResources.length}
+                  </span>
+                )}
+              </button>
+            </nav>
+          </div>
+          {activeTab === 'documents' && (
+            <>
           {/* Error Display */}
           {error && (
             <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg flex items-start space-x-3">
@@ -741,6 +834,115 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                 )}
               </div>
             </div>
+            </>
+          )}
+
+          {activeTab === 'training' && (
+            <div className="space-y-6">
+              <div className="bg-white border border-gray-200 rounded-lg p-6">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-900 flex items-center space-x-2">
+                      <BookOpen className="h-5 w-5 text-purple-600" />
+                      <span>External Resources</span>
+                    </h3>
+                    <p className="text-sm text-gray-500">
+                      Access curated external references provided by your administrators.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={loadTrainingResources}
+                    disabled={isLoadingTraining}
+                    className="inline-flex items-center px-3 py-2 text-sm font-medium border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <RefreshCw className={`h-4 w-4 mr-2 ${isLoadingTraining ? 'animate-spin' : ''}`} />
+                    Refresh
+                  </button>
+                </div>
+
+                {trainingError && (
+                  <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-sm text-red-700">
+                    {trainingError}
+                  </div>
+                )}
+
+                {isLoadingTraining ? (
+                  <div className="py-12 text-center text-gray-600">
+                    <Loader className="h-6 w-6 animate-spin mx-auto mb-3 text-purple-500" />
+                    <p>Loading external resources...</p>
+                  </div>
+                ) : trainingResources.length === 0 ? (
+                  <div className="py-12 text-center text-gray-600">
+                    <BookOpen className="h-8 w-8 mx-auto mb-3 text-purple-500" />
+                    <h4 className="text-lg font-medium text-gray-900 mb-2">No external resources yet</h4>
+                    <p className="text-sm">
+                      External resources added by your administrators will appear here.
+                    </p>
+                  </div>
+                ) : (
+                  <div className="grid gap-4">
+                    {trainingResources.map((resource, index) => {
+                      const name = typeof resource?.name === 'string' && resource.name.trim()
+                        ? resource.name.trim()
+                        : typeof resource?.title === 'string' && resource.title.trim()
+                          ? resource.title.trim()
+                          : 'Untitled resource';
+                      const description = typeof resource?.description === 'string' ? resource.description.trim() : '';
+                      const url = typeof resource?.url === 'string' ? resource.url.trim() : '';
+                      const tag = typeof resource?.tag === 'string' ? resource.tag.trim() : '';
+                      let hostname = '';
+
+                      if (url) {
+                        try {
+                          hostname = new URL(url).hostname;
+                        } catch (urlError) {
+                          hostname = url;
+                        }
+                      }
+
+                      return (
+                        <div
+                          key={resource?.id || index}
+                          className="p-4 border border-gray-200 rounded-lg hover:border-purple-300 hover:shadow-sm transition-all"
+                        >
+                          <div className="flex items-start justify-between gap-4">
+                            <div>
+                              <h4 className="text-base font-semibold text-gray-900">{name}</h4>
+                              {tag && (
+                                <span className="inline-flex items-center mt-2 px-2 py-0.5 text-xs font-medium rounded-full bg-purple-100 text-purple-700">
+                                  #{tag}
+                                </span>
+                              )}
+                            </div>
+                            {url && (
+                              <a
+                                href={url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center text-sm text-purple-600 hover:text-purple-800"
+                                title={url}
+                              >
+                                <span>{hostname ? `Open ${hostname}` : 'Open resource'}</span>
+                                <ExternalLink className="h-4 w-4 ml-1" />
+                              </a>
+                            )}
+                          </div>
+                          {description && (
+                            <p className="mt-3 text-sm text-gray-600">{description}</p>
+                          )}
+                          {!url && (
+                            <p className="mt-3 text-xs text-gray-500">No direct link provided for this resource.</p>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
         </div>
       </div>
     </div>

--- a/src/components/TrainingResourcesAdmin.js
+++ b/src/components/TrainingResourcesAdmin.js
@@ -17,7 +17,7 @@ const TrainingResourcesAdmin = () => {
       const data = await trainingResourceService.getTrainingResources();
       setResources(data);
     } catch (err) {
-      console.error('Failed to load training resources:', err);
+      console.error('Failed to load external resources:', err);
       setResources([]);
     }
   };
@@ -40,7 +40,7 @@ const TrainingResourcesAdmin = () => {
       setResources(prev => [newResource, ...prev]);
       setForm({ name: '', description: '', url: '', tag: '' });
     } catch (err) {
-      console.error('Failed to add training resource:', err);
+      console.error('Failed to add external resource:', err);
       setError(err.message || 'Failed to add resource');
     } finally {
       setIsLoading(false);
@@ -58,7 +58,7 @@ const TrainingResourcesAdmin = () => {
             value={form.name}
             onChange={handleChange}
             className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-            placeholder="Training title"
+            placeholder="External resource title"
           />
         </div>
         <div>
@@ -80,7 +80,7 @@ const TrainingResourcesAdmin = () => {
             value={form.url}
             onChange={handleChange}
             className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-            placeholder="https://example.com/training"
+            placeholder="https://example.com/resource"
           />
         </div>
         <div>
@@ -110,7 +110,7 @@ const TrainingResourcesAdmin = () => {
       <div>
         <h3 className="text-lg font-medium text-gray-900 mb-2">Existing Resources</h3>
         {resources.length === 0 ? (
-          <p className="text-sm text-gray-500">No training resources found.</p>
+          <p className="text-sm text-gray-500">No external resources found.</p>
         ) : (
           <ul className="space-y-3">
             {resources.map(res => (

--- a/src/services/neonService.js
+++ b/src/services/neonService.js
@@ -388,7 +388,7 @@ class NeonService {
   }
 
   /**
-   * Training resources management
+   * External resources management
    */
   async addTrainingResource(resource) {
     try {
@@ -401,7 +401,7 @@ class NeonService {
       });
       return result.resource;
     } catch (error) {
-      console.error('Failed to add training resource:', error);
+      console.error('Failed to add external resource:', error);
       throw error;
     }
   }
@@ -414,7 +414,7 @@ class NeonService {
       });
       return result.resources || [];
     } catch (error) {
-      console.error('Failed to load training resources:', error);
+      console.error('Failed to load external resources:', error);
       return [];
     }
   }

--- a/src/services/trainingResourceService.js
+++ b/src/services/trainingResourceService.js
@@ -6,7 +6,7 @@ class TrainingResourceService {
   }
 
   /**
-   * Load training resources from localStorage
+   * Load external resources from localStorage
    * @returns {Promise<Array>} array of resources
    */
   async getTrainingResources() {
@@ -14,13 +14,13 @@ class TrainingResourceService {
       const raw = localStorage.getItem(this.storageKey);
       return raw ? JSON.parse(raw) : [];
     } catch (error) {
-      console.error('Failed to load training resources from storage:', error);
+      console.error('Failed to load external resources from storage:', error);
       return [];
     }
   }
 
   /**
-   * Synchronously load training resources from localStorage
+   * Synchronously load external resources from localStorage
    * @returns {Array} array of resources
    */
   getTrainingResourcesSync() {
@@ -28,13 +28,13 @@ class TrainingResourceService {
       const raw = localStorage.getItem(this.storageKey);
       return raw ? JSON.parse(raw) : [];
     } catch (error) {
-      console.error('Failed to load training resources from storage:', error);
+      console.error('Failed to load external resources from storage:', error);
       return [];
     }
   }
 
   /**
-   * Add a training resource to localStorage
+   * Add an external resource to localStorage
    * @param {Object} resource resource data
    * @returns {Promise<Object>} newly stored resource with id
    */
@@ -46,7 +46,7 @@ class TrainingResourceService {
       localStorage.setItem(this.storageKey, JSON.stringify(resources));
       return newResource;
     } catch (error) {
-      console.error('Failed to save training resource:', error);
+      console.error('Failed to save external resource:', error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- rename the admin dashboard navigation entry and panel headings from "Training Resources" to "External Resources"
- update the My Resources overlay to present the secondary tab, loading states, and error messaging as "External Resources"
- refresh the training resources admin form, storage helpers, and Neon API logging to reference external resources throughout

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cde9c2ab4c832abf309a890f715baf