### PR TITLE
Enhance sidebar resource relevance scoring

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -174,12 +174,115 @@ const buildResourceKey = (resource, messageIndex, resourceIndex) => {
   return `resource-${messageIndex}-${resourceIndex}`;
 };
 
+const normalizeRole = (value) =>
+  typeof value === 'string' ? value.trim().toLowerCase() : '';
+
+const isUserMessage = (message) => {
+  const role = normalizeRole(message?.role);
+  const type = normalizeRole(message?.type);
+
+  return role === 'user' || type === 'user';
+};
+
+const isAssistantMessage = (message) => {
+  const role = normalizeRole(message?.role);
+  const type = normalizeRole(message?.type);
+
+  return role === 'assistant' || role === 'ai' || type === 'assistant' || type === 'ai';
+};
+
+const collectStrings = (value, results = []) => {
+  if (value == null) {
+    return results;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed) {
+      results.push(trimmed);
+    }
+    return results;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    results.push(String(value));
+    return results;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectStrings(item, results));
+    return results;
+  }
+
+  if (typeof value === 'object') {
+    Object.values(value).forEach((item) => collectStrings(item, results));
+  }
+
+  return results;
+};
+
+const getMessageText = (message) => {
+  const fragments = [];
+
+  collectStrings(message?.content, fragments);
+  collectStrings(message?.text, fragments);
+  collectStrings(message?.message, fragments);
+
+  if (Array.isArray(message?.parts)) {
+    message.parts.forEach((part) => {
+      if (typeof part === 'string' || typeof part === 'number' || typeof part === 'boolean') {
+        collectStrings(part, fragments);
+      } else if (part && typeof part === 'object') {
+        collectStrings(part.text, fragments);
+        collectStrings(part.content, fragments);
+      }
+    });
+  }
+
+  return fragments.join(' ');
+};
+
+const tokenize = (value) => {
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+};
+
+const getResourceTokens = (resource) => {
+  const fragments = [];
+
+  collectStrings(resource?.title, fragments);
+  collectStrings(resource?.description, fragments);
+  collectStrings(resource?.type, fragments);
+  collectStrings(resource?.tags, fragments);
+  collectStrings(resource?.metadata, fragments);
+
+  return tokenize(fragments.join(' '));
+};
+
+const QUESTION_ATTACHMENT_BONUS = 100;
+const ASSISTANT_FOLLOWUP_BONUS = 50;
+
 const extractResourcesFromMessages = (messages) => {
   if (!Array.isArray(messages) || messages.length === 0) {
     return [];
   }
 
   const resourcesMap = new Map();
+  const questionIndex = [...messages]
+    .map((message, index) => ({ message, index }))
+    .reverse()
+    .find(({ message }) => isUserMessage(message))?.index ?? -1;
+
+  const questionTokens = questionIndex >= 0
+    ? new Set(tokenize(getMessageText(messages[questionIndex])))
+    : new Set();
 
   messages.forEach((message, messageIndex) => {
     const messageResources = Array.isArray(message?.resources)
@@ -187,6 +290,11 @@ const extractResourcesFromMessages = (messages) => {
       : [];
 
     const timestampValue = getTimestampValue(message?.timestamp, messageIndex);
+    const isQuestionMessage = messageIndex === questionIndex;
+    const isFollowupAssistantMessage =
+      questionIndex >= 0 &&
+      messageIndex > questionIndex &&
+      isAssistantMessage(message);
 
     messageResources.forEach((resource, resourceIndex) => {
       const normalizedResource = ensureResourceTitle(resource);
@@ -196,12 +304,31 @@ const extractResourcesFromMessages = (messages) => {
 
       const key = buildResourceKey(normalizedResource, messageIndex, resourceIndex);
 
+      const resourceTokens = getResourceTokens(normalizedResource);
+      let overlapScore = 0;
+      if (questionTokens.size > 0 && resourceTokens.length > 0) {
+        const resourceTokenSet = new Set(resourceTokens);
+        questionTokens.forEach((token) => {
+          if (resourceTokenSet.has(token)) {
+            overlapScore += 1;
+          }
+        });
+      }
+
+      let score = overlapScore;
+      if (isQuestionMessage) {
+        score += QUESTION_ATTACHMENT_BONUS;
+      } else if (isFollowupAssistantMessage) {
+        score += ASSISTANT_FOLLOWUP_BONUS;
+      }
+
       const existing = resourcesMap.get(key);
       const entry = {
         resource: normalizedResource,
         order: timestampValue,
         messageIndex,
         resourceIndex,
+        score,
       };
 
       if (!existing) {
@@ -210,11 +337,13 @@ const extractResourcesFromMessages = (messages) => {
       }
 
       if (
-        entry.order > existing.order ||
-        (entry.order === existing.order && entry.messageIndex > existing.messageIndex) ||
-        (entry.order === existing.order &&
-          entry.messageIndex === existing.messageIndex &&
-          entry.resourceIndex >= existing.resourceIndex)
+        entry.score > existing.score ||
+        (entry.score === existing.score &&
+          (entry.order > existing.order ||
+            (entry.order === existing.order && entry.messageIndex > existing.messageIndex) ||
+            (entry.order === existing.order &&
+              entry.messageIndex === existing.messageIndex &&
+              entry.resourceIndex >= existing.resourceIndex)))
       ) {
         resourcesMap.set(key, entry);
       }
@@ -223,6 +352,9 @@ const extractResourcesFromMessages = (messages) => {
 
   return Array.from(resourcesMap.values())
     .sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
       if (b.order !== a.order) {
         return b.order - a.order;
       }

--- a/src/components/Sidebar.test.js
+++ b/src/components/Sidebar.test.js
@@ -88,6 +88,83 @@ describe('Sidebar resource extraction', () => {
     expect(updatedHeadings[1].textContent).toContain('Legacy Guidance');
   });
 
+  it('prioritizes question-related resources based on relevance scoring', async () => {
+    const messages = [
+      {
+        id: 'msg-legacy',
+        role: 'assistant',
+        content: 'Historical reference shared earlier.',
+        resources: [
+          {
+            id: 'resource-legacy',
+            title: 'Legacy Process Overview',
+            type: 'Guideline',
+            description: 'Archived manufacturing process guidance.',
+          },
+        ],
+        timestamp: 500,
+      },
+      {
+        id: 'msg-question',
+        role: 'user',
+        content: 'Can you share the CAPA procedure steps for recent audits?',
+        resources: [
+          {
+            id: 'resource-upload',
+            title: 'CAPA Procedure Attachment',
+            type: 'User Upload',
+            description: 'CAPA procedure steps shared by the user.',
+          },
+        ],
+        timestamp: 1000,
+      },
+      {
+        id: 'msg-answer',
+        role: 'assistant',
+        content: 'Here is the procedure you requested.',
+        resources: [
+          {
+            id: 'resource-capa',
+            title: 'CAPA Process Guide',
+            type: 'Guide',
+            description: 'Comprehensive CAPA procedure steps for audits.',
+          },
+        ],
+        timestamp: 1500,
+      },
+      {
+        id: 'msg-unrelated',
+        role: 'assistant',
+        content: 'Unrelated update about finances.',
+        resources: [
+          {
+            id: 'resource-finance',
+            title: 'Annual Financial Report',
+            type: 'Report',
+            description: 'Latest financial performance overview.',
+          },
+        ],
+        timestamp: 2000,
+      },
+    ];
+
+    await act(async () => {
+      ReactDOM.render(
+        <Sidebar {...baseProps} messages={messages} />,
+        container
+      );
+    });
+
+    const headings = Array.from(container.querySelectorAll('h4')).map((heading) =>
+      heading.textContent.trim()
+    );
+
+    expect(headings[0]).toContain('CAPA Procedure Attachment');
+    expect(headings[1]).toContain('CAPA Process Guide');
+    expect(headings[2]).toContain('Annual Financial Report');
+    expect(headings[3]).toContain('Legacy Process Overview');
+  });
+
   it('derives a display title for resources that are missing one', async () => {
     const messages = [
       {


### PR DESCRIPTION
## Summary
- compute relevance scores for sidebar resources that prioritize the latest user question attachments, follow-up assistant answers, and textual overlap
- fall back to chronological ordering when relevance scores match to maintain stable ordering
- extend sidebar tests with a scenario that verifies relevance-based ordering while retaining existing behaviors

## Testing
- npm test -- Sidebar

------
https://chatgpt.com/codex/tasks/task_e_68d022922580832a877b4a7471d7aed3