### PR TITLE
Use Neon metadata titles for search results

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -172,6 +172,8 @@ const getSourceTitleCandidates = (source) => {
   pushNonFile(source.source_title);
   pushNonFile(source.label);
   pushNonFile(source.name);
+  pushNonFile(source.fileTitle);
+  pushNonFile(source.file_title);
 
   pushNonFile(metadata.documentTitle);
   pushNonFile(metadata.document_title);
@@ -184,10 +186,14 @@ const getSourceTitleCandidates = (source) => {
   pushNonFile(metadata.preferredTitle);
   pushNonFile(metadata.documentName);
   pushNonFile(metadata.document_name);
+  pushNonFile(metadata.fileTitle);
+  pushNonFile(metadata.file_title);
 
   pushNonFile(document.title);
   pushNonFile(document.documentTitle);
   pushNonFile(document.document_title);
+  pushNonFile(document.fileTitle);
+  pushNonFile(document.file_title);
 
   pushNonFile(documentMetadata.title);
   pushNonFile(documentMetadata.documentTitle);
@@ -197,6 +203,8 @@ const getSourceTitleCandidates = (source) => {
   pushNonFile(documentMetadata.displayName);
   pushNonFile(documentMetadata.display_name);
   pushNonFile(documentMetadata.name);
+  pushNonFile(documentMetadata.fileTitle);
+  pushNonFile(documentMetadata.file_title);
 
   pushNonFile(metadataDocumentMetadata.title);
   pushNonFile(metadataDocumentMetadata.documentTitle);
@@ -206,10 +214,14 @@ const getSourceTitleCandidates = (source) => {
   pushNonFile(metadataDocumentMetadata.displayName);
   pushNonFile(metadataDocumentMetadata.display_name);
   pushNonFile(metadataDocumentMetadata.name);
+  pushNonFile(metadataDocumentMetadata.fileTitle);
+  pushNonFile(metadataDocumentMetadata.file_title);
 
   pushNonFile(fileCitation.title);
   pushNonFile(fileCitation.documentTitle);
   pushNonFile(fileCitation.document_title);
+  pushNonFile(fileCitation.fileTitle);
+  pushNonFile(fileCitation.file_title);
 
   pushFile(metadata.filename);
   pushFile(metadata.fileName);


### PR DESCRIPTION
## Summary
- parse Neon document metadata when returning search results so we can expose stored file titles
- resolve human-readable titles from metadata and include them in each source payload instead of always falling back to filenames

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cfef9a69a0832abb6105393f113bc4