### PR TITLE
feat: replace blob PDF embed with pdf.js canvas viewer

### DIFF
--- a/src/components/ResourcesView.test.js
+++ b/src/components/ResourcesView.test.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+
+jest.mock('pdfjs-dist/build/pdf', () => ({
+  GlobalWorkerOptions: {},
+  getDocument: () => ({
+    promise: Promise.resolve({
+      numPages: 1,
+      getPage: async () => ({
+        getViewport: ({ scale }) => ({ width: 600 * scale, height: 800 * scale }),
+        render: () => ({ promise: Promise.resolve() }),
+        cleanup: () => {},
+      }),
+      cleanup: () => {},
+      destroy: () => {},
+    }),
+    destroy: () => {},
+  }),
+}), { virtual: true });
+
+jest.mock('pdfjs-dist/build/pdf.worker.entry', () => 'pdf-worker-stub', { virtual: true });
+
+jest.mock('../services/learningSuggestionsService', () => ({
+  __esModule: true,
+  default: {
+    getLearningSuggestions: jest.fn().mockResolvedValue([]),
+  },
+}));
+
+jest.mock('../services/ragService', () => ({
+  __esModule: true,
+  default: {
+    downloadDocument: jest.fn(),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { DocumentViewer } from './ResourcesView';
+
+describe('DocumentViewer', () => {
+  it('uses the PdfBlobViewer when rendering blob-based PDFs', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <DocumentViewer
+          isOpen
+          title="Test PDF"
+          url="blob:https://example.com/test"
+          contentType="application/pdf"
+          filename="test.pdf"
+          isLoading={false}
+          error={null}
+          onClose={() => {}}
+          allowDownload
+        />
+      );
+    });
+
+    const pdfViewer = container.querySelector('[data-testid="pdf-blob-viewer"]');
+    expect(pdfViewer).not.toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+  });
+});


### PR DESCRIPTION
## Summary
- add a PdfBlobViewer that streams blob URLs through pdfjs-dist and draws PDF pages onto canvas elements
- swap the DocumentViewer blob-PDF branch to use the new component instead of an embedded iframe
- cover the new rendering path with a DocumentViewer test that mocks pdf.js and service dependencies

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d7f015870c832ab99bf1c7362ea0c8