### PR TITLE
Prevent fetching blob URLs without data

### DIFF
--- a/src/components/ResourcesView.js
+++ b/src/components/ResourcesView.js
@@ -761,6 +761,10 @@ export const PdfBlobViewer = memo(({ url, title, blobData }) => {
           }
 
           const normalizedUrl = `${url}`;
+          const isObjectOrDataUrl = isBlobLikeUrl(normalizedUrl);
+          if (isObjectOrDataUrl) {
+            throw new Error('Failed to fetch PDF bytes due to browser security settings.');
+          }
           const isHttpUrl = /^https?:/i.test(normalizedUrl);
 
           if (!isHttpUrl) {


### PR DESCRIPTION
## Summary
- guard the PDF blob viewer from fetching blob/data URLs that lack a byte payload and surface the CSP warning message
- cover the missing-blobData scenario in ResourcesView tests to ensure fetch is not used and the friendly warning is shown

## Testing
- CI=true npm test -- ResourcesView.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8035d6abc832a879dbdc18c3b45a1