### PR TITLE
Send support emails from requester address

### DIFF
--- a/netlify/functions/support-request.js
+++ b/netlify/functions/support-request.js
@@ -1,10 +1,27 @@
-// netlify/functions/support-request.js - Create Jira Service Desk request
+// netlify/functions/support-request.js - Send support requests via email
 
 const headers = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-user-id',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Content-Type': 'application/json',
+};
+
+const SUPPORT_REQUEST_TO_EMAIL =
+  process.env.SUPPORT_REQUEST_TO_EMAIL || 'support@acceleraqa.atlassian.net';
+
+const SENDGRID_API_URL = 'https://api.sendgrid.com/v3/mail/send';
+
+const requiredEnvVars = ['SUPPORT_REQUEST_SENDGRID_API_KEY'];
+
+const escapeHtml = (value = '') => {
+  const stringValue = value == null ? '' : String(value);
+  return stringValue
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 };
 
 exports.handler = async (event, context) => {
@@ -27,66 +44,149 @@ exports.handler = async (event, context) => {
     };
   }
 
-  try {
-    const { email, message } = JSON.parse(event.body || '{}');
+  const missingEnv = requiredEnvVars.filter((key) => !process.env[key]);
+  if (missingEnv.length > 0) {
+    console.error('Support request configuration error', { missingEnv });
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({
+        error: 'Support request configuration error',
+        details: `Missing environment variables: ${missingEnv.join(', ')}`,
+      }),
+    };
+  }
 
-    if (!email || !message) {
+  let bodyData;
+  try {
+    bodyData = JSON.parse(event.body || '{}');
+  } catch (parseError) {
+    console.error('Invalid JSON payload', parseError);
+    return {
+      statusCode: 400,
+      headers,
+      body: JSON.stringify({ error: 'Invalid JSON in request body' }),
+    };
+  }
+
+  const { email, message, name } = bodyData;
+
+  if (!email || typeof email !== 'string' || !message || typeof message !== 'string') {
+    return {
+      statusCode: 400,
+      headers,
+      body: JSON.stringify({ error: 'Missing email or message' }),
+    };
+  }
+
+  const normalizedEmail = email.trim();
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  if (!emailPattern.test(normalizedEmail)) {
+    return {
+      statusCode: 400,
+      headers,
+      body: JSON.stringify({ error: 'Invalid email address' }),
+    };
+  }
+
+  try {
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage) {
       return {
         statusCode: 400,
         headers,
-        body: JSON.stringify({ error: 'Missing email or message' }),
+        body: JSON.stringify({ error: 'Message cannot be empty' }),
       };
     }
 
-    const jiraAuth = Buffer.from(`${process.env.JIRA_API_EMAIL}:${process.env.JIRA_API_TOKEN}`).toString('base64');
+    const safeName = typeof name === 'string' ? name.trim() : '';
+    const requesterLabel = safeName
+      ? `${safeName} <${normalizedEmail}>`
+      : normalizedEmail;
 
-    const jiraResponse = await fetch('https://acceleraqa.atlassian.net/rest/servicedeskapi/request', {
+    const plainText = `Support request from ${requesterLabel}\n\n${trimmedMessage}`;
+    const htmlBody = `
+      <p><strong>From:</strong> ${escapeHtml(requesterLabel)}</p>
+      <p><strong>Email:</strong> ${escapeHtml(normalizedEmail)}</p>
+      <hr />
+      <p>${escapeHtml(trimmedMessage).replace(/\n/g, '<br />')}</p>
+    `;
+    const subject = `Support request from ${safeName || normalizedEmail}`;
+
+    const sender = safeName
+      ? { email: normalizedEmail, name: safeName }
+      : { email: normalizedEmail };
+
+    const sendgridResponse = await fetch(SENDGRID_API_URL, {
       method: 'POST',
       headers: {
-        'Authorization': `Basic ${jiraAuth}`,
-        'Accept': 'application/json',
+        Authorization: `Bearer ${process.env.SUPPORT_REQUEST_SENDGRID_API_KEY}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        serviceDeskId: process.env.JIRA_SERVICE_DESK_ID,
-        requestTypeId: process.env.JIRA_REQUEST_TYPE_ID,
-        requestFieldValues: {
-          summary: `Support request from ${email}`,
-          description: message,
-        },
-        raiseOnBehalfOf: email,
+        personalizations: [
+          {
+            to: [{ email: SUPPORT_REQUEST_TO_EMAIL }],
+          },
+        ],
+        from: sender,
+        reply_to: sender,
+        subject,
+        content: [
+          { type: 'text/plain', value: plainText },
+          { type: 'text/html', value: htmlBody },
+        ],
       }),
     });
 
-    // Parse response body safely (Jira may return plain text on errors)
-    const text = await jiraResponse.text();
-    let data;
-    try {
-      data = JSON.parse(text);
-    } catch {
-      data = text;
-    }
+    if (!sendgridResponse.ok) {
+      const errorText = await sendgridResponse.text();
+      let parsedDetail = errorText;
 
-    if (!jiraResponse.ok) {
-      console.error('Jira API error', data);
+      try {
+        const parsed = JSON.parse(errorText);
+        const messages =
+          parsed?.errors?.map((err) => err?.message).filter(Boolean) || [];
+        if (messages.length > 0) {
+          parsedDetail = messages.join('; ');
+        } else if (parsed?.message) {
+          parsedDetail = parsed.message;
+        }
+      } catch (parseError) {
+        // ignore JSON parse errors, we'll use the raw text instead
+      }
+
+      console.error('SendGrid API error', {
+        status: sendgridResponse.status,
+        body: errorText,
+      });
+
       return {
-        statusCode: jiraResponse.status,
+        statusCode: 502,
         headers,
-        body: JSON.stringify({ error: 'Failed to create support request', details: data }),
+        body: JSON.stringify({
+          error: 'Failed to send support email',
+          details: parsedDetail || 'Unexpected response from email provider',
+        }),
       };
     }
 
     return {
       statusCode: 200,
       headers,
-      body: JSON.stringify({ message: 'Support request created', key: data.key }),
+      body: JSON.stringify({ message: 'Support request email sent' }),
     };
   } catch (error) {
     console.error('Support request error:', error);
     return {
       statusCode: 500,
       headers,
-      body: JSON.stringify({ error: 'Internal server error', message: error.message }),
+      body: JSON.stringify({
+        error: 'Internal server error',
+        message: 'Failed to send support email',
+        details: error.message,
+      }),
     };
   }
 };

--- a/src/components/SupportRequestOverlay.js
+++ b/src/components/SupportRequestOverlay.js
@@ -6,26 +6,62 @@ const SupportRequestOverlay = ({ user, onClose }) => {
   const [submitting, setSubmitting] = useState(false);
 
   const handleSubmit = async () => {
-    if (!message.trim()) return;
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage || submitting) {
+      return;
+    }
+
     setSubmitting(true);
+
     try {
+      const requesterEmail = user?.email || '';
+      const requesterName = user?.name || '';
+
+      if (!requesterEmail) {
+        throw new Error('A valid email address is required to submit a support request.');
+      }
+
       const response = await fetch('/.netlify/functions/support-request', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user?.email, message }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: requesterEmail,
+          name: requesterName,
+          message: trimmedMessage,
+        }),
       });
 
       if (response.ok) {
-        alert('Support request submitted');
+        alert('Support request email sent to AcceleraQA support.');
         setMessage('');
         onClose();
-      } else {
-        console.error('Support request failed', await response.text());
-        alert('Failed to submit support request');
+        return;
       }
+
+      let errorDetail = 'An unknown error occurred.';
+
+      try {
+        const errorData = await response.json();
+        errorDetail =
+          errorData?.details ||
+          errorData?.error ||
+          errorData?.message ||
+          errorDetail;
+      } catch (parseError) {
+        const text = await response.text();
+        if (text) {
+          errorDetail = text;
+        }
+      }
+
+      console.error('Support request failed', errorDetail);
+      alert(`Failed to send support request: ${errorDetail}`);
     } catch (error) {
       console.error('Support request error:', error);
-      alert('Failed to submit support request');
+      const message = error?.message || 'Failed to send support request email';
+      alert(message);
     } finally {
       setSubmitting(false);
     }
@@ -54,7 +90,7 @@ const SupportRequestOverlay = ({ user, onClose }) => {
           <div className="mt-4 flex justify-end">
             <button
               onClick={handleSubmit}
-              disabled={submitting}
+              disabled={submitting || !message.trim()}
               className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             >
               <Send className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- send SendGrid support requests using the logged-in requester's email (and name when available) for both the sender and reply-to fields
- drop the SUPPORT_REQUEST_FROM_EMAIL configuration requirement so only the SendGrid API key must be set

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68d167fa8e10832aa97bbb5368ed8dc7