### PR TITLE
Prioritize resource center entries by question relevance

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -73,30 +73,409 @@ const Sidebar = ({
  * @param {Array} messages - Array of messages
  * @returns {Array} - Array of unique resources
  */
-const extractResourcesFromMessages = (messages) => {
-  if (!messages || !Array.isArray(messages)) {
+const getTimestampValue = (timestamp, fallback) => {
+  if (typeof timestamp === 'number' && Number.isFinite(timestamp)) {
+    return timestamp;
+  }
+
+  if (typeof timestamp === 'string') {
+    const parsed = Date.parse(timestamp);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+
+  return fallback;
+};
+
+const MIN_TOKEN_LENGTH = 3;
+
+const RELEVANCE_WEIGHTS = {
+  QUESTION_ATTACHMENT: 1000,
+  ANSWER_RESOURCE: 500,
+  TOKEN_MATCH: 5,
+};
+
+const isUserMessage = (message) => {
+  if (!message || typeof message !== 'object') {
+    return false;
+  }
+
+  const candidate = typeof message.role === 'string' ? message.role : message.type;
+  if (typeof candidate !== 'string') {
+    return false;
+  }
+
+  const normalized = candidate.toLowerCase();
+  return normalized === 'user' || normalized === 'human';
+};
+
+const isAssistantMessage = (message) => {
+  if (!message || typeof message !== 'object') {
+    return false;
+  }
+
+  const candidate = typeof message.role === 'string' ? message.role : message.type;
+  if (typeof candidate !== 'string') {
+    return false;
+  }
+
+  const normalized = candidate.toLowerCase();
+  return normalized === 'assistant' || normalized === 'ai' || normalized === 'bot';
+};
+
+const collectStrings = (value, collector, depth = 0) => {
+  if (depth > 3 || value == null) {
+    return;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed) {
+      collector.push(trimmed);
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectStrings(item, collector, depth + 1));
+    return;
+  }
+
+  if (typeof value === 'object') {
+    Object.values(value).forEach((item) => collectStrings(item, collector, depth + 1));
+  }
+};
+
+const tokenizeForRelevance = (text) => {
+  if (!text) {
     return [];
   }
 
-  const resourcesMap = new Map();
+  return String(text)
+    .toLowerCase()
+    .match(/[a-z0-9]+/g)
+    ?.filter((token) => token.length >= MIN_TOKEN_LENGTH) || [];
+};
 
-  messages.forEach(message => {
-    if (message.resources && Array.isArray(message.resources)) {
-      message.resources.forEach(resource => {
-        if (!resource || !resource.title) {
-          return;
+const buildTokenSet = (text) => {
+  const tokens = new Set();
+  tokenizeForRelevance(text).forEach((token) => tokens.add(token));
+  return tokens;
+};
+
+const extractMessageText = (message) => {
+  if (!message || typeof message !== 'object') {
+    return '';
+  }
+
+  const parts = [];
+  const { content } = message;
+
+  if (typeof content === 'string') {
+    parts.push(content);
+  } else if (Array.isArray(content)) {
+    content.forEach((item) => {
+      if (typeof item === 'string') {
+        parts.push(item);
+      } else if (item && typeof item === 'object') {
+        if (typeof item.text === 'string') {
+          parts.push(item.text);
+        } else if (typeof item.content === 'string') {
+          parts.push(item.content);
+        } else if (typeof item.value === 'string') {
+          parts.push(item.value);
         }
-
-        const key = resource.url || resource.id || `${resource.title}-${resource.type || ''}`;
-
-        if (!resourcesMap.has(key)) {
-          resourcesMap.set(key, resource);
+      }
+    });
+  } else if (content && typeof content === 'object') {
+    if (typeof content.text === 'string') {
+      parts.push(content.text);
+    }
+    if (typeof content.content === 'string') {
+      parts.push(content.content);
+    }
+    if (Array.isArray(content.parts)) {
+      content.parts.forEach((part) => {
+        if (typeof part === 'string') {
+          parts.push(part);
+        } else if (part && typeof part === 'object' && typeof part.text === 'string') {
+          parts.push(part.text);
         }
       });
     }
+  }
+
+  ['text', 'prompt', 'message', 'question'].forEach((field) => {
+    if (typeof message[field] === 'string') {
+      parts.push(message[field]);
+    }
   });
 
-  return Array.from(resourcesMap.values());
+  return parts.join(' ').trim();
+};
+
+const getResourceSearchableTokens = (resource) => {
+  if (!resource || typeof resource !== 'object') {
+    return new Set();
+  }
+
+  const parts = [];
+  collectStrings(resource.title, parts);
+  collectStrings(resource.description, parts);
+  collectStrings(resource.tag, parts);
+  collectStrings(resource.metadata, parts);
+
+  const tokens = new Set();
+  parts.forEach((part) => {
+    tokenizeForRelevance(part).forEach((token) => tokens.add(token));
+  });
+
+  return tokens;
+};
+
+const mergeContexts = (existingContexts, newContexts) => {
+  const merged = new Set();
+
+  if (existingContexts && typeof existingContexts[Symbol.iterator] === 'function') {
+    for (const value of existingContexts) {
+      merged.add(value);
+    }
+  }
+
+  if (newContexts && typeof newContexts[Symbol.iterator] === 'function') {
+    for (const value of newContexts) {
+      merged.add(value);
+    }
+  }
+
+  return merged;
+};
+
+const contextsHas = (contexts, value) => {
+  if (!contexts) {
+    return false;
+  }
+
+  if (contexts instanceof Set) {
+    return contexts.has(value);
+  }
+
+  if (Array.isArray(contexts)) {
+    return contexts.includes(value);
+  }
+
+  return false;
+};
+
+const ensureResourceTitle = (resource) => {
+  if (!resource || typeof resource !== 'object') {
+    return null;
+  }
+
+  const metadata =
+    resource.metadata && typeof resource.metadata === 'object'
+      ? resource.metadata
+      : {};
+
+  const titleCandidates = [
+    resource.title,
+    metadata.documentTitle,
+    metadata.document_title,
+    metadata.filename,
+    metadata.documentName,
+    metadata.document_name,
+    metadata.title,
+    resource.url,
+    resource.id,
+  ];
+
+  const resolvedTitle = titleCandidates.find(
+    (value) => typeof value === 'string' && value.trim()
+  );
+
+  if (!resolvedTitle) {
+    return null;
+  }
+
+  if (resource.title && resource.title.trim()) {
+    return {
+      ...resource,
+      title: resource.title.trim(),
+      metadata,
+    };
+  }
+
+  const normalizedTitle = resolvedTitle.trim();
+  const normalizedMetadata = { ...metadata };
+
+  if (!normalizedMetadata.documentTitle) {
+    normalizedMetadata.documentTitle = normalizedTitle;
+  }
+
+  return {
+    ...resource,
+    title: normalizedTitle,
+    metadata: normalizedMetadata,
+  };
+};
+
+const buildResourceKey = (resource, messageIndex, resourceIndex) => {
+  if (!resource) {
+    return `resource-${messageIndex}-${resourceIndex}`;
+  }
+
+  const metadata =
+    resource.metadata && typeof resource.metadata === 'object'
+      ? resource.metadata
+      : {};
+
+  const keyCandidates = [
+    resource.id,
+    metadata.documentId,
+    metadata.document_id,
+    metadata.fileId,
+    metadata.file_id,
+    metadata.documentTitle,
+    metadata.document_title,
+    resource.url,
+    resource.title ? `${resource.title}-${resource.type || ''}` : null,
+  ];
+
+  for (const candidate of keyCandidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+
+  return `resource-${messageIndex}-${resourceIndex}`;
+};
+
+const extractResourcesFromMessages = (messages) => {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return [];
+  }
+
+  let latestQuestionIndex = -1;
+  let latestQuestionMessage = null;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (isUserMessage(messages[index])) {
+      latestQuestionIndex = index;
+      latestQuestionMessage = messages[index];
+      break;
+    }
+  }
+
+  const questionText = extractMessageText(latestQuestionMessage);
+  const questionTokens = buildTokenSet(questionText);
+
+  const resourcesMap = new Map();
+
+  messages.forEach((message, messageIndex) => {
+    const messageResources = Array.isArray(message?.resources)
+      ? message.resources
+      : [];
+
+    const timestampValue = getTimestampValue(message?.timestamp, messageIndex);
+
+    messageResources.forEach((resource, resourceIndex) => {
+      const normalizedResource = ensureResourceTitle(resource);
+      if (!normalizedResource) {
+        return;
+      }
+
+      const key = buildResourceKey(normalizedResource, messageIndex, resourceIndex);
+
+      const existing = resourcesMap.get(key);
+      const contexts = new Set();
+
+      if (latestQuestionIndex !== -1 && messageIndex === latestQuestionIndex) {
+        contexts.add('question');
+      } else if (
+        latestQuestionIndex !== -1 &&
+        messageIndex > latestQuestionIndex &&
+        isAssistantMessage(message)
+      ) {
+        contexts.add('answer');
+      } else {
+        contexts.add('other');
+      }
+
+      const mergedContexts = mergeContexts(existing?.contexts, contexts);
+
+      const entry = {
+        resource: normalizedResource,
+        order: timestampValue,
+        messageIndex,
+        resourceIndex,
+        contexts: mergedContexts,
+      };
+
+      if (!existing) {
+        resourcesMap.set(key, entry);
+        return;
+      }
+
+      const shouldReplace =
+        entry.order > existing.order ||
+        (entry.order === existing.order && entry.messageIndex > existing.messageIndex) ||
+        (entry.order === existing.order &&
+          entry.messageIndex === existing.messageIndex &&
+          entry.resourceIndex >= existing.resourceIndex);
+
+      if (shouldReplace) {
+        resourcesMap.set(key, entry);
+      } else if (existing) {
+        existing.contexts = mergedContexts;
+      }
+    });
+  });
+
+  const scoredEntries = Array.from(resourcesMap.values()).map((entry) => {
+    let score = 0;
+    const { contexts } = entry;
+
+    if (contextsHas(contexts, 'question')) {
+      score += RELEVANCE_WEIGHTS.QUESTION_ATTACHMENT;
+    }
+
+    if (contextsHas(contexts, 'answer')) {
+      score += RELEVANCE_WEIGHTS.ANSWER_RESOURCE;
+    }
+
+    if (questionTokens.size > 0) {
+      const resourceTokens = getResourceSearchableTokens(entry.resource);
+      resourceTokens.forEach((token) => {
+        if (questionTokens.has(token)) {
+          score += RELEVANCE_WEIGHTS.TOKEN_MATCH;
+        }
+      });
+    }
+
+    return {
+      ...entry,
+      score,
+    };
+  });
+
+  return scoredEntries
+    .sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      if (b.order !== a.order) {
+        return b.order - a.order;
+      }
+      if (b.messageIndex !== a.messageIndex) {
+        return b.messageIndex - a.messageIndex;
+      }
+      return b.resourceIndex - a.resourceIndex;
+    })
+    .map((entry) => entry.resource);
 };
 
 export default Sidebar;

--- a/src/components/Sidebar.test.js
+++ b/src/components/Sidebar.test.js
@@ -1,0 +1,180 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import Sidebar from './Sidebar';
+
+jest.mock('../config/featureFlags', () => ({
+  FEATURE_FLAGS: { ENABLE_AI_SUGGESTIONS: false },
+  default: { ENABLE_AI_SUGGESTIONS: false },
+}));
+
+jest.mock('../services/learningSuggestionsService', () => ({
+  getLearningSuggestions: jest.fn().mockResolvedValue([]),
+  refreshSuggestions: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../services/ragService', () => ({
+  downloadDocument: jest.fn(),
+}));
+
+describe('Sidebar resource extraction', () => {
+  let container;
+  const baseProps = {
+    thirtyDayMessages: [],
+    user: null,
+    learningSuggestions: [],
+    isLoadingSuggestions: false,
+    onSuggestionsUpdate: () => {},
+    onAddResource: () => {},
+    onConversationSelect: () => {},
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (container) {
+      ReactDOM.unmountComponentAtNode(container);
+      document.body.removeChild(container);
+      container = null;
+    }
+  });
+
+  it('prioritizes resources relevant to the latest user question', async () => {
+    const messages = [
+      {
+        id: 'intro-assistant',
+        role: 'assistant',
+        resources: [
+          {
+            id: 'quality-manual',
+            title: 'General Quality Manual',
+            type: 'Guideline',
+            description: 'High level company quality overview.',
+          },
+          {
+            id: 'capa-checklist',
+            title: 'CAPA Readiness Checklist',
+            type: 'Guideline',
+            description: 'Checklist used before closing CAPA evidence.',
+          },
+        ],
+        timestamp: 1000,
+      },
+      {
+        id: 'user-question',
+        role: 'user',
+        content: 'How do we handle CAPA evidence retention requirements?',
+        resources: [
+          {
+            id: 'question-upload',
+            title: 'CAPA Evidence Template',
+            type: 'User Upload',
+          },
+        ],
+        timestamp: 2000,
+      },
+      {
+        id: 'assistant-answer',
+        role: 'assistant',
+        resources: [
+          {
+            id: 'answer-resource',
+            title: 'CAPA Evidence SOP',
+            description: 'Step-by-step CAPA evidence retention process.',
+            type: 'Knowledge Base',
+          },
+        ],
+        timestamp: 3000,
+      },
+      {
+        id: 'assistant-newer',
+        role: 'assistant',
+        resources: [
+          {
+            id: 'new-unrelated',
+            title: 'General Onboarding Guide',
+            description: 'Orientation material for new hires.',
+            type: 'Training',
+          },
+        ],
+        timestamp: 4000,
+      },
+    ];
+
+    await act(async () => {
+      ReactDOM.render(
+        <Sidebar {...baseProps} messages={messages} />,
+        container
+      );
+    });
+
+    const headings = Array.from(container.querySelectorAll('h4'));
+    expect(headings[0].textContent).toContain('CAPA Evidence Template');
+    expect(headings[1].textContent).toContain('CAPA Evidence SOP');
+    expect(headings[2].textContent).toContain('General Onboarding Guide');
+    expect(headings[3].textContent).toContain('CAPA Readiness Checklist');
+    expect(headings[4].textContent).toContain('General Quality Manual');
+  });
+
+  it('falls back to recency when no user question is present', async () => {
+    const messages = [
+      {
+        id: 'assistant-first',
+        role: 'assistant',
+        resources: [
+          { id: 'older-resource', title: 'Legacy Guidance', type: 'Guideline' },
+        ],
+        timestamp: 1000,
+      },
+      {
+        id: 'assistant-second',
+        role: 'assistant',
+        resources: [
+          { id: 'newer-resource', title: 'Latest CAPA Update', type: 'Training' },
+        ],
+        timestamp: 2000,
+      },
+    ];
+
+    await act(async () => {
+      ReactDOM.render(
+        <Sidebar {...baseProps} messages={messages} />,
+        container
+      );
+    });
+
+    const headings = Array.from(container.querySelectorAll('h4'));
+    expect(headings[0].textContent).toContain('Latest CAPA Update');
+    expect(headings[1].textContent).toContain('Legacy Guidance');
+  });
+
+  it('derives a display title for resources that are missing one', async () => {
+    const messages = [
+      {
+        id: 'msg-3',
+        role: 'assistant',
+        resources: [
+          {
+            id: 'resource-without-title',
+            type: 'Guideline',
+            metadata: { documentTitle: 'Process Validation Playbook' },
+          },
+        ],
+        timestamp: 3000,
+      },
+    ];
+
+    await act(async () => {
+      ReactDOM.render(
+        <Sidebar {...baseProps} messages={messages} />,
+        container
+      );
+    });
+
+    const headings = Array.from(container.querySelectorAll('h4'));
+    expect(headings[0].textContent).toContain('Process Validation Playbook');
+  });
+});

--- a/src/utils/internalResourceUtils.js
+++ b/src/utils/internalResourceUtils.js
@@ -3,8 +3,102 @@ import { UI_CONFIG } from '../config/constants';
 const DEFAULT_LIMIT = UI_CONFIG?.MAX_RESOURCES_PER_RESPONSE || 5;
 const MIN_TOKEN_LENGTH = 3;
 
+const STOP_WORDS = new Set([
+  'the',
+  'and',
+  'for',
+  'from',
+  'with',
+  'that',
+  'this',
+  'your',
+  'into',
+  'onto',
+  'about',
+  'have',
+  'has',
+  'had',
+  'been',
+  'were',
+  'was',
+  'will',
+  'shall',
+  'should',
+  'could',
+  'would',
+  'their',
+  'there',
+  'which',
+  'while',
+  'when',
+  'what',
+  'than',
+  'then',
+  'them',
+  'they',
+  'also',
+  'such',
+  'only',
+  'very',
+  'just',
+  'even',
+  'over',
+  'under',
+  'through',
+  'across',
+  'after',
+  'before',
+  'because',
+  'during',
+  'among',
+  'between',
+  'within',
+  'without',
+  'using',
+  'based',
+  'some',
+  'many',
+  'most',
+  'more',
+  'less',
+  'much',
+  'other',
+  'others',
+  'another',
+  'every',
+  'again',
+  'still',
+  'since',
+  'until',
+  'upon',
+  'here',
+  'else',
+  'each',
+  'per',
+  'via',
+]);
+
 const FILENAME_EXTENSION_PATTERN =
   /\.(pdf|docx|doc|txt|md|rtf|xlsx|xls|csv|pptx|ppt|zip|json|xml|yaml|yml|html|htm|log)$/i;
+
+const KNOWLEDGE_DESCRIPTION_FIELDS = [
+  'description',
+  'summary',
+  'abstract',
+  'overview',
+  'notes',
+  'documentDescription',
+  'document_description',
+  'shortDescription',
+  'short_description',
+  'longDescription',
+  'long_description',
+  'details',
+  'detail',
+  'synopsis',
+];
+
+const KNOWLEDGE_FALLBACK_DESCRIPTION = 'Referenced from your uploaded knowledge base.';
 
 function isLikelyFilename(value) {
   if (typeof value !== 'string') {
@@ -105,6 +199,71 @@ function collectKnowledgeSourceTitleCandidates(source) {
   return candidates;
 }
 
+function collectKnowledgeSourceDescriptionCandidates(source) {
+  if (!source || typeof source !== 'object') {
+    return [];
+  }
+
+  const metadata = source.metadata && typeof source.metadata === 'object' ? source.metadata : {};
+  const metadataDocumentMetadata =
+    metadata.documentMetadata && typeof metadata.documentMetadata === 'object'
+      ? metadata.documentMetadata
+      : {};
+  const document = source.document && typeof source.document === 'object' ? source.document : {};
+  const documentMetadata =
+    document.metadata && typeof document.metadata === 'object' ? document.metadata : {};
+  const fileCitation =
+    source.file_citation && typeof source.file_citation === 'object' ? source.file_citation : {};
+  const fileCitationMetadata =
+    fileCitation.metadata && typeof fileCitation.metadata === 'object'
+      ? fileCitation.metadata
+      : {};
+
+  const seen = new Set();
+  const candidates = [];
+
+  const pushCandidate = (rawValue) => {
+    if (typeof rawValue !== 'string') {
+      return;
+    }
+
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) {
+      return;
+    }
+
+    seen.add(key);
+    candidates.push(trimmed);
+  };
+
+  const pushFromObject = (obj) => {
+    if (!obj || typeof obj !== 'object') {
+      return;
+    }
+
+    KNOWLEDGE_DESCRIPTION_FIELDS.forEach((field) => {
+      if (Object.prototype.hasOwnProperty.call(obj, field)) {
+        pushCandidate(obj[field]);
+      }
+    });
+  };
+
+  pushFromObject(metadataDocumentMetadata);
+  pushFromObject(documentMetadata);
+  pushFromObject(metadata);
+  pushFromObject(document);
+  pushFromObject(fileCitationMetadata);
+  pushFromObject(fileCitation);
+  pushFromObject(source);
+
+  return candidates;
+}
+
 function getFirstNonEmptyString(...values) {
   for (const value of values) {
     if (typeof value === 'string') {
@@ -122,9 +281,11 @@ function tokenizeText(text) {
     return [];
   }
 
-  return String(text)
-    .toLowerCase()
-    .match(/[a-z0-9]{3,}/g) || [];
+  return (
+    String(text)
+      .toLowerCase()
+      .match(/[a-z0-9]{3,}/g) || []
+  ).filter((token) => !STOP_WORDS.has(token));
 }
 
 function buildResourceId(prefix, key, index) {
@@ -245,6 +406,19 @@ export function createKnowledgeBaseResources(sources = []) {
     const preferredTitle = titleCandidates.find(candidate => !isLikelyFilename(candidate));
     const resolvedTitle = preferredTitle || fallbackTitle;
 
+    const descriptionCandidates = collectKnowledgeSourceDescriptionCandidates(source);
+    const documentDescription = descriptionCandidates.length > 0 ? descriptionCandidates[0] : '';
+    const truncatedDocumentDescription = documentDescription
+      ? truncateText(documentDescription, 220)
+      : '';
+    const resolvedDescription =
+      snippet || truncatedDocumentDescription || KNOWLEDGE_FALLBACK_DESCRIPTION;
+    const descriptionSource = snippet
+      ? 'snippet'
+      : truncatedDocumentDescription
+        ? 'document'
+        : 'fallback';
+
     const metadataDocumentId =
       getFirstNonEmptyString(
         source.documentId,
@@ -268,23 +442,43 @@ export function createKnowledgeBaseResources(sources = []) {
                 : typeof source.file_citation?.chunk_index === 'number'
                   ? source.file_citation.chunk_index
                   : null;
-    const existing = deduped.get(key);
+    const existingEntry = deduped.get(key);
 
-    if (existing) {
-      if (snippet && !existing.description.includes(snippet)) {
-        const merged = `${existing.description} ${snippet}`.trim();
-        existing.description = truncateText(merged, 220);
+    if (existingEntry) {
+      const existingResource = existingEntry.resource;
+
+      if (snippet) {
+        if (
+          typeof existingResource.description !== 'string' ||
+          !existingResource.description.includes(snippet)
+        ) {
+          const merged = `${existingResource.description || ''} ${snippet}`.trim();
+          existingResource.description = truncateText(merged, 220);
+        }
+        existingEntry.descriptionSource = 'snippet';
+      } else if (
+        descriptionSource === 'document' &&
+        existingEntry.descriptionSource !== 'snippet'
+      ) {
+        if (truncatedDocumentDescription) {
+          existingResource.description = truncatedDocumentDescription;
+          existingEntry.descriptionSource = 'document';
+        }
+      } else if (!existingResource.description) {
+        existingResource.description = resolvedDescription;
+        existingEntry.descriptionSource = descriptionSource;
       }
-      if (resolvedTitle && existing.title !== resolvedTitle) {
-        existing.title = resolvedTitle;
+
+      if (resolvedTitle && existingResource.title !== resolvedTitle) {
+        existingResource.title = resolvedTitle;
       }
-      if (!existing.metadata?.documentTitle && resolvedTitle) {
-        existing.metadata = {
-          ...(existing.metadata || {}),
+      if (!existingResource.metadata?.documentTitle && resolvedTitle) {
+        existingResource.metadata = {
+          ...(existingResource.metadata || {}),
           documentTitle: resolvedTitle,
         };
       }
-      deduped.set(key, existing);
+      deduped.set(key, existingEntry);
       return;
     }
 
@@ -297,49 +491,59 @@ export function createKnowledgeBaseResources(sources = []) {
     }
 
     deduped.set(key, {
-      id: buildResourceId('knowledge', key, index),
-      title: resolvedTitle,
-      type: 'Knowledge Base',
-      url: source.url || null,
-      description: snippet || 'Referenced from your uploaded knowledge base.',
-      origin: 'Knowledge Base',
-      location: 'Derived from retrieved document context',
-      metadata,
+      resource: {
+        id: buildResourceId('knowledge', key, index),
+        title: resolvedTitle,
+        type: 'Knowledge Base',
+        url: source.url || null,
+        description: resolvedDescription,
+        origin: 'Knowledge Base',
+        location: 'Derived from retrieved document context',
+        metadata,
+      },
+      descriptionSource,
     });
   });
 
-  return Array.from(deduped.values());
+  return Array.from(deduped.values()).map(entry => entry.resource);
 }
 
 function scoreAdminResource(resource, contextTokens) {
   const searchableText = `${resource.name || ''} ${resource.description || ''} ${resource.tag || ''}`;
-  const resourceTokens = tokenizeText(searchableText);
+  const resourceTokens = new Set(tokenizeText(searchableText));
 
-  if (resourceTokens.length === 0) {
-    return 0;
+  if (resourceTokens.size === 0) {
+    return { score: 0, matchedTokenCount: 0, tagMatched: false };
   }
 
-  let score = 0;
   const matchedTokens = new Set();
 
-  resourceTokens.forEach(token => {
+  resourceTokens.forEach((token) => {
     if (token.length < MIN_TOKEN_LENGTH) {
       return;
     }
-    if (contextTokens.has(token) && !matchedTokens.has(token)) {
+    if (contextTokens.has(token)) {
       matchedTokens.add(token);
-      score += 1;
     }
   });
 
+  let tagMatched = false;
   if (resource.tag) {
-    const tagToken = resource.tag.toLowerCase();
-    if (contextTokens.has(tagToken)) {
-      score += 2;
-    }
+    tokenizeText(resource.tag).forEach((token) => {
+      if (contextTokens.has(token)) {
+        tagMatched = true;
+        matchedTokens.add(token);
+      }
+    });
   }
 
-  return score;
+  const score = matchedTokens.size + (tagMatched ? 2 : 0);
+
+  return {
+    score,
+    matchedTokenCount: matchedTokens.size,
+    tagMatched,
+  };
 }
 
 export function matchAdminResourcesToContext(contextText, adminResources = [], limit = DEFAULT_LIMIT) {
@@ -358,8 +562,15 @@ export function matchAdminResourcesToContext(contextText, adminResources = [], l
         return null;
       }
 
-      const score = scoreAdminResource(resource, contextTokens);
-      if (score === 0) {
+      const { score, matchedTokenCount, tagMatched } = scoreAdminResource(resource, contextTokens);
+      if (matchedTokenCount === 0) {
+        return null;
+      }
+
+      const hasSufficientOverlap =
+        matchedTokenCount >= 2 || (tagMatched && matchedTokenCount >= 1);
+
+      if (!hasSufficientOverlap) {
         return null;
       }
 

--- a/src/utils/internalResourceUtils.test.js
+++ b/src/utils/internalResourceUtils.test.js
@@ -1,4 +1,8 @@
-import { createAttachmentResources, createKnowledgeBaseResources } from './internalResourceUtils';
+import {
+  createAttachmentResources,
+  createKnowledgeBaseResources,
+  matchAdminResourcesToContext,
+} from './internalResourceUtils';
 
 describe('createAttachmentResources', () => {
   it('prefers attachment metadata title when available', () => {
@@ -15,6 +19,50 @@ describe('createAttachmentResources', () => {
     expect(resources).toHaveLength(1);
     expect(resources[0].title).toBe('Quality Event SOP');
     expect(resources[0].metadata.documentTitle).toBe('Quality Event SOP');
+  });
+});
+
+describe('matchAdminResourcesToContext', () => {
+  it('filters admin resources that only share a single generic token', () => {
+    const adminResources = [
+      {
+        id: 'admin-1',
+        name: 'Compliance Orientation',
+        description: 'Overview of our compliance onboarding steps.',
+      },
+    ];
+
+    const matches = matchAdminResourcesToContext('Tell me about compliance expectations', adminResources);
+    expect(matches).toHaveLength(0);
+  });
+
+  it('returns admin resources when multiple meaningful tokens overlap', () => {
+    const adminResources = [
+      {
+        id: 'admin-2',
+        name: 'Training SOP Checklist',
+        description: 'Detailed training SOP checklist for new hires.',
+      },
+    ];
+
+    const matches = matchAdminResourcesToContext('Need training SOP checklist for onboarding', adminResources);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].title).toBe('Training SOP Checklist');
+  });
+
+  it('retains admin resources when the tag matches the question keyword', () => {
+    const adminResources = [
+      {
+        id: 'admin-3',
+        name: 'Operations Guide',
+        description: 'Covers day-to-day operations.',
+        tag: 'QAOps',
+      },
+    ];
+
+    const matches = matchAdminResourcesToContext('How does QAOps process work?', adminResources);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].metadata.adminResourceId).toBe('admin-3');
   });
 });
 
@@ -35,12 +83,30 @@ describe('createKnowledgeBaseResources', () => {
     expect(resources[0].metadata.documentTitle).toBe('Quality Event SOP');
   });
 
+  it('uses document description from metadata when available', () => {
+    const sources = [
+      {
+        documentId: 'doc-3',
+        metadata: {
+          documentMetadata: {
+            description: 'Defines the quality system requirements for the organization.',
+          },
+        },
+      },
+    ];
+
+    const resources = createKnowledgeBaseResources(sources);
+    expect(resources).toHaveLength(1);
+    expect(resources[0].description).toBe(
+      'Defines the quality system requirements for the organization.'
+    );
+  });
+
   it('falls back to generic label when no title available', () => {
     const sources = [
       {
         documentId: 'doc-2',
         filename: 'Deviation_Guide.pdf',
-        text: 'Deviation handling guidance.',
       },
     ];
 
@@ -48,5 +114,6 @@ describe('createKnowledgeBaseResources', () => {
     expect(resources).toHaveLength(1);
     expect(resources[0].title).toBe('Referenced document 1');
     expect(resources[0].metadata.documentTitle).toBe('Referenced document 1');
+    expect(resources[0].description).toBe('Referenced from your uploaded knowledge base.');
   });
 });


### PR DESCRIPTION
## Summary
- compute sidebar resource relevance from the latest user message, merging message contexts and token overlap so uploads, answers, and question-matching items surface first
- add utilities for tokenizing message text and resource metadata while fixing the missing `isUserMessage` guard that crashed the live page
- update sidebar tests to cover relevance ordering and ensure recency fallback when no question is present
- tighten admin resource matching by filtering stop words, requiring multiple overlapping tokens (or explicit tag matches), and adding coverage to block irrelevant entries from appearing

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d016e0cc00832abe348348e9a59e7e