### PR TITLE
Fix resource center updates for continued chats

### DIFF
--- a/src/components/Sidebar.test.js
+++ b/src/components/Sidebar.test.js
@@ -1,0 +1,117 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import Sidebar from './Sidebar';
+
+jest.mock('../config/featureFlags', () => ({
+  FEATURE_FLAGS: { ENABLE_AI_SUGGESTIONS: false },
+  default: { ENABLE_AI_SUGGESTIONS: false },
+}));
+
+jest.mock('../services/learningSuggestionsService', () => ({
+  getLearningSuggestions: jest.fn().mockResolvedValue([]),
+  refreshSuggestions: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../services/ragService', () => ({
+  downloadDocument: jest.fn(),
+}));
+
+describe('Sidebar resource extraction', () => {
+  let container;
+  const baseProps = {
+    thirtyDayMessages: [],
+    user: null,
+    learningSuggestions: [],
+    isLoadingSuggestions: false,
+    onSuggestionsUpdate: () => {},
+    onAddResource: () => {},
+    onConversationSelect: () => {},
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (container) {
+      ReactDOM.unmountComponentAtNode(container);
+      document.body.removeChild(container);
+      container = null;
+    }
+  });
+
+  it('places the newest resources at the top when continuing a chat', async () => {
+    const initialMessages = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        resources: [
+          { id: 'old-resource', title: 'Legacy Guidance', type: 'Guideline' },
+        ],
+        timestamp: 1000,
+      },
+    ];
+
+    await act(async () => {
+      ReactDOM.render(
+        <Sidebar {...baseProps} messages={initialMessages} />,
+        container
+      );
+    });
+
+    const initialHeadings = Array.from(container.querySelectorAll('h4'));
+    expect(initialHeadings[0].textContent).toContain('Legacy Guidance');
+
+    const updatedMessages = [
+      ...initialMessages,
+      {
+        id: 'msg-2',
+        role: 'assistant',
+        resources: [
+          { id: 'new-resource', title: 'Latest CAPA Update', type: 'Training' },
+        ],
+        timestamp: 2000,
+      },
+    ];
+
+    await act(async () => {
+      ReactDOM.render(
+        <Sidebar {...baseProps} messages={updatedMessages} />,
+        container
+      );
+    });
+
+    const updatedHeadings = Array.from(container.querySelectorAll('h4'));
+    expect(updatedHeadings[0].textContent).toContain('Latest CAPA Update');
+    expect(updatedHeadings[1].textContent).toContain('Legacy Guidance');
+  });
+
+  it('derives a display title for resources that are missing one', async () => {
+    const messages = [
+      {
+        id: 'msg-3',
+        role: 'assistant',
+        resources: [
+          {
+            id: 'resource-without-title',
+            type: 'Guideline',
+            metadata: { documentTitle: 'Process Validation Playbook' },
+          },
+        ],
+        timestamp: 3000,
+      },
+    ];
+
+    await act(async () => {
+      ReactDOM.render(
+        <Sidebar {...baseProps} messages={messages} />,
+        container
+      );
+    });
+
+    const headings = Array.from(container.querySelectorAll('h4'));
+    expect(headings[0].textContent).toContain('Process Validation Playbook');
+  });
+});


### PR DESCRIPTION
## Summary
- normalize resources extracted from chat messages so that missing titles are derived and duplicates keep the most recent details
- sort extracted resources by recency so the newest items surface first in the resource center
- add sidebar tests that verify ordering and fallback titles without hitting external services

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d016e0cc00832abe348348e9a59e7e