### PR TITLE
Relax support email sender requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ REACT_APP_AUTH0_ORG_CLAIM=https://your-domain.com/org
 NEON_DATABASE_URL=postgres://user:password@host:port/dbname
 REACT_APP_RAG_DOCS_FUNCTION=/.netlify/functions/rag-documents # optional override
 
-# Jira Service Desk (Optional)
-JIRA_API_EMAIL=your_atlassian_email
-JIRA_API_TOKEN=your_atlassian_api_token
-JIRA_SERVICE_DESK_ID=your_service_desk_id
-JIRA_REQUEST_TYPE_ID=your_request_type_id
+# Support Requests (Email via SendGrid)
+SUPPORT_REQUEST_SENDGRID_API_KEY=your_sendgrid_api_key
+SUPPORT_REQUEST_FROM_EMAIL=verified_sender@example.com # optional verified sender override
+SUPPORT_REQUEST_FROM_NAME="AcceleraQA Support" # optional display name when using a verified sender
+SUPPORT_REQUEST_TO_EMAIL=support@acceleraqa.atlassian.net # optional override
 
 # Feature Flags (Optional)
 REACT_APP_ENABLE_AI_SUGGESTIONS=true # set to 'false' to disable AI suggestions

--- a/netlify/functions/support-request.js
+++ b/netlify/functions/support-request.js
@@ -1,10 +1,29 @@
-// netlify/functions/support-request.js - Create Jira Service Desk request
+// netlify/functions/support-request.js - Send support requests via email
 
 const headers = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-user-id',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Content-Type': 'application/json',
+};
+
+const SUPPORT_REQUEST_TO_EMAIL =
+  process.env.SUPPORT_REQUEST_TO_EMAIL || 'support@acceleraqa.atlassian.net';
+const SUPPORT_REQUEST_FROM_EMAIL = process.env.SUPPORT_REQUEST_FROM_EMAIL;
+const SUPPORT_REQUEST_FROM_NAME = process.env.SUPPORT_REQUEST_FROM_NAME;
+
+const SENDGRID_API_URL = 'https://api.sendgrid.com/v3/mail/send';
+
+const requiredEnvVars = ['SUPPORT_REQUEST_SENDGRID_API_KEY'];
+
+const escapeHtml = (value = '') => {
+  const stringValue = value == null ? '' : String(value);
+  return stringValue
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 };
 
 exports.handler = async (event, context) => {
@@ -27,66 +46,167 @@ exports.handler = async (event, context) => {
     };
   }
 
-  try {
-    const { email, message } = JSON.parse(event.body || '{}');
+  const missingEnv = requiredEnvVars.filter((key) => !process.env[key]);
+  if (missingEnv.length > 0) {
+    console.error('Support request configuration error', { missingEnv });
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({
+        error: 'Support request configuration error',
+        details: `Missing environment variables: ${missingEnv.join(', ')}`,
+      }),
+    };
+  }
 
-    if (!email || !message) {
+  let bodyData;
+  try {
+    bodyData = JSON.parse(event.body || '{}');
+  } catch (parseError) {
+    console.error('Invalid JSON payload', parseError);
+    return {
+      statusCode: 400,
+      headers,
+      body: JSON.stringify({ error: 'Invalid JSON in request body' }),
+    };
+  }
+
+  const { email, message, name } = bodyData;
+
+  if (!email || typeof email !== 'string' || !message || typeof message !== 'string') {
+    return {
+      statusCode: 400,
+      headers,
+      body: JSON.stringify({ error: 'Missing email or message' }),
+    };
+  }
+
+  const normalizedEmail = email.trim();
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  if (!emailPattern.test(normalizedEmail)) {
+    return {
+      statusCode: 400,
+      headers,
+      body: JSON.stringify({ error: 'Invalid email address' }),
+    };
+  }
+
+  try {
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage) {
       return {
         statusCode: 400,
         headers,
-        body: JSON.stringify({ error: 'Missing email or message' }),
+        body: JSON.stringify({ error: 'Message cannot be empty' }),
       };
     }
 
-    const jiraAuth = Buffer.from(`${process.env.JIRA_API_EMAIL}:${process.env.JIRA_API_TOKEN}`).toString('base64');
+    const safeName = typeof name === 'string' ? name.trim() : '';
+    const requesterLabel = safeName
+      ? `${safeName} <${normalizedEmail}>`
+      : normalizedEmail;
 
-    const jiraResponse = await fetch('https://acceleraqa.atlassian.net/rest/servicedeskapi/request', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Basic ${jiraAuth}`,
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        serviceDeskId: process.env.JIRA_SERVICE_DESK_ID,
-        requestTypeId: process.env.JIRA_REQUEST_TYPE_ID,
-        requestFieldValues: {
-          summary: `Support request from ${email}`,
-          description: message,
+    const plainText = `Support request from ${requesterLabel}\n\n${trimmedMessage}`;
+    const htmlBody = `
+      <p><strong>From:</strong> ${escapeHtml(requesterLabel)}</p>
+      <p><strong>Email:</strong> ${escapeHtml(normalizedEmail)}</p>
+      <hr />
+      <p>${escapeHtml(trimmedMessage).replace(/\n/g, '<br />')}</p>
+    `;
+    const subject = `Support request from ${safeName || normalizedEmail}`;
+
+    const hasVerifiedSender = Boolean(SUPPORT_REQUEST_FROM_EMAIL);
+    const sender = hasVerifiedSender
+      ? SUPPORT_REQUEST_FROM_NAME
+        ? { email: SUPPORT_REQUEST_FROM_EMAIL, name: SUPPORT_REQUEST_FROM_NAME }
+        : { email: SUPPORT_REQUEST_FROM_EMAIL }
+      : safeName
+      ? { email: normalizedEmail, name: safeName }
+      : { email: normalizedEmail };
+    const replyTo = hasVerifiedSender
+      ? safeName
+        ? { email: normalizedEmail, name: safeName }
+        : { email: normalizedEmail }
+      : undefined;
+
+    const payload = {
+      personalizations: [
+        {
+          to: [{ email: SUPPORT_REQUEST_TO_EMAIL }],
         },
-        raiseOnBehalfOf: email,
-      }),
-    });
+      ],
+      from: sender,
+      subject,
+      content: [
+        { type: 'text/plain', value: plainText },
+        { type: 'text/html', value: htmlBody },
+      ],
+    };
 
-    // Parse response body safely (Jira may return plain text on errors)
-    const text = await jiraResponse.text();
-    let data;
-    try {
-      data = JSON.parse(text);
-    } catch {
-      data = text;
+    if (replyTo) {
+      payload.reply_to = replyTo;
     }
 
-    if (!jiraResponse.ok) {
-      console.error('Jira API error', data);
+    const sendgridResponse = await fetch(SENDGRID_API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.SUPPORT_REQUEST_SENDGRID_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!sendgridResponse.ok) {
+      const errorText = await sendgridResponse.text();
+      let parsedDetail = errorText;
+
+      try {
+        const parsed = JSON.parse(errorText);
+        const messages =
+          parsed?.errors?.map((err) => err?.message).filter(Boolean) || [];
+        if (messages.length > 0) {
+          parsedDetail = messages.join('; ');
+        } else if (parsed?.message) {
+          parsedDetail = parsed.message;
+        }
+      } catch (parseError) {
+        // ignore JSON parse errors, we'll use the raw text instead
+      }
+
+      console.error('SendGrid API error', {
+        status: sendgridResponse.status,
+        body: errorText,
+      });
+
       return {
-        statusCode: jiraResponse.status,
+        statusCode: 502,
         headers,
-        body: JSON.stringify({ error: 'Failed to create support request', details: data }),
+        body: JSON.stringify({
+          error: 'Failed to send support email',
+          details:
+            parsedDetail?.trim() ||
+            sendgridResponse.statusText ||
+            `Email provider error (status ${sendgridResponse.status})`,
+        }),
       };
     }
 
     return {
       statusCode: 200,
       headers,
-      body: JSON.stringify({ message: 'Support request created', key: data.key }),
+      body: JSON.stringify({ message: 'Support request email sent' }),
     };
   } catch (error) {
     console.error('Support request error:', error);
     return {
       statusCode: 500,
       headers,
-      body: JSON.stringify({ error: 'Internal server error', message: error.message }),
+      body: JSON.stringify({
+        error: 'Internal server error',
+        message: 'Failed to send support email',
+        details: error.message,
+      }),
     };
   }
 };

--- a/src/components/SupportRequestOverlay.js
+++ b/src/components/SupportRequestOverlay.js
@@ -1,31 +1,74 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { X, Send } from 'lucide-react';
 
 const SupportRequestOverlay = ({ user, onClose }) => {
   const [message, setMessage] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const textareaRef = useRef(null);
+
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, []);
 
   const handleSubmit = async () => {
-    if (!message.trim()) return;
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage || submitting) {
+      return;
+    }
+
     setSubmitting(true);
+
     try {
+      const requesterEmail = user?.email || '';
+      const requesterName = user?.name || '';
+
+      if (!requesterEmail) {
+        throw new Error('A valid email address is required to submit a support request.');
+      }
+
       const response = await fetch('/.netlify/functions/support-request', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user?.email, message }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: requesterEmail,
+          name: requesterName,
+          message: trimmedMessage,
+        }),
       });
 
       if (response.ok) {
-        alert('Support request submitted');
+        alert('Support request email sent to AcceleraQA support.');
         setMessage('');
         onClose();
-      } else {
-        console.error('Support request failed', await response.text());
-        alert('Failed to submit support request');
+        return;
       }
+
+      let errorDetail = 'An unknown error occurred.';
+
+      try {
+        const errorData = await response.json();
+        errorDetail =
+          errorData?.details ||
+          errorData?.error ||
+          errorData?.message ||
+          errorDetail;
+      } catch (parseError) {
+        const text = await response.text();
+        if (text) {
+          errorDetail = text;
+        }
+      }
+
+      console.error('Support request failed', errorDetail);
+      alert(`Failed to send support request: ${errorDetail}`);
     } catch (error) {
       console.error('Support request error:', error);
-      alert('Failed to submit support request');
+      const message = error?.message || 'Failed to send support request email';
+      alert(message);
     } finally {
       setSubmitting(false);
     }
@@ -46,6 +89,7 @@ const SupportRequestOverlay = ({ user, onClose }) => {
         </div>
         <div className="p-6">
           <textarea
+            ref={textareaRef}
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             placeholder="Describe your issue..."
@@ -54,7 +98,7 @@ const SupportRequestOverlay = ({ user, onClose }) => {
           <div className="mt-4 flex justify-end">
             <button
               onClick={handleSubmit}
-              disabled={submitting}
+              disabled={submitting || !message.trim()}
               className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             >
               <Send className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- allow support emails to originate from the requester when no verified sender override is configured while preserving reply-to headers when present
- improve SendGrid error reporting and only require the API key environment variable for support email delivery
- document the optional nature of the verified sender configuration in the README
- automatically focus the support request textarea when the overlay opens so users can immediately type their message

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68d167fa8e10832aa97bbb5368ed8dc7