### PR TITLE
Improve PDF viewer blob handling

### DIFF
--- a/src/components/ResourcesView.test.js
+++ b/src/components/ResourcesView.test.js
@@ -47,38 +47,46 @@ describe('DocumentViewer', () => {
   });
 
   it('uses the PdfBlobViewer when rendering blob-based PDFs', async () => {
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock;
+
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
 
-    await act(async () => {
-      root.render(
-        <DocumentViewer
-          isOpen
-          title="Test PDF"
-          url="blob:https://example.com/test"
-          blobData={new Uint8Array([1, 2, 3])}
-          contentType="application/pdf"
-          filename="test.pdf"
-          isLoading={false}
-          error={null}
-          onClose={() => {}}
-          allowDownload
-        />
-      );
-    });
+    try {
+      await act(async () => {
+        root.render(
+          <DocumentViewer
+            isOpen
+            title="Test PDF"
+            url="blob:https://example.com/test"
+            blobData={new Uint8Array([1, 2, 3])}
+            contentType="application/pdf"
+            filename="test.pdf"
+            isLoading={false}
+            error={null}
+            onClose={() => {}}
+            allowDownload
+          />
+        );
+      });
 
-    await act(async () => {
-      await Promise.resolve();
-    });
+      await act(async () => {
+        await Promise.resolve();
+      });
 
-    const pdfViewer = container.querySelector('[data-testid="pdf-blob-viewer"]');
-    expect(pdfViewer).not.toBeNull();
-    expect(mockGetDocument).toHaveBeenCalledWith(expect.objectContaining({ data: expect.any(Uint8Array) }));
-
-    await act(async () => {
-      root.unmount();
-    });
-    document.body.removeChild(container);
+      const pdfViewer = container.querySelector('[data-testid="pdf-blob-viewer"]');
+      expect(pdfViewer).not.toBeNull();
+      expect(mockGetDocument).toHaveBeenCalledWith(expect.objectContaining({ data: expect.any(Uint8Array) }));
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      document.body.removeChild(container);
+      global.fetch = originalFetch;
+    }
   });
 });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,5 @@
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+  configurable: true,
+  enumerable: false,
+  value: true,
+});


### PR DESCRIPTION
## Summary
- persist a transport-friendly copy of decoded PDF bytes alongside generated object URLs when opening resources
- update the PDF blob viewer to prefer provided byte sources and only fetch remote HTTP(S) documents when required
- extend the document viewer test to assert stored bytes are passed to PDF.js without invoking fetch and configure the test environment for React act

## Testing
- npm test -- --watchAll=false src/components/ResourcesView.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d7f9c14a4c832aa60d27d32b17a6b7