### PR TITLE
Rename Generate Summary labels

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -764,7 +764,7 @@ function App() {
       const notesContent = typeof notesResult?.answer === 'string' ? notesResult.answer.trim() : '';
 
       if (!notesContent) {
-        throw new Error('The assistant did not return any study notes.');
+        throw new Error('The assistant did not return any notes.');
       }
 
 
@@ -806,7 +806,7 @@ function App() {
           selectedConversationIds: selectedConversations.map((conversation) => conversation.id),
           selectedTopics: topTopics.length
             ? topTopics.join('\n')
-            : 'Study notes generated from your selected conversations.',
+            : 'Notes generated from your selected conversations.',
           selectedTopicsList: topTopics,
           content: notesContent,
           resourceCount: resources.length,
@@ -821,14 +821,14 @@ function App() {
       setMessages((prev) => [...prev, studyNotesMessage]);
       setSelectedMessages(new Set());
     } catch (error) {
-      console.error('Error generating study notes:', error);
+      console.error('Error generating notes:', error);
       setMessages((prev) => [
         ...prev,
         {
           id: uuidv4(),
           role: 'assistant',
           type: 'ai',
-          content: `I couldn't generate study notes: ${error.message || 'Unknown error occurred.'}`,
+          content: `I couldn't generate notes: ${error.message || 'Unknown error occurred.'}`,
           timestamp: Date.now(),
           resources: [],
           sources: [],

--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -699,7 +699,7 @@ const ChatArea = ({
     try {
       exportToWord(studyNotesMessage);
     } catch (error) {
-      console.error('Failed to export study notes to Word:', error);
+      console.error('Failed to export notes to Word:', error);
     }
   }, []);
 
@@ -950,7 +950,7 @@ const ChatArea = ({
                           <div className="flex flex-wrap items-center justify-between gap-3">
                             <div className="flex items-center gap-2 text-sm font-semibold text-blue-700">
                               <BookOpen className="h-4 w-4" />
-                              <span>Study notes ready</span>
+                              <span>Notes ready</span>
                             </div>
                             <button
                               type="button"
@@ -961,11 +961,11 @@ const ChatArea = ({
                                   ? 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500'
                                   : 'bg-blue-100 text-blue-300 cursor-not-allowed focus:ring-blue-200'
                               }`}
-                              aria-label="Export study notes to Word"
+                              aria-label="Export notes to Word"
                               title={
                                 canExportStudyNotes
-                                  ? 'Download a Word copy of these study notes.'
-                                  : 'Study notes are not ready to export yet.'
+                                  ? 'Download a Word copy of these notes.'
+                                  : 'Notes are not ready to export yet.'
                               }
                             >
                               <FileDown className="h-4 w-4" />

--- a/src/components/NotebookView.js
+++ b/src/components/NotebookView.js
@@ -217,7 +217,7 @@ const NotebookView = memo(({
                     ? 'bg-black text-white hover:bg-gray-800 focus:ring-gray-600'
                     : 'bg-gray-100 text-gray-400 cursor-not-allowed focus:ring-gray-300'
                 }`}
-                aria-label="Generate study notes from selected conversations"
+                aria-label="Generate notes from selected conversations"
               >
                 {isGeneratingNotes ? (
                   <span className="flex items-center space-x-2">
@@ -225,7 +225,7 @@ const NotebookView = memo(({
                     <span>Generating...</span>
                   </span>
                 ) : (
-                  'Study Notes'
+                  'Notes'
                 )}
               </button>
             </div>
@@ -490,7 +490,7 @@ const ConversationCard = memo(({
           {conversation.isStudyNotes && (
             <div className="mt-3 pt-2 border-t border-gray-200">
               <span className="text-xs bg-green-100 text-green-700 px-2 py-1 rounded-full font-medium">
-                📚 Study Notes
+                📚 Notes
               </span>
             </div>
           )}

--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -837,7 +837,7 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                     : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
                 }`}
               >
-                <span>Generate QA Summary</span>
+                <span>Generate Summary</span>
               </button>
               <button
                 type="button"
@@ -1069,8 +1069,6 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                   </button>
                 </div>
               </div>
-
-              <SummaryRequestPanel documents={documents} user={user} />
 
               {/* Documents List */}
               <div>

--- a/src/components/SummaryRequestPanel.js
+++ b/src/components/SummaryRequestPanel.js
@@ -186,7 +186,7 @@ const SummaryRequestPanel = ({ documents, user }) => {
         <div>
           <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
             <Sparkles className="h-5 w-5 text-blue-600" />
-            Generate QA Summary
+            Generate Summary
           </h3>
           <p className="text-sm text-gray-600">
             Select a document, tailor role and lens, and AcceleraQA will orchestrate the multi-pass summarization pipeline with

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -76,7 +76,7 @@ export const ERROR_MESSAGES = {
 
   AUTH_ERROR: 'Authentication error occurred.\n\nTROUBLESHOOTING STEPS:\n1. Check that all Auth0 environment variables are set correctly\n2. Verify your Auth0 application configuration\n3. Try signing out and signing in again\n4. Contact support if the problem persists',
 
-  STUDY_NOTES_GENERATION_FAILED: 'Failed to generate study notes. Please check your API configuration and try again.'
+  STUDY_NOTES_GENERATION_FAILED: 'Failed to generate notes. Please check your API configuration and try again.'
 };
 
 // Enhanced environment variable validation with detailed feedback

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -654,10 +654,10 @@ class OpenAIService {
 
   async generateStudyNotes(selectedMessages) {
     if (!selectedMessages || selectedMessages.length === 0) {
-      throw new Error('No messages selected for study notes generation');
+      throw new Error('No messages selected for notes generation');
     }
 
-    console.log('Generating study notes for messages:', selectedMessages);
+    console.log('Generating notes for messages:', selectedMessages);
 
     // Group messages by conversation pairs (user question + AI response)
     const conversationPairs = [];
@@ -682,7 +682,7 @@ class OpenAIService {
     }
 
     if (conversationPairs.length === 0) {
-      throw new Error('No valid conversation pairs found for study notes generation');
+      throw new Error('No valid conversation pairs found for notes generation');
     }
 
     const studyContent = conversationPairs
@@ -699,7 +699,7 @@ class OpenAIService {
       })
       .join('\n');
 
-    const studyPrompt = `Create comprehensive study notes for pharmaceutical quality and compliance based on the following conversation topics. 
+    const notesPrompt = `Create comprehensive notes for pharmaceutical quality and compliance based on the following conversation topics.
 
 Format as organized study material with:
 1. **Executive Summary** - Key takeaways from all conversations
@@ -718,7 +718,7 @@ Number of conversations analyzed: ${conversationPairs.length}
 Conversation content:
 ${studyContent}`;
 
-    return await this.getChatResponse(studyPrompt);
+    return await this.getChatResponse(notesPrompt);
   }
 }
 

--- a/src/utils/exportUtils.js
+++ b/src/utils/exportUtils.js
@@ -126,7 +126,7 @@ export function exportNotebook(messages) {
     }
 
     // CSV headers
-    const headers = ['Timestamp', 'Type', 'Message', 'Resources', 'Study Notes'];
+    const headers = ['Timestamp', 'Type', 'Message', 'Resources', 'Notes'];
     
     // Convert messages to CSV rows
     const rows = recentMessages.map(msg => [
@@ -154,13 +154,13 @@ export function exportNotebook(messages) {
 }
 
 /**
- * Exports study notes as Word document
- * @param {Object} studyNotesMessage - Study notes message object
+ * Exports notes as Word document
+ * @param {Object} studyNotesMessage - Notes message object
  */
 export function exportToWord(studyNotesMessage) {
   try {
     if (!studyNotesMessage) {
-      throw new Error('Invalid study notes message');
+      throw new Error('Invalid notes message');
     }
 
     const resources = Array.isArray(studyNotesMessage.resources)
@@ -172,7 +172,7 @@ export function exportToWord(studyNotesMessage) {
       createFallbackStudyNotesData(studyNotesMessage, resources);
 
     if (!studyData || !studyData.content) {
-      throw new Error('Invalid study notes data');
+      throw new Error('Invalid notes data');
     }
 
     // Create Word document content
@@ -184,7 +184,7 @@ export function exportToWord(studyNotesMessage) {
     });
 
     const timestamp = new Date().toISOString().split('T')[0];
-    const filename = `${APP_CONFIG.NAME}-Study-Notes-${timestamp}.doc`;
+    const filename = `${APP_CONFIG.NAME}-Notes-${timestamp}.doc`;
 
     downloadFile(blob, filename);
   } catch (error) {
@@ -195,7 +195,7 @@ export function exportToWord(studyNotesMessage) {
 
 /**
  * Creates formatted content for Word document
- * @param {Object} studyData - Study notes data
+ * @param {Object} studyData - Notes data
  * @param {Object[]} resources - Array of resources
  * @returns {string} - Formatted document content
  */
@@ -203,7 +203,7 @@ function createWordDocumentContent(studyData, resources) {
   const safeResources = Array.isArray(resources) ? resources : [];
   const generatedDate = studyData.generatedDate || new Date().toLocaleString();
   const selectedTopics =
-    studyData.selectedTopics || 'Study notes generated from your selected conversations.';
+    studyData.selectedTopics || 'Notes generated from your selected conversations.';
   const bodyContent = studyData.content || '';
   const resourceCount =
     typeof studyData.resourceCount === 'number' ? studyData.resourceCount : safeResources.length;
@@ -220,7 +220,7 @@ function createWordDocumentContent(studyData, resources) {
     : 'No additional resources provided.';
 
   const content = [
-    `${APP_CONFIG.NAME.toUpperCase()} - PHARMACEUTICAL QUALITY & COMPLIANCE STUDY NOTES`,
+    `${APP_CONFIG.NAME.toUpperCase()} - PHARMACEUTICAL QUALITY & COMPLIANCE NOTES`,
     '',
     `Generated: ${generatedDate}`,
     `Topics Covered: ${selectedTopics}`,
@@ -278,7 +278,7 @@ function createFallbackStudyNotesData(studyNotesMessage, resources) {
     generatedDate: generatedDateValue.toLocaleString(),
     selectedConversationCount: selectedConversationIds.length,
     selectedConversationIds,
-    selectedTopics: 'Study notes generated from your selected conversations.',
+    selectedTopics: 'Notes generated from your selected conversations.',
     selectedTopicsList: [],
     content,
     resourceCount: Array.isArray(resources) ? resources.length : 0,
@@ -330,7 +330,7 @@ export function exportMessagesToWord(messages, { title } = {}) {
           <div class="meta">Timestamp: ${escapeHtml(timestampLabel)}</div>
           <div class="content">${contentHtml}</div>
           ${resourcesHtml}
-          ${msg.isStudyNotes ? '<div class="study-note">Study Notes Entry</div>' : ''}
+          ${msg.isStudyNotes ? '<div class="study-note">Notes Entry</div>' : ''}
         </section>
       `;
     }).join('');
@@ -435,7 +435,7 @@ export function exportMessagesToExcel(messages, { title } = {}) {
                 <th>Type</th>
                 <th>Message</th>
                 <th>Resources</th>
-                <th>Study Notes</th>
+                <th>Notes</th>
               </tr>
             </thead>
             <tbody>
@@ -568,7 +568,7 @@ export function exportAsText(messages) {
       }
       
       if (msg.isStudyNotes) {
-        textContent += '[Study Notes Generated]\n\n';
+        textContent += '[Notes Generated]\n\n';
       }
       
       textContent += '='.repeat(80) + '\n\n';


### PR DESCRIPTION
## Summary
- remove the Generate QA Summary panel from the My Resources tab so the control only appears in its dedicated summary tab
- retitle the summary controls from "Generate QA Summary" to "Generate Summary"

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8157fa394832a9991d7e374202f6b