### PR TITLE
Add frontend summary pipeline integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,15 @@ npm run build
 ## 📊 Performance Optimizations
 
 - **React.memo**: Prevent unnecessary re-renders
-- **useMemo**: Cache expensive calculations  
+- **useMemo**: Cache expensive calculations
 - **Lazy Loading**: Components loaded on demand
 - **Tree Shaking**: Optimized bundle size
 - **Service Workers**: Built-in with Create React App
+
+## 🧭 Architecture References
+
+- [AcceleraQA Summary-Generation Pipeline Architecture](docs/summary-generation-pipeline.md): end-to-end design for the role-aware, citation-backed summarization service that powers Ask Summarize, focus lenses, and downstream integrations.
+- [Front-end integration for the summary pipeline](docs/summary-pipeline-frontend.md): explains how the React client invokes the Netlify function, decodes document content, and renders summaries with guardrail diagnostics.
 
 ## 🧪 Key Features
 

--- a/docs/summary-generation-pipeline.md
+++ b/docs/summary-generation-pipeline.md
@@ -1,0 +1,250 @@
+# AcceleraQA Summary-Generation Pipeline Architecture
+
+## 0. Objectives
+- Deliver audit-ready summaries of QA and validation artifacts with precise source citations.
+- Tailor outputs for specific roles (Auditor, QA Lead, Engineer, New Hire) and intents (Executive brief, SOP synopsis, CAPA evidence, Training deck).
+- Integrate seamlessly with the Netlify-hosted AcceleraQA front-end and OpenAI File Search / vector databases.
+- Provide observability, guardrails, and optional human-in-the-loop (HITL) review.
+
+---
+
+## 1. User-Facing Modes
+- **Ask Summarize**: One-click summarization for PDF, DOCX, HTML, or Markdown documents with selectable detail levels (*Brief*, *Standard*, *Deep Dive*).
+- **Role Profiles**: Auditor, QA Lead, Engineer, and New Hire profiles adapt rubric, vocabulary, and filters.
+- **Focus Lenses**: *Regulatory*, *Risk & CAPA*, *Training*, *Timeline / Change Log*, *Testing & Evidence*.
+- **Interactive Refinement**: Expand or contract sections, toggle citation visibility, term explanations, version comparisons, and export actions.
+
+---
+
+## 2. High-Level Flow
+1. **Ingest** → 2. **Preprocess & Chunk** → 3. **Index** (Embeddings + metadata) → 4. **Retrieve** (query + role + lens) → 5. **Orchestrate** (multi-pass) → 6. **Generate** (extractive → abstractive) → 7. **Citations & Confidence** → 8. **Guardrails** → 9. **Human Review** → 10. **Persist & Export**.
+
+```
+Client → API → Ingestion svc → Parser → Chunker → Indexer (pgvector/OpenAI File Search)
+     → Retrieval svc → Orchestrator → LLM Workers → Citation Builder → Policy Guard
+     → Review Queue → Storage (NeonDB + S3/Blobs) → Exporters (Vault/Jira/GitHub)
+```
+
+---
+
+## 3. Component Responsibilities
+
+### 3.1 Ingestion Service
+- Source documents from OpenAI File Search, normalizing metadata: `doc_id`, `title`, `owner`, `version`, `effective_date`, `doc_type`, and `system_of_record`.
+- Persist raw bytes in object storage (Netlify Blobs or S3) and record hashes for deduplication.
+
+### 3.2 Preprocessing & Chunking
+- Convert documents to rich text with heading, table, and caption structure while retaining page and paragraph anchors.
+- Apply adaptive chunking (800–1600 tokens with overlap) with boundary boosts at headings and tables.
+- Tag each chunk with metadata (`doc_id`, `section`, `page`, `tags`, `version`).
+
+### 3.3 Index Layer
+- Maintain a vector index (pgvector on NeonDB or OpenAI embeddings) using schema `chunks(id, doc_id, section, page, vector, text, version, tags jsonb)`.
+- Maintain keyword and metadata search via Postgres GIN indexes on `text`, `tags`, `doc_type`, and `version`.
+- Re-embed on updates with transactional upserts keyed by `doc_id` + `hash`.
+
+### 3.4 Retrieval Service
+- Perform hybrid retrieval: semantic kNN + BM25, reranked via cross-encoder.
+- Compose queries from user prompt, role profile rubric, and focus lens constraints, respecting time/version filters.
+- Return diversified top-N chunks (18–30) by section.
+
+### 3.5 Orchestrator (Multi-Pass)
+- **Pass A – Extractive**: Select salient sentences and entities (systems, dates, owners, deviations, regulations).
+- **Pass B – Abstractive**: Compose narratives tailored by role and lens.
+- **Pass C – Evidence & Citations**: Map claims to chunk anchors with confidence scores.
+- **Pass D – Tailoring**: Adjust style, length, glossaries, and role-specific inserts (e.g., risk tables for QA Lead).
+
+### 3.6 Guardrails & Compliance
+- Detect and redact PII/PHI using pattern and ML approaches (configurable per environment).
+- Enforce claim grounding (no uncited statements in Auditor mode) and mark speculative language.
+- Block edits to regulated content and expose confidence bands.
+
+### 3.7 Human Review & Approvals
+- Optional review queue with diff view versus prior summaries.
+- Allow reviewers to pin/unpin citations, edit text, and add notes.
+- Capture audit evidence: reviewer, timestamp, changes.
+
+### 3.8 Persistence & Exports
+- Store `summary_id`, `doc_id`, `mode`, `model`, `prompt_hash`, `citations`, `confidence`, `created_by`, and `checksum` in NeonDB.
+- Support exports to DOCX, PDF, HTML, and integrations with Vault, Jira, and GitHub.
+
+### 3.9 Observability
+- Track latency, token usage, retrieval MRR, section coverage, and citation density.
+- Capture traces with prompt details, retrieved chunk IDs, and model version via OpenTelemetry.
+- Provide dashboards for drift and failure analysis.
+
+---
+
+## 4. Data Contracts
+
+### 4.1 Chunk Metadata
+```json
+{
+  "doc_id": "VEEVA-000123",
+  "version": "3.1",
+  "doc_type": "SOP",
+  "page": 12,
+  "section": "4.2 Risk Assessment",
+  "tags": ["21 CFR 11", "Annex 11", "risk", "CAPA"],
+  "effective_date": "2025-03-01"
+}
+```
+
+### 4.2 Summary Record
+```json
+{
+  "summary_id": "SUM-9f3c",
+  "doc_id": "VEEVA-000123",
+  "mode": {"role": "Auditor", "lens": "Regulatory", "detail": "Standard"},
+  "model": "gpt-5-mini",
+  "prompt_hash": "sha256:...",
+  "citations": [
+    {"page": 12, "section": "4.2", "chunk_id": "c-01", "score": 0.91},
+    {"page": 18, "section": "5.1", "chunk_id": "c-07", "score": 0.86}
+  ],
+  "confidence": 0.88,
+  "created_at": "2025-09-25T13:30:00Z"
+}
+```
+
+---
+
+## 5. Prompting & Rubrics
+- **System Prompt**: “You are AcceleraQA’s summarizer. Write concise, audit-ready summaries grounded ONLY in provided chunks. For each claim, include a citation map {section/page}. If evidence is insufficient, state that explicitly. Adapt to role and lens.”
+- **Role Rubrics**:
+  - Auditor: compliance obligations, signatures, dates, deviations, CAPA actions, acceptance criteria.
+  - QA Lead: risk items, mitigation status, due dates, owner matrix, blockers, change control summary.
+  - Engineer: test coverage, defects, environment/config deltas, pipeline evidence, logs.
+  - New Hire: purpose, context, definitions, responsibilities, training links.
+- **Citation Template**: `[Citation] Statement → (Doc: {doc_id}, Sec {section}, p.{page})`.
+
+---
+
+## 6. Algorithms & Models
+- **Embeddings**: `text-embedding-3-large` (or pgvector-compatible) with periodic refreshes.
+- **Reranking**: Cross-encoder (e.g., MiniLM) for top-k relevance boosts.
+- **LLMs**: `gpt-5` or `gpt-5-mini`, with `mini` used for batch jobs and full model for high-stakes modes.
+- **Extractive Pass**: TextRank + NER (dates, people, systems, regulations, risk terms).
+- **Factuality Check**: QAG to ensure each sentence is grounded in retrieved context.
+
+---
+
+## 7. Evaluation & QA
+- **Coverage**: Ensure summaries address major sections (heading heuristics).
+- **Citations**: Citation density ≥0.7 for Auditor mode; ≥0.4 otherwise.
+- **Factuality**: Automated contradiction detection keeps hallucination rate below threshold.
+- **Human Ratings**: Collect role-specific scores and edit deltas for iterative tuning.
+- **Regression Suite**: Golden documents with expected outputs.
+
+---
+
+## 8. Guardrails & Policy
+- PII/PHI policies: redact or gate access with audit logs.
+- Regulatory language detector ensures mandated disclaimers are present.
+- Safety classifier monitors free-text inputs for prohibited content.
+
+---
+
+## 9. CI/CD & Automation Hooks
+- Regenerate summaries upon document version updates (Vault/GitHub webhooks).
+- Apply PR checks that post engineering-mode summaries for spec changes.
+- Run nightly jobs to rescore embeddings, refresh indices, and detect staleness.
+
+---
+
+## 10. Security & Access Control
+- Enforce row-level security by `system_of_record` and user role.
+- Provide signed, time-bound URLs for citation anchors with audit logging.
+- Manage secrets via Netlify environment variables and encrypt raw bytes/embeddings with KMS.
+
+---
+
+## 11. API Surface
+- **POST /summaries** → `202 Accepted {summary_id}` with body `{ doc_id, role, lens, detail, version?, sections?, language? }`.
+- **GET /summaries/{id}** → Retrieve summary text, citations, confidence, export options.
+- **POST /refine** → Return updated sections with new citations for follow-up queries.
+
+---
+
+## 12. Configuration Examples
+
+### Role & Lens Config (YAML)
+```yaml
+roles:
+  Auditor:
+    min_citation_density: 0.7
+    max_len_tokens: 1200
+    include: [obligations, signatures, dates, deviations, capa]
+  QA_Lead:
+    min_citation_density: 0.5
+    max_len_tokens: 900
+    include: [risks, owners, due_dates, changes]
+lenses:
+  Regulatory:
+    regex_boost: ["21 CFR 11", "Annex 11", "ICH E6"]
+  Risk_CAPA:
+    regex_boost: ["risk", "severity", "impact", "CAPA", "deviation"]
+```
+
+### Chunker Config (YAML)
+```yaml
+chunk_size: 1200
+chunk_overlap: 180
+respect_headings: true
+keep_tables: true
+anchors: ["H1", "H2", "Table", "Figure"]
+```
+
+---
+
+## 13. Core Orchestration (Pseudo-code)
+```ts
+const summarize = async (req) => {
+  const profile = loadProfile(req.role, req.lens, req.detail);
+  const query = buildQuery(req, profile);
+  const chunks = await hybridRetrieve(query, req.doc_id, req.version);
+
+  const extractive = await llmExtractive(chunks, profile);
+  const abstractive = await llmAbstractive(extractive, profile);
+
+  const citations = mapCitations(abstractive, chunks);
+  const guarded = await applyGuardrails(abstractive, citations, profile);
+
+  const confidence = scoreConfidence(guarded, citations, chunks);
+  const record = await persistSummary(req, guarded, citations, confidence);
+
+  emitEvent("summary.created", record);
+  return record;
+};
+```
+
+---
+
+## 14. Performance & Cost Controls
+- Cache retrieval results per (`doc_id`, `version`, `lens`, `role`).
+- Batch process with `gpt-5-mini`, upgrading to `gpt-5` for Auditor or on-demand needs.
+- Optimize prompts for token efficiency and enforce response length caps.
+- Tier storage to balance cost for cold or archived documents.
+
+---
+
+## 15. Integration Blueprints
+- **Veeva Vault**: Trigger summary regeneration on document status changes; attach summaries and maintain cross-links.
+- **Jira / YPT**: Insert summaries into ticket descriptions with citations; auto-update on document changes.
+- **GitHub**: Post engineering-mode summaries on pull requests with evidence links.
+
+---
+
+## 16. Roadmap Enhancements
+- Version-to-version diff summaries with change rationale.
+- Multilingual summary support for global audits.
+- Template-driven executive briefs for QBRs.
+- Explainable retrieval visualizations (saliency heatmaps).
+
+---
+
+## 17. MVP Acceptance Criteria
+- Role/lens summaries achieve ≥0.5 citation density and ≤2% hallucination on golden set.
+- End-to-end latency ≤8s for Standard detail on 50-page documents (warm cache).
+- Vault and Jira exports functioning end-to-end.
+- Observability dashboard exposes retrieval coverage and token usage per summary.

--- a/docs/summary-pipeline-frontend.md
+++ b/docs/summary-pipeline-frontend.md
@@ -1,0 +1,83 @@
+# Front-end integration for the AcceleraQA summary pipeline
+
+This guide explains how the React client invokes the Netlify-hosted summary pipeline, renders multi-pass outputs, and exposes guardrail feedback for QA teams. Use it alongside the [runtime architecture reference](summary-generation-pipeline.md) when building new surfaces that need citation-backed summaries.
+
+## Entry point: RAG configuration screen
+
+* Component: [`SummaryRequestPanel`](../src/components/SummaryRequestPanel.js)
+* Mounted inside the RAG configuration page so document admins can trial summaries before surfacing them elsewhere.
+* Reads the current document inventory, fetches document text, and lets the operator tailor **role**, **lens**, **detail**, query boosts, and filters before calling the pipeline.
+
+Rendered layout:
+
+```
+RAGConfigurationPage
+ └── SummaryRequestPanel
+      ├── Document selector (pulls from ragService.getDocuments)
+      ├── Mode controls (role / lens / detail)
+      ├── Retrieval filters (query + tags + sections)
+      ├── Editable content textarea (pre-filled via ragService.downloadDocument)
+      └── Output dashboard (summary markdown + citations + guardrails + diagnostics)
+```
+
+## Hook: `useSummaryPipeline`
+
+Located at [`src/hooks/useSummaryPipeline.js`](../src/hooks/useSummaryPipeline.js), the hook centralises pipeline calls and normalises state:
+
+* **requestSummary** – shapes the payload, forwards authentication headers via `summaryPipelineService`, and tracks `status`, `metrics`, `diagnostics`, and the persisted summary record.
+* **fetchSummary** – hydrates historical runs by `summary_id`.
+* **reset** – clears cached output when the operator tweaks source content or switches documents.
+* Exposes canonical **role**, **lens**, and **detail** lists so the UI stays aligned with backend rubrics.
+
+Usage snippet:
+
+```jsx
+const {
+  requestSummary,
+  fetchSummary,
+  status,
+  summary,
+  diagnostics,
+  metrics,
+  roleOptions,
+  lensOptions,
+  detailOptions,
+} = useSummaryPipeline();
+
+await requestSummary({
+  document: { ...metadata, content },
+  mode: { role, lens, detail },
+  query,
+  filters: { tags, sections },
+  metadata: { sourceDocumentId },
+});
+```
+
+## Document content workflow
+
+1. The panel calls `ragService.downloadDocument` with the selected document ID.
+2. The helper [`decodeDocumentContent`](../src/utils/documentTextUtils.js) converts the returned base64 payload into summarizable text and surfaces lossy warnings when dealing with PDFs or DOCX files.
+3. Operators can edit the textarea before the request, enabling quick iteration without re-uploading.
+
+## Request → render lifecycle
+
+1. **Submit** – UI disables the primary CTA, shows pipeline activity copy, and stores the mode/query filters that shaped the call.
+2. **Pipeline response** – The Netlify function returns `{ summary, diagnostics, metrics }`. The hook caches everything for downstream renders.
+3. **Output dashboard** – The panel:
+   * Renders markdown-style text in a dark code block.
+   * Lists citations with section/page anchors and confidence scores.
+   * Surfaces guardrail violations (e.g., low citation density) or confirms a clean pass.
+   * Shows stage-by-stage diagnostics for observability.
+4. **Copy / reset** – Users can copy the summary to the clipboard or reset the state to start a new run.
+
+## Extending the experience
+
+* To embed summaries in other screens (e.g., chat replies or ticket exports) reuse `useSummaryPipeline` and the `decodeDocumentContent` helper to keep payloads consistent.
+* Guardrail and diagnostics cards are separated so additional visualisations (sparkline latency, citation charts) can be slotted in without changing the hook API.
+* When enabling automated refreshes, call `fetchSummary(summaryId)` during hydration instead of rerunning the pipeline.
+
+## Troubleshooting tips
+
+* **Binary files look garbled** – the lossy conversion warning signals that a server-side text extraction step should be added for PDFs/DOCX before summarisation.
+* **Auth failures** – the hook surfaces errors from `summaryPipelineService`, so check the Auth0 session and Netlify logs.
+* **Missing citations** – review diagnostics to confirm retrieval returned enough chunks and adjust tag/section filters accordingly.

--- a/netlify/functions/summary-pipeline.js
+++ b/netlify/functions/summary-pipeline.js
@@ -1,0 +1,622 @@
+const crypto = require('crypto');
+
+const HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-user-id, X-Request-ID',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Content-Type': 'application/json',
+};
+
+const ROLE_PROFILES = {
+  Auditor: {
+    keywords: ['compliance', 'deviation', 'capa', 'audit', 'signature', 'approval', 'validation'],
+    tone: 'formal',
+    minCitationDensity: 0.7,
+    sections: ['Compliance Obligations', 'Deviations & CAPA', 'Approvals & Timelines'],
+  },
+  'QA Lead': {
+    keywords: ['risk', 'mitigation', 'owner', 'due date', 'change control', 'blocker'],
+    tone: 'pragmatic',
+    minCitationDensity: 0.5,
+    sections: ['Risk Posture', 'Mitigations & Owners', 'Open Actions'],
+  },
+  Engineer: {
+    keywords: ['test', 'defect', 'environment', 'configuration', 'log', 'pipeline'],
+    tone: 'technical',
+    minCitationDensity: 0.4,
+    sections: ['Testing Summary', 'Defects & Evidence', 'Environment Notes'],
+  },
+  'New Hire': {
+    keywords: ['overview', 'definition', 'context', 'role', 'training'],
+    tone: 'accessible',
+    minCitationDensity: 0.4,
+    sections: ['Purpose & Scope', 'Key Responsibilities', 'Training Pointers'],
+  },
+};
+
+const LENS_KEYWORDS = {
+  Regulatory: ['21 cfr 11', 'annex 11', 'part 820', 'inspection', 'submission'],
+  'Risk & CAPA': ['risk', 'severity', 'impact', 'capa', 'root cause'],
+  Training: ['training', 'curriculum', 'onboarding', 'lesson'],
+  'Timeline/Change log': ['timeline', 'change', 'revision', 'effective date'],
+  'Testing & Evidence': ['test', 'iq', 'oq', 'pq', 'evidence', 'protocol'],
+};
+
+const DETAIL_CONFIG = {
+  BRIEF: { targetSentences: 4, maxChunks: 8 },
+  STANDARD: { targetSentences: 6, maxChunks: 14 },
+  'DEEP DIVE': { targetSentences: 10, maxChunks: 24 },
+};
+
+const summaryStore = new Map();
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: HEADERS,
+      body: JSON.stringify({ message: 'CORS preflight' }),
+    };
+  }
+
+  try {
+    if (event.httpMethod === 'GET') {
+      return handleGet(event);
+    }
+
+    if (event.httpMethod !== 'POST') {
+      return {
+        statusCode: 405,
+        headers: HEADERS,
+        body: JSON.stringify({ error: 'Method not allowed' }),
+      };
+    }
+
+    const body = parseJson(event.body);
+    if (!body) {
+      return {
+        statusCode: 400,
+        headers: HEADERS,
+        body: JSON.stringify({ error: 'Invalid JSON payload' }),
+      };
+    }
+
+    const requestId = getRequestId(event.headers);
+    const response = processSummarizationRequest(body, requestId);
+
+    return {
+      statusCode: 202,
+      headers: HEADERS,
+      body: JSON.stringify(response),
+    };
+  } catch (error) {
+    console.error('summary-pipeline error:', error);
+    return {
+      statusCode: 500,
+      headers: HEADERS,
+      body: JSON.stringify({
+        error: 'Internal server error',
+        message: error.message,
+      }),
+    };
+  }
+};
+
+function handleGet(event) {
+  const params = event.queryStringParameters || {};
+  const summaryId = params.summary_id || params.id || params.summaryId;
+
+  if (!summaryId) {
+    return {
+      statusCode: 400,
+      headers: HEADERS,
+      body: JSON.stringify({ error: 'summary_id query parameter is required' }),
+    };
+  }
+
+  const record = summaryStore.get(summaryId);
+  if (!record) {
+    return {
+      statusCode: 404,
+      headers: HEADERS,
+      body: JSON.stringify({ error: 'Summary not found' }),
+    };
+  }
+
+  return {
+    statusCode: 200,
+    headers: HEADERS,
+    body: JSON.stringify({ summary: record }),
+  };
+}
+
+function parseJson(payload) {
+  if (!payload) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(payload);
+  } catch (error) {
+    console.error('Failed to parse payload', error);
+    return null;
+  }
+}
+
+function getRequestId(headers = {}) {
+  const existing = headers['x-request-id'] || headers['X-Request-ID'];
+  if (existing && typeof existing === 'string') {
+    return existing;
+  }
+
+  return `req_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function processSummarizationRequest(body, requestId) {
+  const diagnostics = [];
+  const startedAt = Date.now();
+
+  const document = normalizeDocument(body.document);
+  diagnostics.push({ stage: 'ingest', message: 'Document normalized', metadata: { docId: document.doc_id } });
+
+  const chunkConfig = {
+    chunkSize: clampNumber(body?.chunkConfig?.chunkSize, 800, 2000, 1200),
+    chunkOverlap: clampNumber(body?.chunkConfig?.chunkOverlap, 100, 400, 180),
+  };
+
+  const chunks = preprocessAndChunk(document, chunkConfig);
+  diagnostics.push({ stage: 'preprocess', message: 'Chunks generated', metadata: { chunkCount: chunks.length } });
+
+  const index = buildSearchIndex(chunks);
+  diagnostics.push({ stage: 'index', message: 'Index prepared', metadata: { tokenCount: index.totalTokens } });
+
+  const mode = buildMode(body.mode);
+  const detailPlan = getDetailPlan(mode.detail);
+
+  const query = buildQuery(body.query, mode, body.filters);
+  const retrieved = retrieveChunks(index, query, detailPlan.maxChunks);
+  diagnostics.push({ stage: 'retrieve', message: 'Chunks retrieved', metadata: { retrieved: retrieved.length } });
+
+  const orchestration = runOrchestration(retrieved, mode, detailPlan);
+  diagnostics.push({ stage: 'orchestrate', message: 'Summary generated', metadata: { sentenceCount: orchestration.sentences.length } });
+
+  const guardrails = runGuardrails(orchestration.summaryText, orchestration.citations, mode);
+  diagnostics.push({ stage: 'guardrails', message: 'Guardrails evaluated', metadata: guardrails });
+
+  const record = persistSummary(document, mode, orchestration, guardrails, requestId);
+  diagnostics.push({ stage: 'persist', message: 'Summary persisted', metadata: { summaryId: record.summary_id } });
+
+  const latencyMs = Date.now() - startedAt;
+
+  return {
+    summary: record,
+    diagnostics,
+    metrics: {
+      latencyMs,
+      chunkCount: chunks.length,
+      retrievedCount: retrieved.length,
+      citationDensity: orchestration.citations.length / Math.max(1, orchestration.sentences.length),
+      confidence: record.confidence,
+    },
+  };
+}
+
+function normalizeDocument(input = {}) {
+  const text = normalizeText(input.content || input.text || '');
+  if (!text) {
+    throw new Error('Document content is required');
+  }
+
+  const docId = input.doc_id || input.id || generateDeterministicId(text);
+  const title = input.title || 'Untitled Document';
+  const version = input.version || '1.0';
+  const docType = input.doc_type || input.type || 'Document';
+  const effectiveDate = input.effective_date || input.effectiveDate || new Date().toISOString().slice(0, 10);
+
+  return {
+    doc_id: docId,
+    title,
+    version,
+    doc_type: docType,
+    effective_date: effectiveDate,
+    owner: input.owner || 'unknown',
+    system_of_record: input.system_of_record || input.systemOfRecord || 'unspecified',
+    content: text,
+  };
+}
+
+function normalizeText(value) {
+  if (!value || typeof value !== 'string') {
+    return '';
+  }
+
+  return value
+    .replace(/\r\n/g, '\n')
+    .replace(/[\u0000-\u001f]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function generateDeterministicId(text) {
+  return crypto.createHash('sha1').update(text).digest('hex').slice(0, 16);
+}
+
+function clampNumber(value, min, max, fallback) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return fallback;
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
+function preprocessAndChunk(document, config) {
+  const paragraphs = document.content.split(/\n{2,}/).map(p => p.trim()).filter(Boolean);
+  const chunks = [];
+  let tokenCursor = 0;
+  let section = 'Introduction';
+  let buffer = [];
+  let bufferTokens = 0;
+  const chunkSize = config.chunkSize;
+  const overlap = config.chunkOverlap;
+
+  const paragraphTokens = paragraphs.map(p => ({
+    text: p,
+    tokens: tokenize(p),
+    isHeading: /^([0-9]+\.|#+|Section\s+\d+)/i.test(p),
+  }));
+
+  const pushChunk = () => {
+    if (buffer.length === 0) {
+      return;
+    }
+    const text = buffer.join(' ');
+    const tokens = tokenize(text);
+    const chunkId = `${document.doc_id}_c${chunks.length + 1}`;
+    const page = Math.max(1, Math.round(tokenCursor / 400) + 1);
+    chunks.push({
+      id: chunkId,
+      doc_id: document.doc_id,
+      section,
+      page,
+      text,
+      tokens,
+      tokenCount: tokens.length,
+      startToken: tokenCursor,
+      endToken: tokenCursor + tokens.length,
+    });
+    tokenCursor += Math.max(tokens.length - overlap, 0);
+    buffer = [];
+    bufferTokens = 0;
+  };
+
+  paragraphTokens.forEach((para) => {
+    if (para.isHeading) {
+      if (bufferTokens > chunkSize * 0.5) {
+        pushChunk();
+      }
+      section = para.text.replace(/^#+\s*/, '').split(/\.|:/)[0].trim() || section;
+      return;
+    }
+
+    if (bufferTokens + para.tokens.length > chunkSize && bufferTokens > 0) {
+      pushChunk();
+    }
+
+    buffer.push(para.text);
+    bufferTokens += para.tokens.length;
+  });
+
+  if (buffer.length > 0) {
+    pushChunk();
+  }
+
+  return chunks;
+}
+
+function tokenize(text) {
+  return text.split(/\s+/).filter(Boolean);
+}
+
+function buildSearchIndex(chunks) {
+  const vocabulary = new Map();
+  let totalTokens = 0;
+
+  chunks.forEach((chunk) => {
+    chunk.termFrequency = new Map();
+    chunk.tokens.forEach((token) => {
+      const normalized = token.toLowerCase().replace(/[^a-z0-9]/gi, '');
+      if (!normalized) {
+        return;
+      }
+      const prevCount = chunk.termFrequency.get(normalized) || 0;
+      chunk.termFrequency.set(normalized, prevCount + 1);
+      totalTokens += 1;
+      vocabulary.set(normalized, (vocabulary.get(normalized) || 0) + 1);
+    });
+  });
+
+  return {
+    chunks,
+    vocabulary,
+    totalTokens,
+  };
+}
+
+function buildMode(rawMode = {}) {
+  const role = ROLE_PROFILES[rawMode.role] ? rawMode.role : 'QA Lead';
+  const lens = LENS_KEYWORDS[rawMode.lens] ? rawMode.lens : 'Regulatory';
+  const detail = normalizeDetail(rawMode.detail);
+
+  return {
+    role,
+    lens,
+    detail,
+  };
+}
+
+function normalizeDetail(detail) {
+  if (!detail) {
+    return 'Standard';
+  }
+
+  const normalized = String(detail).trim().toLowerCase();
+  if (normalized.startsWith('brief')) {
+    return 'Brief';
+  }
+  if (normalized.startsWith('deep')) {
+    return 'Deep Dive';
+  }
+  return 'Standard';
+}
+
+function getDetailPlan(detail) {
+  const key = detail.toUpperCase();
+  return DETAIL_CONFIG[key] || DETAIL_CONFIG.STANDARD;
+}
+
+function buildQuery(userQuery = '', mode, filters = {}) {
+  const baseTerms = tokenize(userQuery.toLowerCase());
+  const roleTerms = ROLE_PROFILES[mode.role].keywords;
+  const lensTerms = LENS_KEYWORDS[mode.lens] || [];
+  const filterTerms = [];
+
+  if (filters?.tags && Array.isArray(filters.tags)) {
+    filters.tags.forEach(tag => filterTerms.push(String(tag).toLowerCase()));
+  }
+
+  if (filters?.sections && Array.isArray(filters.sections)) {
+    filters.sections.forEach(section => filterTerms.push(String(section).toLowerCase()));
+  }
+
+  const terms = [...new Set([...baseTerms, ...roleTerms, ...lensTerms, ...filterTerms].map((term) => term.toLowerCase()))]
+    .filter(Boolean);
+
+  return {
+    terms,
+    role: mode.role,
+    lens: mode.lens,
+  };
+}
+
+function retrieveChunks(index, query, maxChunks) {
+  const scored = index.chunks.map((chunk) => {
+    const score = scoreChunk(chunk, query.terms);
+    return {
+      ...chunk,
+      score,
+    };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, Math.max(maxChunks, 1));
+}
+
+function scoreChunk(chunk, terms) {
+  if (!terms || terms.length === 0) {
+    return chunk.tokenCount / Math.max(1, chunk.tokens.length);
+  }
+
+  let score = 0;
+  terms.forEach((term) => {
+    const normalized = term.toLowerCase().replace(/[^a-z0-9]/gi, '');
+    if (!normalized) {
+      return;
+    }
+    const frequency = chunk.termFrequency.get(normalized) || 0;
+    if (frequency > 0) {
+      score += Math.log(1 + frequency);
+    }
+  });
+
+  const coverageBonus = Math.min(0.5, chunk.tokenCount / 1500);
+  return score + coverageBonus;
+}
+
+function runOrchestration(chunks, mode, detailPlan) {
+  const extractiveSentences = extractSentences(chunks, detailPlan.targetSentences * 2);
+  const sentences = selectSentences(extractiveSentences, detailPlan.targetSentences);
+  const citations = buildCitations(sentences);
+  const summaryText = renderSummary(sentences, citations, mode);
+
+  return {
+    sentences,
+    citations,
+    summaryText,
+  };
+}
+
+function extractSentences(chunks, targetCount) {
+  const sentences = [];
+
+  chunks.forEach((chunk, index) => {
+    const parts = chunk.text.split(/(?<=[.!?])\s+/);
+    parts.forEach((sentence) => {
+      const normalized = sentence.trim();
+      if (!normalized) {
+        return;
+      }
+      const weight = chunk.score + Math.min(0.5, normalized.length / 500);
+      sentences.push({
+        text: normalized,
+        chunkId: chunk.id,
+        section: chunk.section,
+        page: chunk.page,
+        weight,
+        rawScore: chunk.score,
+        order: sentences.length,
+      });
+    });
+  });
+
+  sentences.sort((a, b) => b.weight - a.weight || a.order - b.order);
+  return sentences.slice(0, Math.max(targetCount, 1));
+}
+
+function selectSentences(sentences, targetCount) {
+  const result = [];
+  const seenSections = new Set();
+
+  sentences.forEach((sentence) => {
+    if (result.length >= targetCount) {
+      return;
+    }
+
+    const sectionKey = sentence.section.toLowerCase();
+    if (!seenSections.has(sectionKey) || result.length < targetCount / 2) {
+      result.push(sentence);
+      seenSections.add(sectionKey);
+    } else if (result.length < targetCount) {
+      result.push(sentence);
+    }
+  });
+
+  return result.slice(0, targetCount);
+}
+
+function buildCitations(sentences) {
+  const citations = [];
+  const seen = new Map();
+
+  sentences.forEach((sentence) => {
+    if (!seen.has(sentence.chunkId)) {
+      const citationNumber = seen.size + 1;
+      const citation = {
+        citationNumber,
+        chunk_id: sentence.chunkId,
+        section: sentence.section,
+        page: sentence.page,
+        preview: sentence.text.slice(0, 180),
+        score: Number(sentence.rawScore.toFixed(3)),
+      };
+      seen.set(sentence.chunkId, citation);
+      citations.push(citation);
+    }
+  });
+
+  return citations;
+}
+
+function renderSummary(sentences, citations, mode) {
+  const profile = ROLE_PROFILES[mode.role];
+  const citationLookup = new Map(citations.map((c) => [c.chunk_id, c.citationNumber]));
+
+  const grouped = profile.sections.map((sectionTitle) => ({
+    title: sectionTitle,
+    bullets: [],
+  }));
+
+  const defaultGroup = { title: 'Key Insights', bullets: [] };
+
+  sentences.forEach((sentence) => {
+    const citationNumber = citationLookup.get(sentence.chunkId);
+    const bullet = formatSentence(sentence.text, citationNumber, profile.tone);
+    const matchingGroup = grouped.find((group) => sentence.section.toLowerCase().includes(group.title.split('&')[0].toLowerCase()));
+    if (matchingGroup) {
+      matchingGroup.bullets.push(bullet);
+    } else {
+      defaultGroup.bullets.push(bullet);
+    }
+  });
+
+  const orderedGroups = [...grouped, defaultGroup].filter((group) => group.bullets.length > 0);
+
+  const lines = [];
+  orderedGroups.forEach((group) => {
+    lines.push(`### ${group.title}`);
+    group.bullets.forEach((bullet) => {
+      lines.push(`- ${bullet}`);
+    });
+    lines.push('');
+  });
+
+  return lines.join('\n').trim();
+}
+
+function formatSentence(text, citationNumber, tone) {
+  let sentence = text;
+  if (tone === 'accessible') {
+    sentence = sentence.replace(/\b(QA|CAPA|SOP|IQ|OQ|PQ)\b/g, (match) => `${match} (see glossary)`);
+  }
+
+  if (typeof citationNumber === 'number') {
+    return `${sentence} [${citationNumber}]`;
+  }
+
+  return sentence;
+}
+
+function runGuardrails(summaryText, citations, mode) {
+  const violations = [];
+
+  if (!summaryText || typeof summaryText !== 'string' || summaryText.trim().length === 0) {
+    violations.push({ code: 'EMPTY_SUMMARY', message: 'Summary text is empty' });
+  }
+
+  const citationDensity = citations.length / Math.max(1, (summaryText.match(/\[[0-9]+\]/g) || []).length);
+  const minDensity = ROLE_PROFILES[mode.role].minCitationDensity;
+  if (citationDensity < minDensity) {
+    violations.push({
+      code: 'LOW_CITATION_DENSITY',
+      message: `Citation density ${citationDensity.toFixed(2)} below threshold ${minDensity}`,
+    });
+  }
+
+  const piiMatches = summaryText.match(/\b\d{3}-\d{2}-\d{4}\b/g);
+  if (piiMatches) {
+    violations.push({ code: 'PII_DETECTED', message: 'Potential PII detected in summary output' });
+  }
+
+  return {
+    violations,
+    citationDensity,
+  };
+}
+
+function persistSummary(document, mode, orchestration, guardrails, requestId) {
+  const summaryId = `sum_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  const nowIso = new Date().toISOString();
+  const confidence = calculateConfidence(orchestration.citations, guardrails.violations);
+
+  const record = {
+    summary_id: summaryId,
+    doc_id: document.doc_id,
+    title: document.title,
+    mode,
+    model: 'acceleraqa-orchestrator-v1',
+    prompt_hash: crypto.createHash('sha256').update(`${document.doc_id}:${mode.role}:${mode.lens}`).digest('hex'),
+    citations: orchestration.citations,
+    confidence,
+    created_at: nowIso,
+    request_id: requestId,
+    summary: orchestration.summaryText,
+    guardrails,
+  };
+
+  summaryStore.set(summaryId, record);
+  return record;
+}
+
+function calculateConfidence(citations, violations) {
+  const base = citations.length > 0 ? 0.6 + Math.min(0.3, citations.length * 0.05) : 0.4;
+  const penalty = Math.min(0.3, (violations?.length || 0) * 0.1);
+  return Number(Math.max(0, base - penalty).toFixed(2));
+}

--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -23,6 +23,7 @@ import ragService from '../services/ragService';
 import { getToken } from '../services/authService';
 import { hasAdminRole } from '../utils/auth';
 import trainingResourceService from '../services/trainingResourceService';
+import SummaryRequestPanel from './SummaryRequestPanel';
 
 const describeConversionSource = (conversion) => {
   if (!conversion) {
@@ -1057,6 +1058,8 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                   </button>
                 </div>
               </div>
+
+              <SummaryRequestPanel documents={documents} user={user} />
 
               {/* Documents List */}
               <div>

--- a/src/components/SummaryRequestPanel.js
+++ b/src/components/SummaryRequestPanel.js
@@ -1,0 +1,513 @@
+import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Sparkles,
+  Loader,
+  AlertCircle,
+  ClipboardCopy,
+  RefreshCw,
+  ShieldCheck,
+  ListChecks,
+  FileText,
+} from 'lucide-react';
+import useSummaryPipeline from '../hooks/useSummaryPipeline';
+import ragService from '../services/ragService';
+import decodeDocumentContent from '../utils/documentTextUtils';
+
+const parseListInput = (value) =>
+  value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+const buildDocumentForSummary = (document = {}, content = '') => {
+  const metadata = document.metadata || {};
+  return {
+    doc_id: metadata.doc_id || document.id,
+    title: metadata.title || document.filename || 'Untitled Document',
+    version: metadata.version || metadata.revision || '1.0',
+    doc_type: metadata.doc_type || metadata.category || document.type || 'Document',
+    owner: metadata.owner || metadata.author || 'unknown',
+    system_of_record: metadata.system_of_record || metadata.sourceSystem || 'AcceleraQA',
+    effective_date: metadata.effective_date || metadata.effectiveDate || metadata.updatedAt || metadata.createdAt,
+    content,
+  };
+};
+
+const SummaryRequestPanel = ({ documents, user }) => {
+  const {
+    summary,
+    diagnostics,
+    metrics,
+    status,
+    error,
+    isLoading,
+    hasSummary,
+    requestSummary,
+    reset,
+    roleOptions,
+    lensOptions,
+    detailOptions,
+  } = useSummaryPipeline();
+
+  const [selectedDocumentId, setSelectedDocumentId] = useState('');
+  const [documentContent, setDocumentContent] = useState('');
+  const [documentWarnings, setDocumentWarnings] = useState([]);
+  const [documentError, setDocumentError] = useState(null);
+  const [isFetchingDocument, setIsFetchingDocument] = useState(false);
+  const [mode, setMode] = useState({ role: 'QA Lead', lens: 'Regulatory', detail: detailOptions[1] || detailOptions[0] });
+  const [query, setQuery] = useState('');
+  const [tagsInput, setTagsInput] = useState('');
+  const [sectionsInput, setSectionsInput] = useState('');
+  const [lastRequest, setLastRequest] = useState(null);
+  const [copyFeedback, setCopyFeedback] = useState('');
+
+  useEffect(() => {
+    if (!copyFeedback) {
+      return undefined;
+    }
+
+    const timeout = setTimeout(() => setCopyFeedback(''), 2000);
+    return () => clearTimeout(timeout);
+  }, [copyFeedback]);
+
+  const selectedDocument = useMemo(
+    () => documents.find((doc) => String(doc.id) === String(selectedDocumentId)),
+    [documents, selectedDocumentId]
+  );
+
+  useEffect(() => {
+    if (!selectedDocumentId) {
+      setDocumentContent('');
+      setDocumentWarnings([]);
+      setDocumentError(null);
+      return undefined;
+    }
+
+    let isCancelled = false;
+
+    const loadContent = async () => {
+      setIsFetchingDocument(true);
+      setDocumentError(null);
+      setDocumentWarnings([]);
+
+      try {
+        const payload = await ragService.downloadDocument({ documentId: selectedDocumentId }, user?.sub);
+        const { text, warnings } = decodeDocumentContent(payload);
+        if (!isCancelled) {
+          setDocumentContent(text);
+          setDocumentWarnings(warnings);
+        }
+      } catch (loadError) {
+        if (!isCancelled) {
+          setDocumentError(loadError.message || 'Failed to load document content');
+          setDocumentContent('');
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsFetchingDocument(false);
+        }
+      }
+    };
+
+    loadContent();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [selectedDocumentId, user?.sub]);
+
+  const handleGenerateSummary = useCallback(
+    async (event) => {
+      event.preventDefault();
+
+      const trimmedContent = documentContent.trim();
+      if (!trimmedContent) {
+        setDocumentError('Add or load document content before generating a summary.');
+        return;
+      }
+
+      const filters = {};
+      const parsedTags = parseListInput(tagsInput);
+      const parsedSections = parseListInput(sectionsInput);
+      if (parsedTags.length > 0) {
+        filters.tags = parsedTags;
+      }
+      if (parsedSections.length > 0) {
+        filters.sections = parsedSections;
+      }
+
+      const documentPayload = buildDocumentForSummary(selectedDocument || {}, trimmedContent);
+      const request = {
+        document: documentPayload,
+        mode,
+        query,
+        filters,
+        metadata: {
+          sourceDocumentId: selectedDocument?.id || null,
+          filename: selectedDocument?.filename || null,
+        },
+      };
+
+      try {
+        setLastRequest(request);
+        await requestSummary(request);
+      } catch (requestError) {
+        console.error('Failed to generate summary:', requestError);
+      }
+    },
+    [documentContent, mode, query, requestSummary, sectionsInput, selectedDocument, tagsInput]
+  );
+
+  const handleReset = useCallback(() => {
+    reset();
+    setLastRequest(null);
+    setCopyFeedback('');
+  }, [reset]);
+
+  const handleCopy = useCallback(async () => {
+    if (!summary?.summary || typeof navigator === 'undefined' || !navigator?.clipboard?.writeText) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(summary.summary);
+      setCopyFeedback('Copied!');
+    } catch (copyError) {
+      console.warn('Failed to copy summary to clipboard:', copyError);
+    }
+  }, [summary]);
+
+  const showLoadingState = isLoading || isFetchingDocument;
+
+  return (
+    <section className="bg-white border border-blue-100 rounded-lg p-6 shadow-sm">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-6">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-blue-600" />
+            Generate QA Summary
+          </h3>
+          <p className="text-sm text-gray-600">
+            Select a document, tailor role and lens, and AcceleraQA will orchestrate the multi-pass summarization pipeline with
+            citations.
+          </p>
+        </div>
+        {status === 'succeeded' && summary?.summary_id && (
+          <div className="text-xs font-mono text-blue-600 bg-blue-50 border border-blue-200 rounded px-3 py-1">
+            Summary ID: {summary.summary_id}
+          </div>
+        )}
+      </div>
+
+      <form onSubmit={handleGenerateSummary} className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="md:col-span-1">
+          <label htmlFor="summary-document" className="block text-sm font-medium text-gray-700 mb-1">
+            Source document
+          </label>
+          <select
+            id="summary-document"
+            value={selectedDocumentId}
+            onChange={(event) => setSelectedDocumentId(event.target.value)}
+            className="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="">Select a document…</option>
+            {documents.map((doc) => (
+              <option key={doc.id} value={doc.id}>
+                {(doc.metadata?.title || doc.filename || doc.id).slice(0, 80)}
+              </option>
+            ))}
+          </select>
+          {documentError && (
+            <p className="mt-2 text-xs text-red-600 flex items-center gap-1">
+              <AlertCircle className="h-3 w-3" />
+              {documentError}
+            </p>
+          )}
+          {documentWarnings.length > 0 && (
+            <p className="mt-2 text-xs text-amber-600 flex items-center gap-1">
+              <AlertCircle className="h-3 w-3" />
+              {documentWarnings.join(' ')}
+            </p>
+          )}
+        </div>
+
+        <div className="md:col-span-1 grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div>
+            <label htmlFor="summary-role" className="block text-sm font-medium text-gray-700 mb-1">
+              Role
+            </label>
+            <select
+              id="summary-role"
+              value={mode.role}
+              onChange={(event) => setMode((prev) => ({ ...prev, role: event.target.value }))}
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {roleOptions.map((role) => (
+                <option key={role} value={role}>
+                  {role}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="summary-lens" className="block text-sm font-medium text-gray-700 mb-1">
+              Focus lens
+            </label>
+            <select
+              id="summary-lens"
+              value={mode.lens}
+              onChange={(event) => setMode((prev) => ({ ...prev, lens: event.target.value }))}
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {lensOptions.map((lens) => (
+                <option key={lens} value={lens}>
+                  {lens}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="summary-detail" className="block text-sm font-medium text-gray-700 mb-1">
+              Detail level
+            </label>
+            <select
+              id="summary-detail"
+              value={mode.detail}
+              onChange={(event) => setMode((prev) => ({ ...prev, detail: event.target.value }))}
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {detailOptions.map((detail) => (
+                <option key={detail} value={detail}>
+                  {detail}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="md:col-span-2 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="summary-query" className="block text-sm font-medium text-gray-700 mb-1">
+              Optional query emphasis
+            </label>
+            <input
+              id="summary-query"
+              type="text"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="e.g., highlight CAPA closure evidence"
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="summary-tags" className="block text-sm font-medium text-gray-700 mb-1">
+                Tag filters
+              </label>
+              <input
+                id="summary-tags"
+                type="text"
+                value={tagsInput}
+                onChange={(event) => setTagsInput(event.target.value)}
+                placeholder="risk, 21 CFR 11"
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+              <p className="text-xs text-gray-500 mt-1">Comma-separated list applied during retrieval.</p>
+            </div>
+            <div>
+              <label htmlFor="summary-sections" className="block text-sm font-medium text-gray-700 mb-1">
+                Section filters
+              </label>
+              <input
+                id="summary-sections"
+                type="text"
+                value={sectionsInput}
+                onChange={(event) => setSectionsInput(event.target.value)}
+                placeholder="4.2 Risk Assessment"
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+              <p className="text-xs text-gray-500 mt-1">Helps target specific headings or annexes.</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="md:col-span-2">
+          <label htmlFor="summary-content" className="block text-sm font-medium text-gray-700 mb-1 flex items-center gap-2">
+            <FileText className="h-4 w-4 text-gray-500" />
+            Document content
+          </label>
+          <textarea
+            id="summary-content"
+            value={documentContent}
+            onChange={(event) => setDocumentContent(event.target.value)}
+            rows={6}
+            placeholder="Paste or load document text to summarize"
+            className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          {selectedDocument && (
+            <p className="text-xs text-gray-500 mt-1">
+              Editing the text here lets you regenerate summaries with quick adjustments before re-uploading.
+            </p>
+          )}
+        </div>
+
+        <div className="md:col-span-2 flex flex-wrap gap-3 justify-between items-center border-t border-gray-100 pt-4">
+          <div className="text-sm text-gray-500 flex items-center gap-2">
+            {showLoadingState ? (
+              <Loader className="h-4 w-4 animate-spin text-blue-600" />
+            ) : (
+              <ListChecks className="h-4 w-4 text-blue-600" />
+            )}
+            {showLoadingState ? 'Running retrieval, orchestration, and guardrails…' : 'Pipeline ready.'}
+          </div>
+          <div className="flex items-center gap-2">
+            {hasSummary && (
+              <button
+                type="button"
+                onClick={handleReset}
+                className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 border border-gray-300 rounded-md hover:border-gray-400 transition"
+              >
+                <RefreshCw className="h-4 w-4 mr-2 inline" />
+                Reset
+              </button>
+            )}
+            <button
+              type="submit"
+              disabled={showLoadingState || !documentContent.trim()}
+              className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            >
+              <Sparkles className="h-4 w-4" />
+              {showLoadingState ? 'Generating…' : 'Generate summary'}
+            </button>
+          </div>
+        </div>
+      </form>
+
+      {error && (
+        <div className="mt-4 p-4 bg-red-50 border border-red-200 rounded-md text-sm text-red-700 flex items-start gap-2">
+          <AlertCircle className="h-4 w-4 mt-0.5" />
+          <div>
+            <p className="font-medium">Summary request failed</p>
+            <p>{error.message}</p>
+          </div>
+        </div>
+      )}
+
+      {summary && (
+        <div className="mt-6 space-y-6">
+          <div className="flex flex-wrap items-center gap-3 justify-between">
+            <h4 className="text-md font-semibold text-gray-900 flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5 text-emerald-600" />
+              Guarded summary output
+            </h4>
+            <div className="flex items-center gap-2 text-xs text-gray-500">
+              {copyFeedback && <span className="text-emerald-600 font-medium">{copyFeedback}</span>}
+              <button
+                type="button"
+                onClick={handleCopy}
+                disabled={!summary.summary}
+                className="inline-flex items-center gap-1 px-2 py-1 border border-gray-300 rounded-md hover:border-gray-400 text-gray-600 hover:text-gray-800"
+              >
+                <ClipboardCopy className="h-3 w-3" />
+                Copy summary
+              </button>
+            </div>
+          </div>
+
+          <div className="bg-slate-900 text-slate-100 text-sm rounded-lg p-4 whitespace-pre-wrap overflow-auto max-h-96">
+            {summary.summary}
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+            <div className="border border-gray-200 rounded-lg p-4">
+              <h5 className="text-sm font-semibold text-gray-800 mb-2">Citations</h5>
+              {Array.isArray(summary.citations) && summary.citations.length > 0 ? (
+                <ul className="space-y-2 text-sm text-gray-700">
+                  {summary.citations.map((citation) => (
+                    <li key={citation.chunk_id} className="border border-gray-100 rounded-md p-2">
+                      <p className="font-medium text-gray-900">[{citation.citationNumber}] Sec {citation.section} · p.{citation.page}</p>
+                      <p className="text-xs text-gray-600 mt-1">{citation.preview}</p>
+                      <p className="text-xs text-gray-500 mt-1">Confidence: {(citation.score * 100).toFixed(0)}%</p>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-gray-500">No citations were attached to this summary.</p>
+              )}
+            </div>
+
+            <div className="border border-gray-200 rounded-lg p-4">
+              <h5 className="text-sm font-semibold text-gray-800 mb-2">Metrics</h5>
+              <ul className="text-sm text-gray-700 space-y-1">
+                <li>Latency: {metrics?.latencyMs ? `${metrics.latencyMs.toLocaleString()} ms` : '—'}</li>
+                <li>Chunks retrieved: {metrics?.retrievedCount ?? '—'}</li>
+                <li>Chunks analyzed: {metrics?.chunkCount ?? '—'}</li>
+                <li>Citation density: {metrics?.citationDensity ? metrics.citationDensity.toFixed(2) : '—'}</li>
+                <li>Confidence: {metrics?.confidence ? (metrics.confidence * 100).toFixed(0) + '%' : summary.confidence * 100 + '%'}</li>
+              </ul>
+              {lastRequest && (
+                <div className="mt-3 text-xs text-gray-500">
+                  Mode: {lastRequest.mode.role} · {lastRequest.mode.lens} · {lastRequest.mode.detail}
+                </div>
+              )}
+            </div>
+
+            <div className="border border-gray-200 rounded-lg p-4">
+              <h5 className="text-sm font-semibold text-gray-800 mb-2">Guardrail status</h5>
+              {summary.guardrails?.violations?.length ? (
+                <ul className="text-sm text-red-600 space-y-1">
+                  {summary.guardrails.violations.map((violation) => (
+                    <li key={violation.code}>
+                      <span className="font-medium">{violation.code}:</span> {violation.message}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-emerald-600">No guardrail violations detected.</p>
+              )}
+            </div>
+          </div>
+
+          {diagnostics.length > 0 && (
+            <div className="border border-gray-200 rounded-lg p-4">
+              <h5 className="text-sm font-semibold text-gray-800 mb-3">Diagnostics</h5>
+              <ol className="space-y-2 text-sm text-gray-700">
+                {diagnostics.map((entry, index) => (
+                  <li key={`${entry.stage}-${index}`} className="border border-gray-100 rounded-md p-3">
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium text-gray-900">{entry.stage}</span>
+                      {entry.metadata && (
+                        <span className="text-xs text-gray-500 font-mono">
+                          {JSON.stringify(entry.metadata)}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-gray-600 mt-1">{entry.message}</p>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+};
+
+SummaryRequestPanel.propTypes = {
+  documents: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    filename: PropTypes.string,
+    metadata: PropTypes.object,
+  })).isRequired,
+  user: PropTypes.shape({
+    sub: PropTypes.string,
+  }),
+};
+
+SummaryRequestPanel.defaultProps = {
+  user: null,
+};
+
+export default SummaryRequestPanel;

--- a/src/hooks/useSummaryPipeline.js
+++ b/src/hooks/useSummaryPipeline.js
@@ -1,0 +1,182 @@
+import { useState, useCallback, useMemo } from 'react';
+import summaryPipelineService, { DETAIL_LEVELS } from '../services/summaryPipelineService';
+
+export const ROLE_OPTIONS = [
+  'Auditor',
+  'QA Lead',
+  'Engineer',
+  'New Hire',
+];
+
+export const LENS_OPTIONS = [
+  'Regulatory',
+  'Risk & CAPA',
+  'Training',
+  'Timeline/Change log',
+  'Testing & Evidence',
+];
+
+export const DETAIL_OPTIONS = [
+  DETAIL_LEVELS.BRIEF,
+  DETAIL_LEVELS.STANDARD,
+  DETAIL_LEVELS.DEEP_DIVE,
+];
+
+const DEFAULT_MODE = {
+  role: 'QA Lead',
+  lens: 'Regulatory',
+  detail: DETAIL_LEVELS.STANDARD,
+};
+
+const isString = (value) => typeof value === 'string' && value.trim().length > 0;
+
+const normalizeMode = (mode = {}) => ({
+  role: ROLE_OPTIONS.includes(mode.role) ? mode.role : DEFAULT_MODE.role,
+  lens: LENS_OPTIONS.includes(mode.lens) ? mode.lens : DEFAULT_MODE.lens,
+  detail: DETAIL_OPTIONS.includes(mode.detail) ? mode.detail : DEFAULT_MODE.detail,
+});
+
+const buildDocumentPayload = (document = {}) => {
+  if (!document || typeof document !== 'object') {
+    throw new Error('Document metadata is required to request a summary');
+  }
+
+  const text = document.content || document.text;
+  if (!isString(text)) {
+    throw new Error('Document content must be provided as a non-empty string');
+  }
+
+  return {
+    doc_id: document.doc_id || document.id || `doc_${Date.now().toString(36)}`,
+    title: document.title || document.filename || 'Untitled Document',
+    version: document.version || '1.0',
+    doc_type: document.doc_type || document.type || 'Document',
+    owner: document.owner || 'unknown',
+    effective_date: document.effective_date || document.effectiveDate || new Date().toISOString().slice(0, 10),
+    system_of_record: document.system_of_record || document.systemOfRecord || 'unspecified',
+    content: text,
+  };
+};
+
+const buildFilters = (filters = {}) => {
+  const normalized = {};
+
+  if (Array.isArray(filters.tags) && filters.tags.length > 0) {
+    normalized.tags = filters.tags.filter(isString);
+  }
+
+  if (Array.isArray(filters.sections) && filters.sections.length > 0) {
+    normalized.sections = filters.sections.filter(isString);
+  }
+
+  return normalized;
+};
+
+const mergeMetadata = (metadata = {}) => ({
+  requestedFrom: 'frontend',
+  requestTimestamp: new Date().toISOString(),
+  ...metadata,
+});
+
+const deriveStatus = (nextStatus, previousSummary) => {
+  if (nextStatus === 'loading' && previousSummary) {
+    return 'refreshing';
+  }
+  return nextStatus;
+};
+
+const useSummaryPipeline = ({ defaultMode = DEFAULT_MODE } = {}) => {
+  const [summary, setSummary] = useState(null);
+  const [diagnostics, setDiagnostics] = useState([]);
+  const [metrics, setMetrics] = useState(null);
+  const [status, setStatus] = useState('idle');
+  const [error, setError] = useState(null);
+
+  const normalizedDefaultMode = useMemo(() => normalizeMode(defaultMode), [defaultMode]);
+
+  const requestSummary = useCallback(
+    async ({ document, mode, query = '', filters, metadata } = {}) => {
+      const payload = {
+        document: buildDocumentPayload(document),
+        mode: normalizeMode(mode || normalizedDefaultMode),
+        query: isString(query) ? query.trim() : '',
+        filters: buildFilters(filters),
+        metadata: mergeMetadata(metadata),
+      };
+
+      setStatus((prevStatus) => deriveStatus('loading', summary));
+      setError(null);
+
+      try {
+        const response = await summaryPipelineService.createSummary(payload);
+        setSummary(response.summary || null);
+        setDiagnostics(Array.isArray(response.diagnostics) ? response.diagnostics : []);
+        setMetrics(response.metrics || null);
+        setStatus('succeeded');
+        return response;
+      } catch (requestError) {
+        setStatus('failed');
+        setSummary(null);
+        setDiagnostics([]);
+        setMetrics(null);
+        setError(requestError);
+        throw requestError;
+      }
+    },
+    [normalizedDefaultMode, summary]
+  );
+
+  const fetchSummary = useCallback(
+    async (summaryId) => {
+      if (!isString(summaryId)) {
+        throw new Error('A summaryId string is required to retrieve a stored summary');
+      }
+
+      setStatus((prevStatus) => deriveStatus('loading', summary));
+      setError(null);
+
+      try {
+        const response = await summaryPipelineService.getSummary(summaryId.trim());
+        const record = response?.summary || null;
+        setSummary(record);
+        setDiagnostics([]);
+        setMetrics(null);
+        setStatus('succeeded');
+        return record;
+      } catch (requestError) {
+        setStatus('failed');
+        setError(requestError);
+        throw requestError;
+      }
+    },
+    [summary]
+  );
+
+  const reset = useCallback(() => {
+    setSummary(null);
+    setDiagnostics([]);
+    setMetrics(null);
+    setStatus('idle');
+    setError(null);
+  }, []);
+
+  const isLoading = status === 'loading' || status === 'refreshing';
+
+  return {
+    summary,
+    diagnostics,
+    metrics,
+    status,
+    error,
+    isLoading,
+    hasSummary: Boolean(summary),
+    requestSummary,
+    fetchSummary,
+    reset,
+    roleOptions: ROLE_OPTIONS,
+    lensOptions: LENS_OPTIONS,
+    detailOptions: DETAIL_OPTIONS,
+  };
+};
+
+export default useSummaryPipeline;

--- a/src/services/summaryPipelineService.js
+++ b/src/services/summaryPipelineService.js
@@ -1,0 +1,192 @@
+import { getToken, getUserId } from './authService';
+
+const DEFAULT_ENDPOINT = process.env.REACT_APP_SUMMARY_PIPELINE_ENDPOINT || '/.netlify/functions/summary-pipeline';
+
+const DETAIL_LEVELS = {
+  BRIEF: 'Brief',
+  STANDARD: 'Standard',
+  DEEP_DIVE: 'Deep Dive',
+};
+
+const DEFAULT_MODE = {
+  role: 'QA Lead',
+  lens: 'Regulatory',
+  detail: DETAIL_LEVELS.STANDARD,
+};
+
+export const buildSummaryRequest = ({ document, mode = {}, query = '', filters = {}, metadata = {} }) => {
+  if (!document || typeof document !== 'object') {
+    throw new Error('document metadata is required');
+  }
+
+  const rawContent = typeof document.content === 'string' ? document.content : document.text;
+  if (!rawContent || typeof rawContent !== 'string' || !rawContent.trim()) {
+    throw new Error('document content must be a non-empty string');
+  }
+
+  const content = rawContent.replace(/\r\n/g, '\n').trim();
+
+  const normalizedMode = {
+    role: typeof mode.role === 'string' ? mode.role : DEFAULT_MODE.role,
+    lens: typeof mode.lens === 'string' ? mode.lens : DEFAULT_MODE.lens,
+    detail: normalizeDetail(mode.detail),
+  };
+
+  const docId = document.doc_id || document.id || createDeterministicId(content);
+  const timestamp = new Date().toISOString();
+
+  return {
+    document: {
+      doc_id: docId,
+      title: document.title || 'Untitled Document',
+      version: document.version || '1.0',
+      doc_type: document.doc_type || document.type || 'Document',
+      owner: document.owner || 'unknown',
+      effective_date: document.effective_date || document.effectiveDate || timestamp.slice(0, 10),
+      system_of_record: document.system_of_record || document.systemOfRecord || 'unspecified',
+      content,
+    },
+    mode: normalizedMode,
+    query,
+    filters,
+    metadata: {
+      requestTimestamp: timestamp,
+      ...metadata,
+    },
+    chunkConfig: {
+      chunkSize: 1200,
+      chunkOverlap: 180,
+    },
+    requestId: createRequestId(),
+  };
+};
+
+class SummaryPipelineService {
+  constructor(endpoint = DEFAULT_ENDPOINT) {
+    this.endpoint = endpoint;
+  }
+
+  async createSummary(params) {
+    const payload = buildSummaryRequest(params);
+
+    const headers = await this.buildAuthHeaders();
+    const response = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        ...headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw await this.normalizeError(response);
+    }
+
+    return response.json();
+  }
+
+  async getSummary(summaryId) {
+    if (!summaryId || typeof summaryId !== 'string') {
+      throw new Error('summaryId must be provided');
+    }
+
+    const headers = await this.buildAuthHeaders();
+    const response = await fetch(`${this.endpoint}?summary_id=${encodeURIComponent(summaryId)}`, {
+      method: 'GET',
+      headers,
+    });
+
+    if (!response.ok) {
+      throw await this.normalizeError(response);
+    }
+
+    return response.json();
+  }
+
+  async buildAuthHeaders() {
+    const token = await getToken();
+    const userId = await getUserId();
+
+    if (!token) {
+      throw new Error('Authentication token is required to call the summary pipeline');
+    }
+    if (!userId) {
+      throw new Error('User identity is required to call the summary pipeline');
+    }
+
+    return {
+      Authorization: `Bearer ${token}`,
+      'x-user-id': userId,
+      'X-Client-Version': '2.1.0',
+    };
+  }
+
+  async normalizeError(response) {
+    let payload;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      payload = { error: response.statusText || 'Unknown error' };
+    }
+
+    const message = payload?.error || payload?.message || `Request failed with status ${response.status}`;
+    const error = new Error(message);
+    error.status = response.status;
+    error.details = payload;
+    return error;
+  }
+}
+
+function normalizeDetail(detail) {
+  if (!detail) {
+    return DETAIL_LEVELS.STANDARD;
+  }
+
+  const normalized = String(detail).trim().toLowerCase();
+  if (normalized.startsWith('brief')) {
+    return DETAIL_LEVELS.BRIEF;
+  }
+  if (normalized.startsWith('deep')) {
+    return DETAIL_LEVELS.DEEP_DIVE;
+  }
+  if (normalized.startsWith('standard')) {
+    return DETAIL_LEVELS.STANDARD;
+  }
+  return DETAIL_LEVELS.STANDARD;
+}
+
+function createDeterministicId(content) {
+  if (typeof globalThis !== 'undefined') {
+    const nativeCrypto = globalThis.crypto;
+    if (nativeCrypto && typeof nativeCrypto.randomUUID === 'function') {
+      const seeded = hashCode(content);
+      const uuidFragment = Math.abs(seeded).toString(16).padStart(12, '0').slice(0, 12);
+      return `doc_${uuidFragment}`;
+    }
+  }
+
+  return `doc_${Math.abs(hashCode(content)).toString(16).padStart(8, '0').slice(0, 12)}`;
+}
+
+function createRequestId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+
+  return `req_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function hashCode(value) {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return hash;
+}
+
+const summaryPipelineService = new SummaryPipelineService();
+
+export default summaryPipelineService;
+export { SummaryPipelineService, DETAIL_LEVELS };

--- a/src/services/summaryPipelineService.test.js
+++ b/src/services/summaryPipelineService.test.js
@@ -1,0 +1,107 @@
+import { jest } from '@jest/globals';
+
+let mockGetToken;
+let mockGetUserId;
+
+jest.mock('./authService', () => ({
+  getToken: (...args) => mockGetToken(...args),
+  getUserId: (...args) => mockGetUserId(...args),
+}));
+
+import summaryPipelineService, {
+  buildSummaryRequest,
+  DETAIL_LEVELS,
+  SummaryPipelineService,
+} from './summaryPipelineService';
+
+describe('buildSummaryRequest', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-09-09T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('normalizes document metadata and mode defaults', () => {
+    const payload = buildSummaryRequest({
+      document: {
+        title: 'Validation Plan',
+        content: 'Section 1. Overview.\n\nThis plan validates equipment.\n\nSection 2. Testing. IQ and OQ complete.',
+        owner: 'QA Team',
+      },
+      mode: { role: 'Auditor', detail: 'deep dive' },
+      query: 'Provide regulatory summary',
+    });
+
+    expect(payload.document.doc_id).toMatch(/^doc_/);
+    expect(payload.document.title).toBe('Validation Plan');
+    expect(payload.mode.role).toBe('Auditor');
+    expect(payload.mode.detail).toBe(DETAIL_LEVELS.DEEP_DIVE);
+    expect(payload.chunkConfig).toEqual({ chunkSize: 1200, chunkOverlap: 180 });
+    expect(payload.metadata.requestTimestamp).toBe('2025-09-09T12:00:00.000Z');
+    expect(typeof payload.requestId).toBe('string');
+  });
+
+  it('throws when content is missing', () => {
+    expect(() => buildSummaryRequest({ document: { title: 'Empty' } })).toThrow('document content must be a non-empty string');
+  });
+});
+
+describe('SummaryPipelineService', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    global.fetch = jest.fn();
+    mockGetToken = jest.fn().mockResolvedValue('token-123');
+    mockGetUserId = jest.fn().mockResolvedValue('user-456');
+  });
+
+  it('POSTs to create a summary with auth headers', async () => {
+    const fakeResponse = { summary: { summary_id: 'sum_abc' } };
+    fetch.mockResolvedValue({ ok: true, json: async () => fakeResponse });
+
+    const result = await summaryPipelineService.createSummary({
+      document: { title: 'Doc', content: 'A test document.' },
+      mode: { lens: 'Risk & CAPA' },
+      query: 'Highlight risks',
+    });
+
+    expect(result).toEqual(fakeResponse);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, options] = fetch.mock.calls[0];
+    expect(url).toContain('/.netlify/functions/summary-pipeline');
+    expect(options.method).toBe('POST');
+    expect(options.headers.Authorization).toBe('Bearer token-123');
+    expect(options.headers['x-user-id']).toBe('user-456');
+    expect(JSON.parse(options.body).mode.lens).toBe('Risk & CAPA');
+  });
+
+  it('throws normalized error when backend responds with failure', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: async () => ({ error: 'Unsupported mode' }),
+    });
+
+    await expect(summaryPipelineService.createSummary({
+      document: { content: 'text' },
+    })).rejects.toThrow('Unsupported mode');
+  });
+
+  it('retrieves a persisted summary by id', async () => {
+    fetch.mockResolvedValue({ ok: true, json: async () => ({ summary: { summary_id: 'sum_123' } }) });
+
+    const service = new SummaryPipelineService('https://api.example.com/summary-pipeline');
+    const result = await service.getSummary('sum_123');
+
+    expect(result.summary.summary_id).toBe('sum_123');
+    expect(fetch).toHaveBeenCalledWith('https://api.example.com/summary-pipeline?summary_id=sum_123', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer token-123',
+        'x-user-id': 'user-456',
+        'X-Client-Version': '2.1.0',
+      },
+    });
+  });
+});

--- a/src/utils/documentTextUtils.js
+++ b/src/utils/documentTextUtils.js
@@ -1,0 +1,98 @@
+const TEXTUAL_MIME_INDICATORS = [
+  'text/',
+  'application/json',
+  'application/xml',
+  'application/xhtml+xml',
+  'application/x-yaml',
+  'application/yaml',
+  'application/csv',
+  'text/csv',
+  'application/rtf',
+  'text/markdown',
+];
+
+const BINARY_HINTS = [
+  'pdf',
+  'msword',
+  'officedocument',
+  'octet-stream',
+];
+
+const LOSSY_WARNING = 'Binary document converted using a lossy UTF-8 fallback. Consider uploading a text-friendly version for better summaries.';
+
+const UNKNOWN_WARNING = 'Unknown content type decoded as UTF-8 text. Validate the extracted content before summarizing.';
+
+const decodeBytesToString = (bytes) => {
+  if (typeof globalThis !== 'undefined' && typeof globalThis.TextDecoder === 'function') {
+    return new globalThis.TextDecoder('utf-8', { fatal: false }).decode(bytes);
+  }
+
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('utf8');
+  }
+
+  let result = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    result += String.fromCharCode(bytes[i]);
+  }
+  return result;
+};
+
+const base64ToUint8Array = (base64) => {
+  if (typeof base64 !== 'string' || base64.length === 0) {
+    return new Uint8Array();
+  }
+
+  if (typeof atob === 'function') {
+    const binary = atob(base64);
+    const length = binary.length;
+    const bytes = new Uint8Array(length);
+    for (let i = 0; i < length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  return Uint8Array.from(Buffer.from(base64, 'base64'));
+};
+
+const stripBinaryArtifacts = (text) => {
+  if (typeof text !== 'string') {
+    return '';
+  }
+
+  return text
+    .replace(/[\x00-\x1f]+/g, ' ')
+    .replace(/[\x7f-\x9f]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+export const decodeDocumentContent = (downloadPayload = {}) => {
+  const { content, contentType } = downloadPayload;
+
+  if (!content) {
+    throw new Error('Document download payload is missing base64 content');
+  }
+
+  const normalizedType = typeof contentType === 'string' ? contentType.toLowerCase() : '';
+  const bytes = base64ToUint8Array(content);
+  const decoded = decodeBytesToString(bytes);
+
+  if (TEXTUAL_MIME_INDICATORS.some((indicator) => normalizedType.startsWith(indicator) || normalizedType.includes(indicator))) {
+    return { text: decoded, warnings: [] };
+  }
+
+  if (BINARY_HINTS.some((hint) => normalizedType.includes(hint))) {
+    const sanitized = stripBinaryArtifacts(decoded);
+    if (!sanitized) {
+      throw new Error('Unable to extract readable text from binary document. Download the file and provide a text version.');
+    }
+    return { text: sanitized, warnings: [LOSSY_WARNING] };
+  }
+
+  const sanitized = stripBinaryArtifacts(decoded);
+  return { text: sanitized || decoded, warnings: sanitized ? [UNKNOWN_WARNING] : [UNKNOWN_WARNING] };
+};
+
+export default decodeDocumentContent;

--- a/src/utils/documentTextUtils.test.js
+++ b/src/utils/documentTextUtils.test.js
@@ -1,0 +1,32 @@
+import { decodeDocumentContent } from './documentTextUtils';
+
+describe('decodeDocumentContent', () => {
+  it('decodes UTF-8 text payloads without warnings', () => {
+    const payload = {
+      content: Buffer.from('Quality system overview').toString('base64'),
+      contentType: 'text/plain',
+    };
+
+    const result = decodeDocumentContent(payload);
+    expect(result.text).toBe('Quality system overview');
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('sanitizes binary payloads and surfaces a lossy warning', () => {
+    const binarySample = '\u0000PDF-1.4 Sample Content\u0000';
+    const payload = {
+      content: Buffer.from(binarySample, 'utf8').toString('base64'),
+      contentType: 'application/pdf',
+    };
+
+    const result = decodeDocumentContent(payload);
+    expect(result.text).toContain('PDF-1.4');
+    expect(result.warnings[0]).toMatch(/lossy/i);
+  });
+
+  it('throws when payload is missing content', () => {
+    expect(() => decodeDocumentContent({ contentType: 'text/plain' })).toThrow(
+      'Document download payload is missing base64 content'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a SummaryRequestPanel to the RAG configuration screen that uses the Netlify summary function with role/lens/detail controls and guardrail output
- introduce a reusable useSummaryPipeline hook plus documentTextUtils helper to prepare requests and decode downloaded content, with unit coverage
- document how the React client drives the pipeline and link the new guide from the README

## Testing
- CI=true npm test -- documentTextUtils.test.js summaryPipelineService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d67cf3fad8832abc2f5c136a897d55