### PR TITLE
Implement summary generation pipeline runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,14 @@ npm run build
 ## 📊 Performance Optimizations
 
 - **React.memo**: Prevent unnecessary re-renders
-- **useMemo**: Cache expensive calculations  
+- **useMemo**: Cache expensive calculations
 - **Lazy Loading**: Components loaded on demand
 - **Tree Shaking**: Optimized bundle size
 - **Service Workers**: Built-in with Create React App
+
+## 🧭 Architecture References
+
+- [AcceleraQA Summary-Generation Pipeline Architecture](docs/summary-generation-pipeline.md): end-to-end design for the role-aware, citation-backed summarization service that powers Ask Summarize, focus lenses, and downstream integrations.
 
 ## 🧪 Key Features
 

--- a/docs/summary-generation-pipeline.md
+++ b/docs/summary-generation-pipeline.md
@@ -1,0 +1,250 @@
+# AcceleraQA Summary-Generation Pipeline Architecture
+
+## 0. Objectives
+- Deliver audit-ready summaries of QA and validation artifacts with precise source citations.
+- Tailor outputs for specific roles (Auditor, QA Lead, Engineer, New Hire) and intents (Executive brief, SOP synopsis, CAPA evidence, Training deck).
+- Integrate seamlessly with the Netlify-hosted AcceleraQA front-end and OpenAI File Search / vector databases.
+- Provide observability, guardrails, and optional human-in-the-loop (HITL) review.
+
+---
+
+## 1. User-Facing Modes
+- **Ask Summarize**: One-click summarization for PDF, DOCX, HTML, or Markdown documents with selectable detail levels (*Brief*, *Standard*, *Deep Dive*).
+- **Role Profiles**: Auditor, QA Lead, Engineer, and New Hire profiles adapt rubric, vocabulary, and filters.
+- **Focus Lenses**: *Regulatory*, *Risk & CAPA*, *Training*, *Timeline / Change Log*, *Testing & Evidence*.
+- **Interactive Refinement**: Expand or contract sections, toggle citation visibility, term explanations, version comparisons, and export actions.
+
+---
+
+## 2. High-Level Flow
+1. **Ingest** → 2. **Preprocess & Chunk** → 3. **Index** (Embeddings + metadata) → 4. **Retrieve** (query + role + lens) → 5. **Orchestrate** (multi-pass) → 6. **Generate** (extractive → abstractive) → 7. **Citations & Confidence** → 8. **Guardrails** → 9. **Human Review** → 10. **Persist & Export**.
+
+```
+Client → API → Ingestion svc → Parser → Chunker → Indexer (pgvector/OpenAI File Search)
+     → Retrieval svc → Orchestrator → LLM Workers → Citation Builder → Policy Guard
+     → Review Queue → Storage (NeonDB + S3/Blobs) → Exporters (Vault/Jira/GitHub)
+```
+
+---
+
+## 3. Component Responsibilities
+
+### 3.1 Ingestion Service
+- Source documents from OpenAI File Search, normalizing metadata: `doc_id`, `title`, `owner`, `version`, `effective_date`, `doc_type`, and `system_of_record`.
+- Persist raw bytes in object storage (Netlify Blobs or S3) and record hashes for deduplication.
+
+### 3.2 Preprocessing & Chunking
+- Convert documents to rich text with heading, table, and caption structure while retaining page and paragraph anchors.
+- Apply adaptive chunking (800–1600 tokens with overlap) with boundary boosts at headings and tables.
+- Tag each chunk with metadata (`doc_id`, `section`, `page`, `tags`, `version`).
+
+### 3.3 Index Layer
+- Maintain a vector index (pgvector on NeonDB or OpenAI embeddings) using schema `chunks(id, doc_id, section, page, vector, text, version, tags jsonb)`.
+- Maintain keyword and metadata search via Postgres GIN indexes on `text`, `tags`, `doc_type`, and `version`.
+- Re-embed on updates with transactional upserts keyed by `doc_id` + `hash`.
+
+### 3.4 Retrieval Service
+- Perform hybrid retrieval: semantic kNN + BM25, reranked via cross-encoder.
+- Compose queries from user prompt, role profile rubric, and focus lens constraints, respecting time/version filters.
+- Return diversified top-N chunks (18–30) by section.
+
+### 3.5 Orchestrator (Multi-Pass)
+- **Pass A – Extractive**: Select salient sentences and entities (systems, dates, owners, deviations, regulations).
+- **Pass B – Abstractive**: Compose narratives tailored by role and lens.
+- **Pass C – Evidence & Citations**: Map claims to chunk anchors with confidence scores.
+- **Pass D – Tailoring**: Adjust style, length, glossaries, and role-specific inserts (e.g., risk tables for QA Lead).
+
+### 3.6 Guardrails & Compliance
+- Detect and redact PII/PHI using pattern and ML approaches (configurable per environment).
+- Enforce claim grounding (no uncited statements in Auditor mode) and mark speculative language.
+- Block edits to regulated content and expose confidence bands.
+
+### 3.7 Human Review & Approvals
+- Optional review queue with diff view versus prior summaries.
+- Allow reviewers to pin/unpin citations, edit text, and add notes.
+- Capture audit evidence: reviewer, timestamp, changes.
+
+### 3.8 Persistence & Exports
+- Store `summary_id`, `doc_id`, `mode`, `model`, `prompt_hash`, `citations`, `confidence`, `created_by`, and `checksum` in NeonDB.
+- Support exports to DOCX, PDF, HTML, and integrations with Vault, Jira, and GitHub.
+
+### 3.9 Observability
+- Track latency, token usage, retrieval MRR, section coverage, and citation density.
+- Capture traces with prompt details, retrieved chunk IDs, and model version via OpenTelemetry.
+- Provide dashboards for drift and failure analysis.
+
+---
+
+## 4. Data Contracts
+
+### 4.1 Chunk Metadata
+```json
+{
+  "doc_id": "VEEVA-000123",
+  "version": "3.1",
+  "doc_type": "SOP",
+  "page": 12,
+  "section": "4.2 Risk Assessment",
+  "tags": ["21 CFR 11", "Annex 11", "risk", "CAPA"],
+  "effective_date": "2025-03-01"
+}
+```
+
+### 4.2 Summary Record
+```json
+{
+  "summary_id": "SUM-9f3c",
+  "doc_id": "VEEVA-000123",
+  "mode": {"role": "Auditor", "lens": "Regulatory", "detail": "Standard"},
+  "model": "gpt-5-mini",
+  "prompt_hash": "sha256:...",
+  "citations": [
+    {"page": 12, "section": "4.2", "chunk_id": "c-01", "score": 0.91},
+    {"page": 18, "section": "5.1", "chunk_id": "c-07", "score": 0.86}
+  ],
+  "confidence": 0.88,
+  "created_at": "2025-09-25T13:30:00Z"
+}
+```
+
+---
+
+## 5. Prompting & Rubrics
+- **System Prompt**: “You are AcceleraQA’s summarizer. Write concise, audit-ready summaries grounded ONLY in provided chunks. For each claim, include a citation map {section/page}. If evidence is insufficient, state that explicitly. Adapt to role and lens.”
+- **Role Rubrics**:
+  - Auditor: compliance obligations, signatures, dates, deviations, CAPA actions, acceptance criteria.
+  - QA Lead: risk items, mitigation status, due dates, owner matrix, blockers, change control summary.
+  - Engineer: test coverage, defects, environment/config deltas, pipeline evidence, logs.
+  - New Hire: purpose, context, definitions, responsibilities, training links.
+- **Citation Template**: `[Citation] Statement → (Doc: {doc_id}, Sec {section}, p.{page})`.
+
+---
+
+## 6. Algorithms & Models
+- **Embeddings**: `text-embedding-3-large` (or pgvector-compatible) with periodic refreshes.
+- **Reranking**: Cross-encoder (e.g., MiniLM) for top-k relevance boosts.
+- **LLMs**: `gpt-5` or `gpt-5-mini`, with `mini` used for batch jobs and full model for high-stakes modes.
+- **Extractive Pass**: TextRank + NER (dates, people, systems, regulations, risk terms).
+- **Factuality Check**: QAG to ensure each sentence is grounded in retrieved context.
+
+---
+
+## 7. Evaluation & QA
+- **Coverage**: Ensure summaries address major sections (heading heuristics).
+- **Citations**: Citation density ≥0.7 for Auditor mode; ≥0.4 otherwise.
+- **Factuality**: Automated contradiction detection keeps hallucination rate below threshold.
+- **Human Ratings**: Collect role-specific scores and edit deltas for iterative tuning.
+- **Regression Suite**: Golden documents with expected outputs.
+
+---
+
+## 8. Guardrails & Policy
+- PII/PHI policies: redact or gate access with audit logs.
+- Regulatory language detector ensures mandated disclaimers are present.
+- Safety classifier monitors free-text inputs for prohibited content.
+
+---
+
+## 9. CI/CD & Automation Hooks
+- Regenerate summaries upon document version updates (Vault/GitHub webhooks).
+- Apply PR checks that post engineering-mode summaries for spec changes.
+- Run nightly jobs to rescore embeddings, refresh indices, and detect staleness.
+
+---
+
+## 10. Security & Access Control
+- Enforce row-level security by `system_of_record` and user role.
+- Provide signed, time-bound URLs for citation anchors with audit logging.
+- Manage secrets via Netlify environment variables and encrypt raw bytes/embeddings with KMS.
+
+---
+
+## 11. API Surface
+- **POST /summaries** → `202 Accepted {summary_id}` with body `{ doc_id, role, lens, detail, version?, sections?, language? }`.
+- **GET /summaries/{id}** → Retrieve summary text, citations, confidence, export options.
+- **POST /refine** → Return updated sections with new citations for follow-up queries.
+
+---
+
+## 12. Configuration Examples
+
+### Role & Lens Config (YAML)
+```yaml
+roles:
+  Auditor:
+    min_citation_density: 0.7
+    max_len_tokens: 1200
+    include: [obligations, signatures, dates, deviations, capa]
+  QA_Lead:
+    min_citation_density: 0.5
+    max_len_tokens: 900
+    include: [risks, owners, due_dates, changes]
+lenses:
+  Regulatory:
+    regex_boost: ["21 CFR 11", "Annex 11", "ICH E6"]
+  Risk_CAPA:
+    regex_boost: ["risk", "severity", "impact", "CAPA", "deviation"]
+```
+
+### Chunker Config (YAML)
+```yaml
+chunk_size: 1200
+chunk_overlap: 180
+respect_headings: true
+keep_tables: true
+anchors: ["H1", "H2", "Table", "Figure"]
+```
+
+---
+
+## 13. Core Orchestration (Pseudo-code)
+```ts
+const summarize = async (req) => {
+  const profile = loadProfile(req.role, req.lens, req.detail);
+  const query = buildQuery(req, profile);
+  const chunks = await hybridRetrieve(query, req.doc_id, req.version);
+
+  const extractive = await llmExtractive(chunks, profile);
+  const abstractive = await llmAbstractive(extractive, profile);
+
+  const citations = mapCitations(abstractive, chunks);
+  const guarded = await applyGuardrails(abstractive, citations, profile);
+
+  const confidence = scoreConfidence(guarded, citations, chunks);
+  const record = await persistSummary(req, guarded, citations, confidence);
+
+  emitEvent("summary.created", record);
+  return record;
+};
+```
+
+---
+
+## 14. Performance & Cost Controls
+- Cache retrieval results per (`doc_id`, `version`, `lens`, `role`).
+- Batch process with `gpt-5-mini`, upgrading to `gpt-5` for Auditor or on-demand needs.
+- Optimize prompts for token efficiency and enforce response length caps.
+- Tier storage to balance cost for cold or archived documents.
+
+---
+
+## 15. Integration Blueprints
+- **Veeva Vault**: Trigger summary regeneration on document status changes; attach summaries and maintain cross-links.
+- **Jira / YPT**: Insert summaries into ticket descriptions with citations; auto-update on document changes.
+- **GitHub**: Post engineering-mode summaries on pull requests with evidence links.
+
+---
+
+## 16. Roadmap Enhancements
+- Version-to-version diff summaries with change rationale.
+- Multilingual summary support for global audits.
+- Template-driven executive briefs for QBRs.
+- Explainable retrieval visualizations (saliency heatmaps).
+
+---
+
+## 17. MVP Acceptance Criteria
+- Role/lens summaries achieve ≥0.5 citation density and ≤2% hallucination on golden set.
+- End-to-end latency ≤8s for Standard detail on 50-page documents (warm cache).
+- Vault and Jira exports functioning end-to-end.
+- Observability dashboard exposes retrieval coverage and token usage per summary.

--- a/netlify/functions/summary-pipeline.js
+++ b/netlify/functions/summary-pipeline.js
@@ -1,0 +1,622 @@
+const crypto = require('crypto');
+
+const HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-user-id, X-Request-ID',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Content-Type': 'application/json',
+};
+
+const ROLE_PROFILES = {
+  Auditor: {
+    keywords: ['compliance', 'deviation', 'capa', 'audit', 'signature', 'approval', 'validation'],
+    tone: 'formal',
+    minCitationDensity: 0.7,
+    sections: ['Compliance Obligations', 'Deviations & CAPA', 'Approvals & Timelines'],
+  },
+  'QA Lead': {
+    keywords: ['risk', 'mitigation', 'owner', 'due date', 'change control', 'blocker'],
+    tone: 'pragmatic',
+    minCitationDensity: 0.5,
+    sections: ['Risk Posture', 'Mitigations & Owners', 'Open Actions'],
+  },
+  Engineer: {
+    keywords: ['test', 'defect', 'environment', 'configuration', 'log', 'pipeline'],
+    tone: 'technical',
+    minCitationDensity: 0.4,
+    sections: ['Testing Summary', 'Defects & Evidence', 'Environment Notes'],
+  },
+  'New Hire': {
+    keywords: ['overview', 'definition', 'context', 'role', 'training'],
+    tone: 'accessible',
+    minCitationDensity: 0.4,
+    sections: ['Purpose & Scope', 'Key Responsibilities', 'Training Pointers'],
+  },
+};
+
+const LENS_KEYWORDS = {
+  Regulatory: ['21 cfr 11', 'annex 11', 'part 820', 'inspection', 'submission'],
+  'Risk & CAPA': ['risk', 'severity', 'impact', 'capa', 'root cause'],
+  Training: ['training', 'curriculum', 'onboarding', 'lesson'],
+  'Timeline/Change log': ['timeline', 'change', 'revision', 'effective date'],
+  'Testing & Evidence': ['test', 'iq', 'oq', 'pq', 'evidence', 'protocol'],
+};
+
+const DETAIL_CONFIG = {
+  BRIEF: { targetSentences: 4, maxChunks: 8 },
+  STANDARD: { targetSentences: 6, maxChunks: 14 },
+  'DEEP DIVE': { targetSentences: 10, maxChunks: 24 },
+};
+
+const summaryStore = new Map();
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: HEADERS,
+      body: JSON.stringify({ message: 'CORS preflight' }),
+    };
+  }
+
+  try {
+    if (event.httpMethod === 'GET') {
+      return handleGet(event);
+    }
+
+    if (event.httpMethod !== 'POST') {
+      return {
+        statusCode: 405,
+        headers: HEADERS,
+        body: JSON.stringify({ error: 'Method not allowed' }),
+      };
+    }
+
+    const body = parseJson(event.body);
+    if (!body) {
+      return {
+        statusCode: 400,
+        headers: HEADERS,
+        body: JSON.stringify({ error: 'Invalid JSON payload' }),
+      };
+    }
+
+    const requestId = getRequestId(event.headers);
+    const response = processSummarizationRequest(body, requestId);
+
+    return {
+      statusCode: 202,
+      headers: HEADERS,
+      body: JSON.stringify(response),
+    };
+  } catch (error) {
+    console.error('summary-pipeline error:', error);
+    return {
+      statusCode: 500,
+      headers: HEADERS,
+      body: JSON.stringify({
+        error: 'Internal server error',
+        message: error.message,
+      }),
+    };
+  }
+};
+
+function handleGet(event) {
+  const params = event.queryStringParameters || {};
+  const summaryId = params.summary_id || params.id || params.summaryId;
+
+  if (!summaryId) {
+    return {
+      statusCode: 400,
+      headers: HEADERS,
+      body: JSON.stringify({ error: 'summary_id query parameter is required' }),
+    };
+  }
+
+  const record = summaryStore.get(summaryId);
+  if (!record) {
+    return {
+      statusCode: 404,
+      headers: HEADERS,
+      body: JSON.stringify({ error: 'Summary not found' }),
+    };
+  }
+
+  return {
+    statusCode: 200,
+    headers: HEADERS,
+    body: JSON.stringify({ summary: record }),
+  };
+}
+
+function parseJson(payload) {
+  if (!payload) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(payload);
+  } catch (error) {
+    console.error('Failed to parse payload', error);
+    return null;
+  }
+}
+
+function getRequestId(headers = {}) {
+  const existing = headers['x-request-id'] || headers['X-Request-ID'];
+  if (existing && typeof existing === 'string') {
+    return existing;
+  }
+
+  return `req_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function processSummarizationRequest(body, requestId) {
+  const diagnostics = [];
+  const startedAt = Date.now();
+
+  const document = normalizeDocument(body.document);
+  diagnostics.push({ stage: 'ingest', message: 'Document normalized', metadata: { docId: document.doc_id } });
+
+  const chunkConfig = {
+    chunkSize: clampNumber(body?.chunkConfig?.chunkSize, 800, 2000, 1200),
+    chunkOverlap: clampNumber(body?.chunkConfig?.chunkOverlap, 100, 400, 180),
+  };
+
+  const chunks = preprocessAndChunk(document, chunkConfig);
+  diagnostics.push({ stage: 'preprocess', message: 'Chunks generated', metadata: { chunkCount: chunks.length } });
+
+  const index = buildSearchIndex(chunks);
+  diagnostics.push({ stage: 'index', message: 'Index prepared', metadata: { tokenCount: index.totalTokens } });
+
+  const mode = buildMode(body.mode);
+  const detailPlan = getDetailPlan(mode.detail);
+
+  const query = buildQuery(body.query, mode, body.filters);
+  const retrieved = retrieveChunks(index, query, detailPlan.maxChunks);
+  diagnostics.push({ stage: 'retrieve', message: 'Chunks retrieved', metadata: { retrieved: retrieved.length } });
+
+  const orchestration = runOrchestration(retrieved, mode, detailPlan);
+  diagnostics.push({ stage: 'orchestrate', message: 'Summary generated', metadata: { sentenceCount: orchestration.sentences.length } });
+
+  const guardrails = runGuardrails(orchestration.summaryText, orchestration.citations, mode);
+  diagnostics.push({ stage: 'guardrails', message: 'Guardrails evaluated', metadata: guardrails });
+
+  const record = persistSummary(document, mode, orchestration, guardrails, requestId);
+  diagnostics.push({ stage: 'persist', message: 'Summary persisted', metadata: { summaryId: record.summary_id } });
+
+  const latencyMs = Date.now() - startedAt;
+
+  return {
+    summary: record,
+    diagnostics,
+    metrics: {
+      latencyMs,
+      chunkCount: chunks.length,
+      retrievedCount: retrieved.length,
+      citationDensity: orchestration.citations.length / Math.max(1, orchestration.sentences.length),
+      confidence: record.confidence,
+    },
+  };
+}
+
+function normalizeDocument(input = {}) {
+  const text = normalizeText(input.content || input.text || '');
+  if (!text) {
+    throw new Error('Document content is required');
+  }
+
+  const docId = input.doc_id || input.id || generateDeterministicId(text);
+  const title = input.title || 'Untitled Document';
+  const version = input.version || '1.0';
+  const docType = input.doc_type || input.type || 'Document';
+  const effectiveDate = input.effective_date || input.effectiveDate || new Date().toISOString().slice(0, 10);
+
+  return {
+    doc_id: docId,
+    title,
+    version,
+    doc_type: docType,
+    effective_date: effectiveDate,
+    owner: input.owner || 'unknown',
+    system_of_record: input.system_of_record || input.systemOfRecord || 'unspecified',
+    content: text,
+  };
+}
+
+function normalizeText(value) {
+  if (!value || typeof value !== 'string') {
+    return '';
+  }
+
+  return value
+    .replace(/\r\n/g, '\n')
+    .replace(/[\u0000-\u001f]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function generateDeterministicId(text) {
+  return crypto.createHash('sha1').update(text).digest('hex').slice(0, 16);
+}
+
+function clampNumber(value, min, max, fallback) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return fallback;
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
+function preprocessAndChunk(document, config) {
+  const paragraphs = document.content.split(/\n{2,}/).map(p => p.trim()).filter(Boolean);
+  const chunks = [];
+  let tokenCursor = 0;
+  let section = 'Introduction';
+  let buffer = [];
+  let bufferTokens = 0;
+  const chunkSize = config.chunkSize;
+  const overlap = config.chunkOverlap;
+
+  const paragraphTokens = paragraphs.map(p => ({
+    text: p,
+    tokens: tokenize(p),
+    isHeading: /^([0-9]+\.|#+|Section\s+\d+)/i.test(p),
+  }));
+
+  const pushChunk = () => {
+    if (buffer.length === 0) {
+      return;
+    }
+    const text = buffer.join(' ');
+    const tokens = tokenize(text);
+    const chunkId = `${document.doc_id}_c${chunks.length + 1}`;
+    const page = Math.max(1, Math.round(tokenCursor / 400) + 1);
+    chunks.push({
+      id: chunkId,
+      doc_id: document.doc_id,
+      section,
+      page,
+      text,
+      tokens,
+      tokenCount: tokens.length,
+      startToken: tokenCursor,
+      endToken: tokenCursor + tokens.length,
+    });
+    tokenCursor += Math.max(tokens.length - overlap, 0);
+    buffer = [];
+    bufferTokens = 0;
+  };
+
+  paragraphTokens.forEach((para) => {
+    if (para.isHeading) {
+      if (bufferTokens > chunkSize * 0.5) {
+        pushChunk();
+      }
+      section = para.text.replace(/^#+\s*/, '').split(/\.|:/)[0].trim() || section;
+      return;
+    }
+
+    if (bufferTokens + para.tokens.length > chunkSize && bufferTokens > 0) {
+      pushChunk();
+    }
+
+    buffer.push(para.text);
+    bufferTokens += para.tokens.length;
+  });
+
+  if (buffer.length > 0) {
+    pushChunk();
+  }
+
+  return chunks;
+}
+
+function tokenize(text) {
+  return text.split(/\s+/).filter(Boolean);
+}
+
+function buildSearchIndex(chunks) {
+  const vocabulary = new Map();
+  let totalTokens = 0;
+
+  chunks.forEach((chunk) => {
+    chunk.termFrequency = new Map();
+    chunk.tokens.forEach((token) => {
+      const normalized = token.toLowerCase().replace(/[^a-z0-9]/gi, '');
+      if (!normalized) {
+        return;
+      }
+      const prevCount = chunk.termFrequency.get(normalized) || 0;
+      chunk.termFrequency.set(normalized, prevCount + 1);
+      totalTokens += 1;
+      vocabulary.set(normalized, (vocabulary.get(normalized) || 0) + 1);
+    });
+  });
+
+  return {
+    chunks,
+    vocabulary,
+    totalTokens,
+  };
+}
+
+function buildMode(rawMode = {}) {
+  const role = ROLE_PROFILES[rawMode.role] ? rawMode.role : 'QA Lead';
+  const lens = LENS_KEYWORDS[rawMode.lens] ? rawMode.lens : 'Regulatory';
+  const detail = normalizeDetail(rawMode.detail);
+
+  return {
+    role,
+    lens,
+    detail,
+  };
+}
+
+function normalizeDetail(detail) {
+  if (!detail) {
+    return 'Standard';
+  }
+
+  const normalized = String(detail).trim().toLowerCase();
+  if (normalized.startsWith('brief')) {
+    return 'Brief';
+  }
+  if (normalized.startsWith('deep')) {
+    return 'Deep Dive';
+  }
+  return 'Standard';
+}
+
+function getDetailPlan(detail) {
+  const key = detail.toUpperCase();
+  return DETAIL_CONFIG[key] || DETAIL_CONFIG.STANDARD;
+}
+
+function buildQuery(userQuery = '', mode, filters = {}) {
+  const baseTerms = tokenize(userQuery.toLowerCase());
+  const roleTerms = ROLE_PROFILES[mode.role].keywords;
+  const lensTerms = LENS_KEYWORDS[mode.lens] || [];
+  const filterTerms = [];
+
+  if (filters?.tags && Array.isArray(filters.tags)) {
+    filters.tags.forEach(tag => filterTerms.push(String(tag).toLowerCase()));
+  }
+
+  if (filters?.sections && Array.isArray(filters.sections)) {
+    filters.sections.forEach(section => filterTerms.push(String(section).toLowerCase()));
+  }
+
+  const terms = [...new Set([...baseTerms, ...roleTerms, ...lensTerms, ...filterTerms].map((term) => term.toLowerCase()))]
+    .filter(Boolean);
+
+  return {
+    terms,
+    role: mode.role,
+    lens: mode.lens,
+  };
+}
+
+function retrieveChunks(index, query, maxChunks) {
+  const scored = index.chunks.map((chunk) => {
+    const score = scoreChunk(chunk, query.terms);
+    return {
+      ...chunk,
+      score,
+    };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, Math.max(maxChunks, 1));
+}
+
+function scoreChunk(chunk, terms) {
+  if (!terms || terms.length === 0) {
+    return chunk.tokenCount / Math.max(1, chunk.tokens.length);
+  }
+
+  let score = 0;
+  terms.forEach((term) => {
+    const normalized = term.toLowerCase().replace(/[^a-z0-9]/gi, '');
+    if (!normalized) {
+      return;
+    }
+    const frequency = chunk.termFrequency.get(normalized) || 0;
+    if (frequency > 0) {
+      score += Math.log(1 + frequency);
+    }
+  });
+
+  const coverageBonus = Math.min(0.5, chunk.tokenCount / 1500);
+  return score + coverageBonus;
+}
+
+function runOrchestration(chunks, mode, detailPlan) {
+  const extractiveSentences = extractSentences(chunks, detailPlan.targetSentences * 2);
+  const sentences = selectSentences(extractiveSentences, detailPlan.targetSentences);
+  const citations = buildCitations(sentences);
+  const summaryText = renderSummary(sentences, citations, mode);
+
+  return {
+    sentences,
+    citations,
+    summaryText,
+  };
+}
+
+function extractSentences(chunks, targetCount) {
+  const sentences = [];
+
+  chunks.forEach((chunk, index) => {
+    const parts = chunk.text.split(/(?<=[.!?])\s+/);
+    parts.forEach((sentence) => {
+      const normalized = sentence.trim();
+      if (!normalized) {
+        return;
+      }
+      const weight = chunk.score + Math.min(0.5, normalized.length / 500);
+      sentences.push({
+        text: normalized,
+        chunkId: chunk.id,
+        section: chunk.section,
+        page: chunk.page,
+        weight,
+        rawScore: chunk.score,
+        order: sentences.length,
+      });
+    });
+  });
+
+  sentences.sort((a, b) => b.weight - a.weight || a.order - b.order);
+  return sentences.slice(0, Math.max(targetCount, 1));
+}
+
+function selectSentences(sentences, targetCount) {
+  const result = [];
+  const seenSections = new Set();
+
+  sentences.forEach((sentence) => {
+    if (result.length >= targetCount) {
+      return;
+    }
+
+    const sectionKey = sentence.section.toLowerCase();
+    if (!seenSections.has(sectionKey) || result.length < targetCount / 2) {
+      result.push(sentence);
+      seenSections.add(sectionKey);
+    } else if (result.length < targetCount) {
+      result.push(sentence);
+    }
+  });
+
+  return result.slice(0, targetCount);
+}
+
+function buildCitations(sentences) {
+  const citations = [];
+  const seen = new Map();
+
+  sentences.forEach((sentence) => {
+    if (!seen.has(sentence.chunkId)) {
+      const citationNumber = seen.size + 1;
+      const citation = {
+        citationNumber,
+        chunk_id: sentence.chunkId,
+        section: sentence.section,
+        page: sentence.page,
+        preview: sentence.text.slice(0, 180),
+        score: Number(sentence.rawScore.toFixed(3)),
+      };
+      seen.set(sentence.chunkId, citation);
+      citations.push(citation);
+    }
+  });
+
+  return citations;
+}
+
+function renderSummary(sentences, citations, mode) {
+  const profile = ROLE_PROFILES[mode.role];
+  const citationLookup = new Map(citations.map((c) => [c.chunk_id, c.citationNumber]));
+
+  const grouped = profile.sections.map((sectionTitle) => ({
+    title: sectionTitle,
+    bullets: [],
+  }));
+
+  const defaultGroup = { title: 'Key Insights', bullets: [] };
+
+  sentences.forEach((sentence) => {
+    const citationNumber = citationLookup.get(sentence.chunkId);
+    const bullet = formatSentence(sentence.text, citationNumber, profile.tone);
+    const matchingGroup = grouped.find((group) => sentence.section.toLowerCase().includes(group.title.split('&')[0].toLowerCase()));
+    if (matchingGroup) {
+      matchingGroup.bullets.push(bullet);
+    } else {
+      defaultGroup.bullets.push(bullet);
+    }
+  });
+
+  const orderedGroups = [...grouped, defaultGroup].filter((group) => group.bullets.length > 0);
+
+  const lines = [];
+  orderedGroups.forEach((group) => {
+    lines.push(`### ${group.title}`);
+    group.bullets.forEach((bullet) => {
+      lines.push(`- ${bullet}`);
+    });
+    lines.push('');
+  });
+
+  return lines.join('\n').trim();
+}
+
+function formatSentence(text, citationNumber, tone) {
+  let sentence = text;
+  if (tone === 'accessible') {
+    sentence = sentence.replace(/\b(QA|CAPA|SOP|IQ|OQ|PQ)\b/g, (match) => `${match} (see glossary)`);
+  }
+
+  if (typeof citationNumber === 'number') {
+    return `${sentence} [${citationNumber}]`;
+  }
+
+  return sentence;
+}
+
+function runGuardrails(summaryText, citations, mode) {
+  const violations = [];
+
+  if (!summaryText || typeof summaryText !== 'string' || summaryText.trim().length === 0) {
+    violations.push({ code: 'EMPTY_SUMMARY', message: 'Summary text is empty' });
+  }
+
+  const citationDensity = citations.length / Math.max(1, (summaryText.match(/\[[0-9]+\]/g) || []).length);
+  const minDensity = ROLE_PROFILES[mode.role].minCitationDensity;
+  if (citationDensity < minDensity) {
+    violations.push({
+      code: 'LOW_CITATION_DENSITY',
+      message: `Citation density ${citationDensity.toFixed(2)} below threshold ${minDensity}`,
+    });
+  }
+
+  const piiMatches = summaryText.match(/\b\d{3}-\d{2}-\d{4}\b/g);
+  if (piiMatches) {
+    violations.push({ code: 'PII_DETECTED', message: 'Potential PII detected in summary output' });
+  }
+
+  return {
+    violations,
+    citationDensity,
+  };
+}
+
+function persistSummary(document, mode, orchestration, guardrails, requestId) {
+  const summaryId = `sum_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  const nowIso = new Date().toISOString();
+  const confidence = calculateConfidence(orchestration.citations, guardrails.violations);
+
+  const record = {
+    summary_id: summaryId,
+    doc_id: document.doc_id,
+    title: document.title,
+    mode,
+    model: 'acceleraqa-orchestrator-v1',
+    prompt_hash: crypto.createHash('sha256').update(`${document.doc_id}:${mode.role}:${mode.lens}`).digest('hex'),
+    citations: orchestration.citations,
+    confidence,
+    created_at: nowIso,
+    request_id: requestId,
+    summary: orchestration.summaryText,
+    guardrails,
+  };
+
+  summaryStore.set(summaryId, record);
+  return record;
+}
+
+function calculateConfidence(citations, violations) {
+  const base = citations.length > 0 ? 0.6 + Math.min(0.3, citations.length * 0.05) : 0.4;
+  const penalty = Math.min(0.3, (violations?.length || 0) * 0.1);
+  return Number(Math.max(0, base - penalty).toFixed(2));
+}

--- a/src/services/summaryPipelineService.js
+++ b/src/services/summaryPipelineService.js
@@ -1,0 +1,192 @@
+import { getToken, getUserId } from './authService';
+
+const DEFAULT_ENDPOINT = process.env.REACT_APP_SUMMARY_PIPELINE_ENDPOINT || '/.netlify/functions/summary-pipeline';
+
+const DETAIL_LEVELS = {
+  BRIEF: 'Brief',
+  STANDARD: 'Standard',
+  DEEP_DIVE: 'Deep Dive',
+};
+
+const DEFAULT_MODE = {
+  role: 'QA Lead',
+  lens: 'Regulatory',
+  detail: DETAIL_LEVELS.STANDARD,
+};
+
+export const buildSummaryRequest = ({ document, mode = {}, query = '', filters = {}, metadata = {} }) => {
+  if (!document || typeof document !== 'object') {
+    throw new Error('document metadata is required');
+  }
+
+  const rawContent = typeof document.content === 'string' ? document.content : document.text;
+  if (!rawContent || typeof rawContent !== 'string' || !rawContent.trim()) {
+    throw new Error('document content must be a non-empty string');
+  }
+
+  const content = rawContent.replace(/\r\n/g, '\n').trim();
+
+  const normalizedMode = {
+    role: typeof mode.role === 'string' ? mode.role : DEFAULT_MODE.role,
+    lens: typeof mode.lens === 'string' ? mode.lens : DEFAULT_MODE.lens,
+    detail: normalizeDetail(mode.detail),
+  };
+
+  const docId = document.doc_id || document.id || createDeterministicId(content);
+  const timestamp = new Date().toISOString();
+
+  return {
+    document: {
+      doc_id: docId,
+      title: document.title || 'Untitled Document',
+      version: document.version || '1.0',
+      doc_type: document.doc_type || document.type || 'Document',
+      owner: document.owner || 'unknown',
+      effective_date: document.effective_date || document.effectiveDate || timestamp.slice(0, 10),
+      system_of_record: document.system_of_record || document.systemOfRecord || 'unspecified',
+      content,
+    },
+    mode: normalizedMode,
+    query,
+    filters,
+    metadata: {
+      requestTimestamp: timestamp,
+      ...metadata,
+    },
+    chunkConfig: {
+      chunkSize: 1200,
+      chunkOverlap: 180,
+    },
+    requestId: createRequestId(),
+  };
+};
+
+class SummaryPipelineService {
+  constructor(endpoint = DEFAULT_ENDPOINT) {
+    this.endpoint = endpoint;
+  }
+
+  async createSummary(params) {
+    const payload = buildSummaryRequest(params);
+
+    const headers = await this.buildAuthHeaders();
+    const response = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        ...headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw await this.normalizeError(response);
+    }
+
+    return response.json();
+  }
+
+  async getSummary(summaryId) {
+    if (!summaryId || typeof summaryId !== 'string') {
+      throw new Error('summaryId must be provided');
+    }
+
+    const headers = await this.buildAuthHeaders();
+    const response = await fetch(`${this.endpoint}?summary_id=${encodeURIComponent(summaryId)}`, {
+      method: 'GET',
+      headers,
+    });
+
+    if (!response.ok) {
+      throw await this.normalizeError(response);
+    }
+
+    return response.json();
+  }
+
+  async buildAuthHeaders() {
+    const token = await getToken();
+    const userId = await getUserId();
+
+    if (!token) {
+      throw new Error('Authentication token is required to call the summary pipeline');
+    }
+    if (!userId) {
+      throw new Error('User identity is required to call the summary pipeline');
+    }
+
+    return {
+      Authorization: `Bearer ${token}`,
+      'x-user-id': userId,
+      'X-Client-Version': '2.1.0',
+    };
+  }
+
+  async normalizeError(response) {
+    let payload;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      payload = { error: response.statusText || 'Unknown error' };
+    }
+
+    const message = payload?.error || payload?.message || `Request failed with status ${response.status}`;
+    const error = new Error(message);
+    error.status = response.status;
+    error.details = payload;
+    return error;
+  }
+}
+
+function normalizeDetail(detail) {
+  if (!detail) {
+    return DETAIL_LEVELS.STANDARD;
+  }
+
+  const normalized = String(detail).trim().toLowerCase();
+  if (normalized.startsWith('brief')) {
+    return DETAIL_LEVELS.BRIEF;
+  }
+  if (normalized.startsWith('deep')) {
+    return DETAIL_LEVELS.DEEP_DIVE;
+  }
+  if (normalized.startsWith('standard')) {
+    return DETAIL_LEVELS.STANDARD;
+  }
+  return DETAIL_LEVELS.STANDARD;
+}
+
+function createDeterministicId(content) {
+  if (typeof globalThis !== 'undefined') {
+    const nativeCrypto = globalThis.crypto;
+    if (nativeCrypto && typeof nativeCrypto.randomUUID === 'function') {
+      const seeded = hashCode(content);
+      const uuidFragment = Math.abs(seeded).toString(16).padStart(12, '0').slice(0, 12);
+      return `doc_${uuidFragment}`;
+    }
+  }
+
+  return `doc_${Math.abs(hashCode(content)).toString(16).padStart(8, '0').slice(0, 12)}`;
+}
+
+function createRequestId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+
+  return `req_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function hashCode(value) {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return hash;
+}
+
+const summaryPipelineService = new SummaryPipelineService();
+
+export default summaryPipelineService;
+export { SummaryPipelineService, DETAIL_LEVELS };

--- a/src/services/summaryPipelineService.test.js
+++ b/src/services/summaryPipelineService.test.js
@@ -1,0 +1,107 @@
+import { jest } from '@jest/globals';
+
+let mockGetToken;
+let mockGetUserId;
+
+jest.mock('./authService', () => ({
+  getToken: (...args) => mockGetToken(...args),
+  getUserId: (...args) => mockGetUserId(...args),
+}));
+
+import summaryPipelineService, {
+  buildSummaryRequest,
+  DETAIL_LEVELS,
+  SummaryPipelineService,
+} from './summaryPipelineService';
+
+describe('buildSummaryRequest', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-09-09T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('normalizes document metadata and mode defaults', () => {
+    const payload = buildSummaryRequest({
+      document: {
+        title: 'Validation Plan',
+        content: 'Section 1. Overview.\n\nThis plan validates equipment.\n\nSection 2. Testing. IQ and OQ complete.',
+        owner: 'QA Team',
+      },
+      mode: { role: 'Auditor', detail: 'deep dive' },
+      query: 'Provide regulatory summary',
+    });
+
+    expect(payload.document.doc_id).toMatch(/^doc_/);
+    expect(payload.document.title).toBe('Validation Plan');
+    expect(payload.mode.role).toBe('Auditor');
+    expect(payload.mode.detail).toBe(DETAIL_LEVELS.DEEP_DIVE);
+    expect(payload.chunkConfig).toEqual({ chunkSize: 1200, chunkOverlap: 180 });
+    expect(payload.metadata.requestTimestamp).toBe('2025-09-09T12:00:00.000Z');
+    expect(typeof payload.requestId).toBe('string');
+  });
+
+  it('throws when content is missing', () => {
+    expect(() => buildSummaryRequest({ document: { title: 'Empty' } })).toThrow('document content must be a non-empty string');
+  });
+});
+
+describe('SummaryPipelineService', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    global.fetch = jest.fn();
+    mockGetToken = jest.fn().mockResolvedValue('token-123');
+    mockGetUserId = jest.fn().mockResolvedValue('user-456');
+  });
+
+  it('POSTs to create a summary with auth headers', async () => {
+    const fakeResponse = { summary: { summary_id: 'sum_abc' } };
+    fetch.mockResolvedValue({ ok: true, json: async () => fakeResponse });
+
+    const result = await summaryPipelineService.createSummary({
+      document: { title: 'Doc', content: 'A test document.' },
+      mode: { lens: 'Risk & CAPA' },
+      query: 'Highlight risks',
+    });
+
+    expect(result).toEqual(fakeResponse);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, options] = fetch.mock.calls[0];
+    expect(url).toContain('/.netlify/functions/summary-pipeline');
+    expect(options.method).toBe('POST');
+    expect(options.headers.Authorization).toBe('Bearer token-123');
+    expect(options.headers['x-user-id']).toBe('user-456');
+    expect(JSON.parse(options.body).mode.lens).toBe('Risk & CAPA');
+  });
+
+  it('throws normalized error when backend responds with failure', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: async () => ({ error: 'Unsupported mode' }),
+    });
+
+    await expect(summaryPipelineService.createSummary({
+      document: { content: 'text' },
+    })).rejects.toThrow('Unsupported mode');
+  });
+
+  it('retrieves a persisted summary by id', async () => {
+    fetch.mockResolvedValue({ ok: true, json: async () => ({ summary: { summary_id: 'sum_123' } }) });
+
+    const service = new SummaryPipelineService('https://api.example.com/summary-pipeline');
+    const result = await service.getSummary('sum_123');
+
+    expect(result.summary.summary_id).toBe('sum_123');
+    expect(fetch).toHaveBeenCalledWith('https://api.example.com/summary-pipeline?summary_id=sum_123', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer token-123',
+        'x-user-id': 'user-456',
+        'X-Client-Version': '2.1.0',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Netlify summary-pipeline function that ingests documents, chunks content, retrieves relevant sections, orchestrates multi-pass summarization, and persists guardrailed results
- add a client summaryPipelineService with helpers to normalize requests, call the pipeline, and fetch persisted summaries
- cover the service with targeted Jest tests for request shaping, success paths, and error handling

## Testing
- CI=true npm test -- summaryPipelineService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d67cf3fad8832abc2f5c136a897d55