### PR TITLE
Align AI model defaults with ChatGPT 4.1

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -79,13 +79,14 @@ const Header = memo(({
     <header className="bg-gray-50 border-b border-gray-200">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center h-16">
-          <div className="flex-shrink-0">
+          <div className="flex-shrink-0 flex items-center space-x-2">
             <img
               src="/AceleraQA_logo.png"
               alt="AcceleraQA logo"
               width="180"
               height="20"
             />
+            <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">|beta</span>
           </div>
 
           <div className="relative flex items-center space-x-4 ml-auto">

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -7,8 +7,8 @@ export const APP_CONFIG = {
 
 // OpenAI Configuration
 export const OPENAI_CONFIG = {
-  MODEL: 'gpt-4o-mini',
-  SUGGESTIONS_MODEL: 'gpt-4o-mini',
+  MODEL: 'chatgpt-4.1',
+  SUGGESTIONS_MODEL: 'gpt-4.1-mini',
   MAX_TOKENS: 1200,
   TEMPERATURE: 0.7,
   SYSTEM_PROMPT: `You are AcceleraQA, an AI assistant for pharmaceutical quality, compliance, and clinical trial integrity.

--- a/src/config/modelConfig.js
+++ b/src/config/modelConfig.js
@@ -2,9 +2,9 @@ import { isStorageAvailable } from '../utils/storageUtils';
 
 export const MODEL_STORAGE_KEY = 'acceleraqa_ai_model';
 
-export const MODEL_OPTIONS = ['gpt-5o', 'gpt-4o-mini', 'gpt-4o', 'gpt-3.5-turbo'];
+export const MODEL_OPTIONS = ['chatgpt-4.1', 'gpt-4.1-mini', 'gpt-4o', 'gpt-3.5-turbo'];
 
-export const DEFAULT_MODEL = 'gpt-4o-mini';
+export const DEFAULT_MODEL = 'chatgpt-4.1';
 
 export function getCurrentModel() {
   try {


### PR DESCRIPTION
## Summary
- set the primary chat model default and configuration to `chatgpt-4.1`
- retain the resource center on `gpt-4.1-mini` while updating selectable model options
- display a beta label next to the header logo

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d8200d13c4832aa09547840af4ee6d