### PR TITLE
Support conversation history in RAG follow-up queries

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -554,7 +554,7 @@ function App() {
         : undefined;
 
       const response = ragEnabled && !preparedFile
-        ? await ragSearch(rawInput, user?.sub, ragSearchOptions)
+        ? await ragSearch(rawInput, user?.sub, ragSearchOptions, conversationHistory)
         : await openaiService.getChatResponse(
             rawInput,
             preparedFile,

--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -908,9 +908,9 @@ class RAGService {
     return result;
   }
 
-  async generateRAGResponse(query, userId, options = {}) {
+  async generateRAGResponse(query, userId, options = {}, conversationHistory = []) {
     if (this.isNeonBackend()) {
-      return this.generateNeonRagResponse(query, userId, options);
+      return this.generateNeonRagResponse(query, userId, options, conversationHistory);
     }
 
 
@@ -918,6 +918,77 @@ class RAGService {
     if (!trimmedQuery) {
       throw new Error('Query is required to generate a response');
     }
+
+    const normalizedHistory = Array.isArray(conversationHistory)
+      ? conversationHistory
+          .map(item => {
+            if (!item || typeof item !== 'object') {
+              return null;
+            }
+
+            const role = item.role === 'assistant' || item.role === 'user'
+              ? item.role
+              : item.type === 'ai'
+                ? 'assistant'
+                : item.type === 'user'
+                  ? 'user'
+                  : null;
+
+            if (role !== 'assistant' && role !== 'user') {
+              return null;
+            }
+
+            let textContent = '';
+
+            if (typeof item.content === 'string') {
+              textContent = item.content;
+            } else if (Array.isArray(item.content)) {
+              textContent = item.content
+                .map(part => {
+                  if (typeof part === 'string') {
+                    return part;
+                  }
+
+                  if (part && typeof part === 'object') {
+                    if (typeof part.text === 'string') {
+                      return part.text;
+                    }
+
+                    if (typeof part.value === 'string') {
+                      return part.value;
+                    }
+                  }
+
+                  return '';
+                })
+                .filter(Boolean)
+                .join(' ');
+            } else if (item.content && typeof item.content === 'object') {
+              if (typeof item.content.text === 'string') {
+                textContent = item.content.text;
+              } else if (typeof item.content.value === 'string') {
+                textContent = item.content.value;
+              }
+            }
+
+            const trimmedText = typeof textContent === 'string' ? textContent.trim() : '';
+
+            if (!trimmedText) {
+              return null;
+            }
+
+            return {
+              role,
+              content: [
+                {
+                  type: 'input_text',
+                  text: trimmedText,
+                },
+              ],
+            };
+          })
+          .filter(Boolean)
+      : [];
 
     const includeDefaultVectorStore = options?.includeDefaultVectorStore !== false;
     let defaultVectorStoreId = null;
@@ -958,13 +1029,13 @@ class RAGService {
     const body = {
       model: getCurrentModel(),
       input: [
+        ...normalizedHistory,
         {
           role: 'user',
           content: [
             {
               type: 'input_text',
               text: trimmedQuery,
-
             },
           ],
         },
@@ -1270,7 +1341,7 @@ class RAGService {
     };
   }
 
-  async generateNeonRagResponse(query, userId, options = {}) {
+  async generateNeonRagResponse(query, userId, options = {}, conversationHistory = []) {
     if (!userId) {
       throw new Error('User ID is required for Neon RAG responses');
     }
@@ -1278,6 +1349,11 @@ class RAGService {
     const trimmedQuery = (query || '').trim();
     if (!trimmedQuery) {
       throw new Error('Search query is required');
+    }
+
+    if (Array.isArray(conversationHistory) && conversationHistory.length > 0) {
+      // Neon backend currently builds prompts without multi-turn context.
+      // The parameter is accepted to keep parity with the OpenAI search implementation.
     }
 
     const searchOptions = {
@@ -1370,9 +1446,9 @@ class RAGService {
     };
   }
 
-  async search(query, userId, options = {}) {
+  async search(query, userId, options = {}, conversationHistory = []) {
     try {
-      const response = await this.generateRAGResponse(query, userId, options);
+      const response = await this.generateRAGResponse(query, userId, options, conversationHistory);
       return {
         answer: response.answer,
         sources: response.sources || [],
@@ -1619,12 +1695,14 @@ const ragService = new RAGService();
 export default ragService;
 
 export const uploadDocument = (file, metadata, userId) => ragService.uploadDocument(file, metadata, userId);
-export const search = (query, userId, options = {}) => ragService.search(query, userId, options);
+export const search = (query, userId, options = {}, conversationHistory = []) =>
+  ragService.search(query, userId, options, conversationHistory);
 export const searchDocuments = (query, options = {}, userId) => ragService.searchDocuments(query, options, userId);
 export const getDocuments = (userId) => ragService.getDocuments(userId);
 export const deleteDocument = (documentId, userId) => ragService.deleteDocument(documentId, userId);
 export const downloadDocument = (documentReference, userId) => ragService.downloadDocument(documentReference, userId);
-export const generateRAGResponse = (query, userId, options = {}) => ragService.generateRAGResponse(query, userId, options);
+export const generateRAGResponse = (query, userId, options = {}, conversationHistory = []) =>
+  ragService.generateRAGResponse(query, userId, options, conversationHistory);
 export const testConnection = (userId) => ragService.testConnection(userId);
 export const getStats = (userId) => ragService.getStats(userId);
 export const runDiagnostics = (userId) => ragService.runDiagnostics(userId);

--- a/src/services/ragService.test.js
+++ b/src/services/ragService.test.js
@@ -322,6 +322,71 @@ describe('document persistence with Neon metadata store', () => {
     expect(tools).toHaveLength(1);
     expect(tools[0].vector_store_ids).toEqual(['vs_default_user', additionalVectorStore]);
   });
+
+  test('generateRAGResponse includes prior conversation turns when provided', async () => {
+    const uploadOptions = { documentApiMock, uploadFileId: 'file_rag_history', vectorStoreId: 'vs_history_user' };
+    const { ragService, mocks } = await loadRagService(uploadOptions);
+
+    const capturedBodies = [];
+    mocks.openai.makeRequest.mockImplementation(async (endpoint, options = {}) => {
+      if (endpoint === '/responses') {
+        const parsedBody = options?.body ? JSON.parse(options.body) : {};
+        capturedBodies.push(parsedBody);
+        return {
+          output: [],
+          output_text: 'History aware answer',
+          usage: {},
+        };
+      }
+
+      if (endpoint === '/files') {
+        return { data: [] };
+      }
+
+      return { success: true };
+    });
+
+    const conversationHistory = [
+      { role: 'user', content: 'What is GMP?' },
+      { role: 'assistant', content: 'GMP stands for Good Manufacturing Practice.' },
+      { role: 'assistant', content: '   ' },
+      { role: 'system', content: 'ignored' },
+    ];
+
+    await ragService.generateRAGResponse('And what does it ensure?', 'user-history-1', {}, conversationHistory);
+
+    expect(capturedBodies).toHaveLength(1);
+    const { input } = capturedBodies[0];
+    expect(Array.isArray(input)).toBe(true);
+    expect(input).toHaveLength(3);
+    expect(input[0]).toEqual({
+      role: 'user',
+      content: [
+        {
+          type: 'input_text',
+          text: 'What is GMP?',
+        },
+      ],
+    });
+    expect(input[1]).toEqual({
+      role: 'assistant',
+      content: [
+        {
+          type: 'input_text',
+          text: 'GMP stands for Good Manufacturing Practice.',
+        },
+      ],
+    });
+    expect(input[2]).toEqual({
+      role: 'user',
+      content: [
+        {
+          type: 'input_text',
+          text: 'And what does it ensure?',
+        },
+      ],
+    });
+  });
 });
 
 describe('downloadDocument', () => {

--- a/src/utils/messageUtils.js
+++ b/src/utils/messageUtils.js
@@ -239,7 +239,7 @@ export function buildChatHistory(messages) {
         return null;
       }
 
-      return { role, content };
+      return { role, content: trimmed };
     })
     .filter(Boolean);
 }

--- a/src/utils/messageUtils.test.js
+++ b/src/utils/messageUtils.test.js
@@ -26,4 +26,18 @@ describe('buildChatHistory', () => {
     expect(buildChatHistory(undefined)).toEqual([]);
     expect(buildChatHistory([{ id: '1', type: 'ai', content: '   ' }])).toEqual([]);
   });
+
+  it('omits empty or unsupported entries and trims retained content', () => {
+    const messages = [
+      { id: '7', role: 'system', content: 'Ignore me', timestamp: 7 },
+      { id: '8', role: 'user', content: '  Prior question?  ', timestamp: 8 },
+      { id: '9', role: 'assistant', content: ['Prior answer.  ', '   '], timestamp: 9 },
+      { id: '10', role: 'assistant', content: '   ', timestamp: 10 },
+    ];
+
+    expect(buildChatHistory(messages)).toEqual([
+      { role: 'user', content: 'Prior question?' },
+      { role: 'assistant', content: 'Prior answer.' },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- allow ragService search and response generation to accept optional conversation history turns and include them in the OpenAI payload
- pass the existing chat history from the app to ragSearch and trim empty history entries
- extend messageUtils and ragService unit tests to cover conversation history filtering and multi-turn RAG requests

## Testing
- CI=true npm test -- --runTestsByPath src/utils/messageUtils.test.js src/services/ragService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d853780a1c832aa54802770dcc2a2b