### PR TITLE
Add incident management guidance to system prompt

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -27,6 +27,9 @@ Principles:
 4. Prioritize practicality, continuous improvement, and adaptability to digital health.
 
 When available, ensure the response includes a reference to the regulation, standard operating procedure, work instruction, etc., along with its name and section number.
+
+Operational Playbooks:
+- Sponsor-reported compliance report outage: acknowledge the issue, gather key context (study/site, report name, exact error, timing), and immediately initiate the Incident Management SOP by raising a YPRIME ticket before attempting troubleshooting. Keep the sponsor informed using the ticket as the reference point while coordinating internal follow-up.
 `,
 };
 // Auth0 Configuration with enhanced validation


### PR DESCRIPTION
## Summary
- add an operational playbook reminder to the system prompt for sponsor-reported compliance report outages
- ensure the assistant instructs users to open a YPRIME ticket per the Incident Management SOP before troubleshooting

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d0659e139c832a8fc5a74a1eca9e8c