### PR TITLE
Allow multilingual snippets in source snippet selection

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -4,6 +4,16 @@ import React, { useCallback } from 'react';
 import { Send, Loader2, Database, Paperclip, X, ExternalLink, BookOpen, FileDown } from 'lucide-react';
 import { exportToWord } from '../utils/exportUtils';
 
+const createUnicodeLetterRegex = () => {
+  try {
+    return new RegExp('\\p{L}', 'u');
+  } catch (error) {
+    return /[a-z]/i;
+  }
+};
+
+const UNICODE_LETTER_REGEX = createUnicodeLetterRegex();
+
 const isPdfAttachment = (file) => {
   if (!file) return false;
   const name = typeof file.name === 'string' ? file.name.toLowerCase() : '';
@@ -136,7 +146,7 @@ const isLikelyOpaqueIdentifier = (value) => {
     return false;
   }
 
-  if (!/[a-z]/i.test(trimmed)) {
+  if (!UNICODE_LETTER_REGEX.test(trimmed)) {
     return true;
   }
 
@@ -583,10 +593,6 @@ function getSourceSnippet(source, options = {}) {
     }
 
     if (isLikelyFilename(normalized)) {
-      return;
-    }
-
-    if (!/[a-z]/i.test(normalized)) {
       return;
     }
 
@@ -1043,4 +1049,5 @@ const ChatArea = ({
   );
 };
 
+export { getSourceSnippet, isDisallowedSnippet };
 export default ChatArea;

--- a/src/components/ChatArea.test.js
+++ b/src/components/ChatArea.test.js
@@ -1,0 +1,28 @@
+import { getSourceSnippet, isDisallowedSnippet } from './ChatArea';
+
+describe('getSourceSnippet', () => {
+  it('preserves non-Latin snippets instead of dropping them', () => {
+    const multilingualSnippet = '这是一个测试片段，用于验证多语言支持。';
+    const source = {
+      snippet: multilingualSnippet,
+      metadata: {
+        language: 'zh-CN',
+      },
+    };
+
+    const result = getSourceSnippet(source);
+
+    expect(result).toBe(multilingualSnippet);
+  });
+});
+
+describe('isDisallowedSnippet', () => {
+  it('allows multilingual text that includes non-Latin characters', () => {
+    const multilingualSnippet = '这是一个测试片段，用于验证多语言支持。';
+    expect(isDisallowedSnippet(multilingualSnippet)).toBe(false);
+  });
+
+  it('still filters typical opaque identifiers', () => {
+    expect(isDisallowedSnippet('file-1A2B3C4D5E')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- update source snippet selection to use a Unicode-aware letter check instead of rejecting non-Latin text
- rely on the opaque identifier guardrails while exporting helpers for targeted testing
- add tests that keep multilingual snippets and continue filtering opaque identifiers

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d009e9b1a0832abf3a9882d116f192