### PR TITLE
Secure support request submission

### DIFF
--- a/netlify/functions/support-request.js
+++ b/netlify/functions/support-request.js
@@ -7,6 +7,22 @@ const headers = {
   'Content-Type': 'application/json',
 };
 
+const getHeader = (eventHeaders = {}, name) => {
+  const lower = name.toLowerCase();
+  return (
+    eventHeaders[name] ||
+    eventHeaders[lower] ||
+    eventHeaders[name.toUpperCase()]
+  );
+};
+
+const requiredEnvVars = [
+  'JIRA_API_EMAIL',
+  'JIRA_API_TOKEN',
+  'JIRA_SERVICE_DESK_ID',
+  'JIRA_REQUEST_TYPE_ID',
+];
+
 exports.handler = async (event, context) => {
   console.log('Support request function called', { method: event.httpMethod });
 
@@ -27,24 +43,75 @@ exports.handler = async (event, context) => {
     };
   }
 
+  const authHeader = getHeader(event.headers, 'authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return {
+      statusCode: 401,
+      headers,
+      body: JSON.stringify({
+        error: 'Authentication required',
+        details: 'Missing or invalid bearer token',
+      }),
+    };
+  }
+
+  const userId = getHeader(event.headers, 'x-user-id') || getHeader(event.headers, 'x-userid');
+  if (!userId || userId === 'anonymous') {
+    return {
+      statusCode: 400,
+      headers,
+      body: JSON.stringify({
+        error: 'User identification required',
+        details: 'User ID header is missing',
+      }),
+    };
+  }
+
+  const missingEnv = requiredEnvVars.filter((key) => !process.env[key]);
+  if (missingEnv.length > 0) {
+    console.error('Support request configuration error', { missingEnv });
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({
+        error: 'Support request configuration error',
+        details: `Missing environment variables: ${missingEnv.join(', ')}`,
+      }),
+    };
+  }
+
+  let bodyData;
   try {
-    const { email, message } = JSON.parse(event.body || '{}');
+    bodyData = JSON.parse(event.body || '{}');
+  } catch (parseError) {
+    console.error('Invalid JSON payload', parseError);
+    return {
+      statusCode: 400,
+      headers,
+      body: JSON.stringify({ error: 'Invalid JSON in request body' }),
+    };
+  }
 
-    if (!email || !message) {
-      return {
-        statusCode: 400,
-        headers,
-        body: JSON.stringify({ error: 'Missing email or message' }),
-      };
-    }
+  const { email, message } = bodyData;
 
-    const jiraAuth = Buffer.from(`${process.env.JIRA_API_EMAIL}:${process.env.JIRA_API_TOKEN}`).toString('base64');
+  if (!email || !message) {
+    return {
+      statusCode: 400,
+      headers,
+      body: JSON.stringify({ error: 'Missing email or message' }),
+    };
+  }
+
+  try {
+    const jiraAuth = Buffer.from(
+      `${process.env.JIRA_API_EMAIL}:${process.env.JIRA_API_TOKEN}`
+    ).toString('base64');
 
     const jiraResponse = await fetch('https://acceleraqa.atlassian.net/rest/servicedeskapi/request', {
       method: 'POST',
       headers: {
-        'Authorization': `Basic ${jiraAuth}`,
-        'Accept': 'application/json',
+        Authorization: `Basic ${jiraAuth}`,
+        Accept: 'application/json',
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
@@ -58,7 +125,6 @@ exports.handler = async (event, context) => {
       }),
     });
 
-    // Parse response body safely (Jira may return plain text on errors)
     const text = await jiraResponse.text();
     let data;
     try {
@@ -68,11 +134,23 @@ exports.handler = async (event, context) => {
     }
 
     if (!jiraResponse.ok) {
-      console.error('Jira API error', data);
+      const detail =
+        typeof data === 'string'
+          ? data
+          : data?.errorMessage || data?.message || JSON.stringify(data);
+
+      console.error('Jira API error', { status: jiraResponse.status, detail });
+
       return {
         statusCode: jiraResponse.status,
         headers,
-        body: JSON.stringify({ error: 'Failed to create support request', details: data }),
+        body: JSON.stringify({
+          error: 'Failed to create support request',
+          details:
+            jiraResponse.status === 401
+              ? 'Support system authentication failed. Please contact an administrator.'
+              : detail,
+        }),
       };
     }
 


### PR DESCRIPTION
## Summary
- require an Auth0 access token and user identifier when the support overlay sends a request
- add clearer error handling in the UI so authentication or Jira issues surface actionable messages
- harden the Netlify support-request function by validating headers, configuration, and upstream failures before calling Jira

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68d167fa8e10832aa97bbb5368ed8dc7