### PR TITLE
Switch RAG workflow to Neon-backed Netlify functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ npm run build
 ### AI Integration
 - OpenAI GPT-4 integration
 - Pharmaceutical-specific prompts
-- File uploads via Files API with in-message file references
-- Document metadata and vector store IDs persisted in Neon PostgreSQL for cross-device access while files remain in OpenAI's File Assistant
+- Document ingestion and retrieval via Netlify functions backed by Neon PostgreSQL full-text search
+- Secure document metadata persistence in Neon for cross-device access
 - Error handling and rate limiting
 - Usage tracking
 
@@ -194,7 +194,9 @@ npm run build
 2. Set environment variables in Netlify dashboard
    - `OPENAI_API_KEY` for serverless calls to OpenAI
    - `REACT_APP_OPENAI_API_KEY` for client-side features
-3. Deploy with automatic builds. Netlify will expose the `openai-file-search` function at `/api/rag/*` to proxy requests to OpenAI's file-search API.
+   - `NEON_DATABASE_URL` for the Neon PostgreSQL document store
+   - `REACT_APP_RAG_BACKEND=neon` if you need to override the default locally
+3. Deploy with automatic builds. Netlify will execute the Neon-backed RAG functions to serve document search and storage.
 
 ### Environment Variables in Netlify:
 ```bash
@@ -208,13 +210,7 @@ JIRA_API_TOKEN=your_atlassian_api_token
 JIRA_SERVICE_DESK_ID=your_service_desk_id
 JIRA_REQUEST_TYPE_ID=your_request_type_id
 ```
-### Vector Store Preparation
-
-Run the OpenAI vector store setup script to create a store for RAG document search:
-
-```bash
-npm run setup:vectorstore
-```
+> **Note:** The RAG workflow now uses the Neon-backed Netlify functions (`neon-rag-fixed`, `neon-db`, and `rag-documents`) instead of the OpenAI File Assistant. Ensure your Neon connection string has permission to create the required tables on first run.
 ## 🔍 Troubleshooting
 
 ### Common Issues

--- a/src/App.js
+++ b/src/App.js
@@ -178,6 +178,7 @@ function App() {
   );
   const adminResourcesLoadedRef = useRef(false);
   const inactivityTimerRef = useRef(null);
+  const usesNeonBackend = useMemo(() => ragService.isNeonBackend(), []);
 
   const handleLogoutComplete = useCallback(() => {
     setIsAuthenticated(false);
@@ -546,10 +547,12 @@ function App() {
       return;
     }
 
-    const vectorStoreIdToUse = preparedFile ? null : activeDocument?.vectorStoreId || null;
+    const vectorStoreIdToUse = usesNeonBackend || preparedFile
+      ? null
+      : activeDocument?.vectorStoreId || null;
 
     try {
-      const ragSearchOptions = activeDocument?.vectorStoreId
+      const ragSearchOptions = !usesNeonBackend && activeDocument?.vectorStoreId
         ? { vectorStoreIds: [activeDocument.vectorStoreId] }
         : undefined;
 
@@ -588,7 +591,7 @@ function App() {
 
       setMessages((prev) => [...prev, assistantMessage]);
 
-      if (response.vectorStoreId) {
+      if (!usesNeonBackend && response.vectorStoreId) {
         if (preparedFile) {
           const now = Date.now();
           setActiveDocument({

--- a/src/config/ragConfig.js
+++ b/src/config/ragConfig.js
@@ -6,7 +6,7 @@ export const RAG_BACKENDS = {
 const backendEnv = (process.env.REACT_APP_RAG_BACKEND || '').toLowerCase();
 export const RAG_BACKEND = Object.values(RAG_BACKENDS).includes(backendEnv)
   ? backendEnv
-  : RAG_BACKENDS.OPENAI;
+  : RAG_BACKENDS.NEON;
 
 const DEFAULT_NEON_FUNCTION = '/.netlify/functions/neon-rag-fixed';
 const DEFAULT_NEON_DB_FUNCTION = '/.netlify/functions/neon-db';
@@ -19,9 +19,11 @@ export const RAG_DOCS_FUNCTION = process.env.REACT_APP_RAG_DOCS_FUNCTION || DEFA
 export const isNeonBackend = () => RAG_BACKEND === RAG_BACKENDS.NEON;
 
 export const getRagBackendLabel = () =>
-  RAG_BACKEND === RAG_BACKENDS.NEON ? 'Neon PostgreSQL' : 'OpenAI File Search';
+  RAG_BACKEND === RAG_BACKENDS.NEON
+    ? 'Neon PostgreSQL (Netlify Functions)'
+    : 'OpenAI File Search';
 
 export const getRagSearchDescription = () =>
   RAG_BACKEND === RAG_BACKENDS.NEON
-    ? 'Search your uploaded documents using PostgreSQL full-text search with ranking.'
+    ? 'Search your uploaded documents using the Netlify Neon PostgreSQL full-text pipeline.'
     : 'Search your uploaded documents using OpenAI vector search with Assistants API.';

--- a/src/services/ragService.test.js
+++ b/src/services/ragService.test.js
@@ -4,444 +4,170 @@ import { TextEncoder, TextDecoder } from 'util';
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 
-const pdfSupported = false;
-
-function createPdfFile() {
-  const pdfContent = `%PDF-1.3\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj\n3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 144]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj\n4 0 obj<</Length 44>>stream\nBT\n/F1 24 Tf\n72 96 Td\n(Hello PDF) Tj\nET\nendstream\nendobj\n5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\nxref\n0 6\n0000000000 65535 f \n0000000010 00000 n \n0000000061 00000 n \n0000000112 00000 n \n0000000221 00000 n \n0000000332 00000 n \ntrailer<</Size 6/Root 1 0 R>>\nstartxref\n383\n%%EOF`;
-  const buffer = Buffer.from(pdfContent, 'utf-8');
-  const arrayBuf = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
-  return {
-    name: 'sample.pdf',
-    type: 'application/pdf',
-    size: buffer.length,
-    arrayBuffer: async () => arrayBuf,
-  };
-}
-
-const createDocumentApiMock = (userStore) => {
-  const calls = [];
-  const handler = async (action, userId, payload = {}) => {
-    calls.push([action, userId, payload]);
-    if (!userStore.has(userId)) {
-      userStore.set(userId, { vectorStoreId: null, documents: [] });
-    }
-    const state = userStore.get(userId);
-
-    switch (action) {
-      case 'health':
-        return { status: 'ok' };
-      case 'get_vector_store':
-        return { vectorStoreId: state.vectorStoreId };
-      case 'set_vector_store':
-        state.vectorStoreId = payload.vectorStoreId;
-        return { vectorStoreId: state.vectorStoreId };
-      case 'list_documents':
-        return { documents: state.documents };
-      case 'save_document': {
-        const incoming = payload.document || {};
-        const id = incoming.id || incoming.fileId;
-        const stored = {
-          ...incoming,
-          id,
-          fileId: incoming.fileId || id,
-          createdAt: incoming.createdAt || new Date().toISOString(),
-        };
-        const existingIndex = state.documents.findIndex(doc => doc.id === id);
-        if (existingIndex >= 0) {
-          state.documents[existingIndex] = stored;
-        } else {
-          state.documents.push(stored);
-        }
-        return { document: stored };
-      }
-      case 'delete_document':
-        state.documents = state.documents.filter(doc => doc.id !== payload.documentId);
-        return { success: true };
-      default:
-        return { error: `unsupported action: ${action}` };
-    }
-  };
-
-  handler.calls = calls;
-  handler.clear = () => {
-    calls.length = 0;
-  };
-
-  return handler;
-};
-
-const loadRagService = async ({ documentApiMock, uploadFileId = 'file_mock', vectorStoreId = 'vs_mock' } = {}) => {
+const setupNeonRagService = async ({ neonResponses = {}, chatResponse } = {}) => {
   jest.resetModules();
 
+  process.env.REACT_APP_RAG_BACKEND = 'neon';
   process.env.REACT_APP_OPENAI_API_KEY = 'test-key';
-  process.env.REACT_APP_RAG_BACKEND = 'openai';
 
-  const authModule = await import('./authService.js');
-  const getTokenSpy = jest.spyOn(authModule, 'getToken').mockResolvedValue('test-token');
-  const getUserIdSpy = jest.spyOn(authModule, 'getUserId').mockResolvedValue('test-user');
+  const ragModule = await import('./ragService.js');
+  const ragService = ragModule.default;
+
+  const makeNeonRequestSpy = jest
+    .spyOn(ragService, 'makeNeonRequest')
+    .mockImplementation(async (action, userId, payload = {}) => {
+      const handler = neonResponses[action];
+      if (typeof handler === 'function') {
+        return handler(userId, payload);
+      }
+      if (handler) {
+        return handler;
+      }
+      return {};
+    });
+
+  jest.spyOn(ragService, 'extractTextFromFile').mockResolvedValue('Document text');
 
   const openaiModule = await import('./openaiService.js');
-  const uploadFileSpy = jest.spyOn(openaiModule.default, 'uploadFile').mockResolvedValue(uploadFileId);
-  const createVectorStoreSpy = jest
-    .spyOn(openaiModule.default, 'createVectorStore')
-    .mockResolvedValue(vectorStoreId);
-  const attachFileSpy = jest
-    .spyOn(openaiModule.default, 'attachFileToVectorStore')
-    .mockResolvedValue({});
-  const makeRequestSpy = jest
-    .spyOn(openaiModule.default, 'makeRequest')
-    .mockImplementation(async (endpoint) => {
-      if (endpoint === '/files') {
-        return { data: [{ id: uploadFileId }] };
-      }
-      return { success: true };
-    });
+  const chatSpy = jest
+    .spyOn(openaiModule.default, 'getChatResponse')
+    .mockResolvedValue(chatResponse || { answer: 'Example response', resources: [] });
 
-  const module = await import('./ragService.js');
-  const ragServiceInstance = module.default;
-  const convertMock = jest.fn(async (file) => ({
-    file,
-    converted: false,
-    originalFileName: file?.name || null,
-    originalMimeType: file?.type || null,
-    conversion: null,
-  }));
-  ragServiceInstance.convertDocxToPdfIfNeeded = convertMock;
-  let documentApiSpy = null;
-  if (documentApiMock) {
-    documentApiSpy = jest
-      .spyOn(ragServiceInstance, 'makeDocumentMetadataRequest')
-      .mockImplementation((action, userId, payload = {}) => documentApiMock(action, userId, payload));
-  }
-
-  return {
-    ragService: ragServiceInstance,
-    mocks: {
-      getToken: getTokenSpy,
-      getUserId: getUserIdSpy,
-      openai: {
-        uploadFile: uploadFileSpy,
-        createVectorStore: createVectorStoreSpy,
-        attachFileToVectorStore: attachFileSpy,
-        makeRequest: makeRequestSpy,
-      },
-      convertDocxToPdfIfNeeded: convertMock,
-      documentApi: documentApiSpy,
-    },
-  };
+  return { ragService, makeNeonRequestSpy, chatSpy };
 };
 
-describe('ragService PDF extraction', () => {
-  (pdfSupported ? test : test.skip)('extracts text from a PDF', async () => {
-    const { ragService } = await loadRagService();
-    const file = createPdfFile();
-    const text = await ragService.extractTextFromFile(file);
-    expect(text).toContain('Hello PDF');
-  });
+afterEach(() => {
+  jest.restoreAllMocks();
+  delete process.env.REACT_APP_RAG_BACKEND;
+  delete process.env.REACT_APP_OPENAI_API_KEY;
 });
 
-describe('neon-rag-fixed upload chunking', () => {
-  (pdfSupported ? test : test.skip)('stores PDF text chunks', async () => {
-    const { ragService } = await loadRagService();
-    const file = createPdfFile();
-    const text = await ragService.extractTextFromFile(file);
-
-    process.env.NEON_DATABASE_URL = 'postgres://user:pass@localhost/db';
-    process.env.REACT_APP_AUTH0_DOMAIN = 'example.com';
-    process.env.REACT_APP_AUTH0_AUDIENCE = 'test';
-
-    const client = {
-      query: jest.fn().mockImplementation((q, params) => {
-        if (q.includes('INSERT INTO rag_documents')) {
-          return { rows: [{ id: 1, filename: params[1], created_at: 'now' }] };
-        }
-        return { rows: [] };
+describe('ragService neon backend integration', () => {
+  test('uploadDocument sends sanitized metadata to Neon', async () => {
+    const neonResponses = {
+      upload: (_userId, payload) => ({
+        id: 'doc-1',
+        filename: payload.document.filename,
+        metadata: payload.document.metadata,
+        message: 'stored',
       }),
-      release: jest.fn(),
-    };
-    const connect = jest.fn().mockResolvedValue(client);
-
-    await jest.unstable_mockModule('@neondatabase/serverless', () => ({
-      Pool: jest.fn(() => ({ connect })),
-      neonConfig: {},
-    }));
-    await jest.unstable_mockModule('ws', () => ({ default: class {} }));
-
-    const { handler } = await import('../../netlify/functions/neon-rag-fixed.js');
-    const event = {
-      httpMethod: 'POST',
-      headers: { 'x-user-id': 'user1' },
-      body: JSON.stringify({ action: 'upload', document: { filename: 'sample.pdf', text } }),
-    };
-    const res = await handler(event, {});
-    const body = JSON.parse(res.body);
-    expect(res.statusCode).toBe(201);
-    expect(body.chunks).toBeGreaterThan(0);
-    const chunkCalls = client.query.mock.calls.filter(([q]) => q.includes('rag_document_chunks'));
-    expect(chunkCalls.length).toBe(body.chunks);
-  });
-});
-
-describe('document persistence with Neon metadata store', () => {
-  const userStore = new Map();
-  const documentApiMock = createDocumentApiMock(userStore);
-
-  beforeEach(() => {
-    userStore.clear();
-    documentApiMock.clear();
-  });
-
-  test('documents uploaded in one session are available in a fresh session', async () => {
-    const uploadOptions = { documentApiMock, uploadFileId: 'file_doc_1', vectorStoreId: 'vs_persist_1' };
-    const { ragService: firstSession, mocks: firstMocks } = await loadRagService(uploadOptions);
-
-    const file = { name: 'SOP.pdf', type: 'application/pdf', size: 2048 };
-    await firstSession.uploadDocument(file, { category: 'quality' }, 'user-123');
-
-    expect(firstMocks.openai.uploadFile).toHaveBeenCalledTimes(1);
-    expect(firstMocks.openai.createVectorStore).toHaveBeenCalledTimes(1);
-
-    const callSummary = documentApiMock.calls.map(([action, user]) => [action, user]);
-    expect(callSummary).toEqual([
-      ['get_vector_store', 'user-123'],
-      ['set_vector_store', 'user-123'],
-      ['save_document', 'user-123'],
-    ]);
-    expect([...userStore.keys()]).toEqual(['user-123']);
-
-    const persistedAfterUpload = userStore.get('user-123');
-    expect(persistedAfterUpload.documents).toHaveLength(1);
-
-    const sessionOneDocs = await firstSession.getDocuments('user-123');
-    expect(sessionOneDocs).toHaveLength(1);
-    expect(sessionOneDocs[0].filename).toBe('SOP.pdf');
-
-    const { ragService: secondSession, mocks: secondMocks } = await loadRagService(uploadOptions);
-    const sessionTwoDocs = await secondSession.getDocuments('user-123');
-    expect(sessionTwoDocs).toHaveLength(1);
-    expect(sessionTwoDocs[0].id).toBe('file_doc_1');
-    expect(sessionTwoDocs[0].filename).toBe('SOP.pdf');
-
-    const vectorStoreId = await secondSession.getVectorStoreId('user-123');
-    expect(vectorStoreId).toBe('vs_persist_1');
-    expect(secondMocks.openai.createVectorStore).not.toHaveBeenCalled();
-
-    const persistedState = userStore.get('user-123');
-    expect(persistedState.vectorStoreId).toBe('vs_persist_1');
-    expect(persistedState.documents).toHaveLength(1);
-    expect(persistedState.documents[0].id).toBe('file_doc_1');
-  });
-
-  test('docx uploads are converted and metadata keeps original details', async () => {
-    const uploadOptions = { documentApiMock, uploadFileId: 'file_docx_1', vectorStoreId: 'vs_docx_1' };
-    const { ragService, mocks } = await loadRagService(uploadOptions);
-
-    const originalFile = {
-      name: 'Guideline.docx',
-      type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      size: 1024,
     };
 
-    const convertedFile = {
-      name: 'Guideline.pdf',
-      type: 'application/pdf',
-      size: 2048,
-    };
+    const { ragService, makeNeonRequestSpy } = await setupNeonRagService({ neonResponses });
 
-    mocks.convertDocxToPdfIfNeeded.mockResolvedValue({
-      file: convertedFile,
-      converted: true,
-      originalFileName: originalFile.name,
-      originalMimeType: originalFile.type,
-      conversion: 'docx-to-pdf',
-    });
+    const file = { name: 'Policy.pdf', type: 'application/pdf', size: 2048 };
 
-    await ragService.uploadDocument(originalFile, { category: 'quality' }, 'user-456');
-
-    expect(mocks.convertDocxToPdfIfNeeded).toHaveBeenCalledWith(originalFile);
-    expect(mocks.openai.uploadFile).toHaveBeenCalledWith(convertedFile);
-
-    const saveCall = documentApiMock.calls.find(([action]) => action === 'save_document');
-    expect(saveCall).toBeTruthy();
-    const savedDoc = saveCall[2].document;
-    expect(savedDoc.filename).toBe(convertedFile.name);
-    expect(savedDoc.type).toBe(convertedFile.type);
-    expect(savedDoc.metadata.originalFilename).toBe(originalFile.name);
-    expect(savedDoc.metadata.originalMimeType).toBe(originalFile.type);
-    expect(savedDoc.metadata.conversion).toBe('docx-to-pdf');
-  });
-
-  test('captures version metadata when provided', async () => {
-    const uploadOptions = { documentApiMock, uploadFileId: 'file_version_1', vectorStoreId: 'vs_version_1' };
-    const { ragService } = await loadRagService(uploadOptions);
-
-    const file = { name: 'Procedure.pdf', type: 'application/pdf', size: 4096 };
-    await ragService.uploadDocument(file, { category: 'quality', version: '  Rev 2 ' }, 'user-789');
-
-    const saveCall = documentApiMock.calls.find(([action]) => action === 'save_document');
-    expect(saveCall).toBeTruthy();
-    const savedMetadata = saveCall[2].document.metadata;
-    expect(savedMetadata.version).toBe('Rev 2');
-
-    const docs = await ragService.getDocuments('user-789');
-    expect(docs).toHaveLength(1);
-    expect(docs[0].metadata.version).toBe('Rev 2');
-  });
-
-  test('captures base64 document content when file size is within persistence limit', async () => {
-    const uploadOptions = { documentApiMock, uploadFileId: 'file_content_1', vectorStoreId: 'vs_content_1' };
-    const { ragService } = await loadRagService(uploadOptions);
-
-    const buffer = Buffer.from('document payload for persistence test', 'utf8');
-    const arrayBuffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
-
-    const file = {
-      name: 'Content.pdf',
-      type: 'application/pdf',
-      size: buffer.length,
-      arrayBuffer: async () => arrayBuffer,
-    };
-
-    await ragService.uploadDocument(file, {}, 'user-content');
-
-    const saveCall = documentApiMock.calls.find(([action]) => action === 'save_document');
-    expect(saveCall).toBeTruthy();
-    const savedDoc = saveCall[2].document;
-    expect(savedDoc.encoding).toBe('base64');
-    expect(savedDoc.content).toBe(buffer.toString('base64'));
-  });
-
-  test('generateRAGResponse merges user upload vector stores into search', async () => {
-    const uploadOptions = { documentApiMock, uploadFileId: 'file_rag_1', vectorStoreId: 'vs_default_user' };
-    const { ragService, mocks } = await loadRagService(uploadOptions);
-
-    const capturedBodies = [];
-    mocks.openai.makeRequest.mockImplementation(async (endpoint, options = {}) => {
-      if (endpoint === '/responses') {
-        const parsedBody = options?.body ? JSON.parse(options.body) : {};
-        capturedBodies.push(parsedBody);
-        return {
-          output: [],
-          output_text: 'Search answer',
-          usage: {},
-        };
-      }
-
-      if (endpoint === '/files') {
-        return { data: [] };
-      }
-
-      return { success: true };
-    });
-
-    const additionalVectorStore = 'vs_active_upload';
-    const response = await ragService.generateRAGResponse('Explain CAPA expectations', 'user-search-1', {
-      vectorStoreIds: [additionalVectorStore, '  ', null, additionalVectorStore],
-    });
-
-    expect(response.answer).toBe('Search answer');
-    expect(capturedBodies).toHaveLength(1);
-    const tools = capturedBodies[0]?.tools || [];
-    expect(tools).toHaveLength(1);
-    expect(tools[0].vector_store_ids).toEqual(['vs_default_user', additionalVectorStore]);
-  });
-
-  test('generateRAGResponse includes prior conversation turns when provided', async () => {
-    const uploadOptions = { documentApiMock, uploadFileId: 'file_rag_history', vectorStoreId: 'vs_history_user' };
-    const { ragService, mocks } = await loadRagService(uploadOptions);
-
-    const capturedBodies = [];
-    mocks.openai.makeRequest.mockImplementation(async (endpoint, options = {}) => {
-      if (endpoint === '/responses') {
-        const parsedBody = options?.body ? JSON.parse(options.body) : {};
-        capturedBodies.push(parsedBody);
-        return {
-          output: [],
-          output_text: 'History aware answer',
-          usage: {},
-        };
-      }
-
-      if (endpoint === '/files') {
-        return { data: [] };
-      }
-
-      return { success: true };
-    });
-
-    const conversationHistory = [
-      { role: 'user', content: 'What is GMP?' },
-      { role: 'assistant', content: 'GMP stands for Good Manufacturing Practice.' },
-      { role: 'assistant', content: '   ' },
-      { role: 'system', content: 'ignored' },
-    ];
-
-    await ragService.generateRAGResponse('And what does it ensure?', 'user-history-1', {}, conversationHistory);
-
-    expect(capturedBodies).toHaveLength(1);
-    const { input } = capturedBodies[0];
-    expect(Array.isArray(input)).toBe(true);
-    expect(input).toHaveLength(3);
-    expect(input[0]).toEqual({
-      role: 'user',
-      content: [
-        {
-          type: 'input_text',
-          text: 'What is GMP?',
-        },
-      ],
-    });
-    expect(input[1]).toEqual({
-      role: 'assistant',
-      content: [
-        {
-          type: 'output_text',
-          text: 'GMP stands for Good Manufacturing Practice.',
-        },
-      ],
-    });
-    expect(input[2]).toEqual({
-      role: 'user',
-      content: [
-        {
-          type: 'input_text',
-          text: 'And what does it ensure?',
-        },
-      ],
-    });
-  });
-});
-
-describe('downloadDocument', () => {
-  test('requests document content through metadata service', async () => {
-    const downloadResponse = {
-      filename: 'Quality_Event_SOP.pdf',
-      contentType: 'application/pdf',
-      content: Buffer.from('pdf-content').toString('base64'),
-      encoding: 'base64',
-    };
-
-    const documentApiMock = jest.fn(async (action, userId, payload) => {
-      if (action === 'download_document') {
-        expect(userId).toBe('user-download');
-        expect(payload).toEqual({ documentId: 'doc-download-1' });
-        return downloadResponse;
-      }
-      return { documents: [] };
-    });
-
-    const { ragService } = await loadRagService({ documentApiMock });
-    const result = await ragService.downloadDocument('doc-download-1', 'user-download');
-
-    expect(documentApiMock).toHaveBeenCalledWith('download_document', 'user-download', { documentId: 'doc-download-1' });
-    expect(result).toEqual(downloadResponse);
-  });
-
-  test('throws when no identifier provided', async () => {
-    const { ragService } = await loadRagService({ documentApiMock: jest.fn() });
-    await expect(ragService.downloadDocument({}, 'user-download')).rejects.toThrow(
-      'documentId or fileId is required to download a document'
+    const result = await ragService.uploadDocument(
+      file,
+      { title: '  Policy Overview ', tags: ' gmp , qa ' },
+      'user-1'
     );
+
+    expect(makeNeonRequestSpy).toHaveBeenCalledWith(
+      'upload',
+      'user-1',
+      expect.objectContaining({
+        document: expect.objectContaining({
+          filename: 'Policy.pdf',
+          metadata: expect.objectContaining({
+            title: 'Policy Overview',
+            tags: ['gmp', 'qa'],
+            processingMode: 'neon-postgresql',
+          }),
+        }),
+      })
+    );
+
+    expect(result.storage).toBe('neon-postgresql');
+    expect(result.metadata.title).toBe('Policy Overview');
+    expect(result.metadata.tags).toEqual(['gmp', 'qa']);
   });
 
+  test('getDocuments returns Neon document list', async () => {
+    const neonResponses = {
+      list: () => ({
+        documents: [
+          { id: 'doc-1', filename: 'Doc.pdf', metadata: { title: 'Doc' } },
+          { id: 'doc-2', filename: 'Guide.pdf', metadata: { title: 'Guide' } },
+        ],
+      }),
+    };
+
+    const { ragService, makeNeonRequestSpy } = await setupNeonRagService({ neonResponses });
+
+    const documents = await ragService.getDocuments('user-2');
+
+    expect(makeNeonRequestSpy).toHaveBeenCalledWith('list', 'user-2');
+    expect(documents).toHaveLength(2);
+    expect(documents[0].filename).toBe('Doc.pdf');
+  });
+
+  test('searchDocuments proxies to Neon search', async () => {
+    const neonResponses = {
+      search: (_userId, payload) => {
+        expect(payload.query).toBe('gmp compliance');
+        return {
+          results: [
+            {
+              documentId: 'doc-1',
+              filename: 'Doc.pdf',
+              chunkIndex: 0,
+              text: 'Example text',
+            },
+          ],
+        };
+      },
+    };
+
+    const { ragService, makeNeonRequestSpy } = await setupNeonRagService({ neonResponses });
+
+    const result = await ragService.searchDocuments('gmp compliance', { limit: 1 }, 'user-3');
+
+    expect(makeNeonRequestSpy).toHaveBeenCalledWith(
+      'search',
+      'user-3',
+      expect.objectContaining({ query: 'gmp compliance', options: expect.objectContaining({ limit: 1 }) })
+    );
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].documentId).toBe('doc-1');
+  });
+
+  test('generateRAGResponse builds context from Neon search results', async () => {
+    const neonResponses = {
+      search: () => ({
+        results: [
+          {
+            documentId: 'doc-1',
+            filename: 'Doc.pdf',
+            chunkIndex: 0,
+            text: 'Follow GMP Annex 1 guidance for aseptic processing.',
+            metadata: { documentTitle: 'GMP Annex 1' },
+          },
+        ],
+      }),
+    };
+
+    const chatResponse = {
+      answer: 'Maintain aseptic controls as outlined in GMP Annex 1.',
+      resources: [{ title: 'Internal SOP', url: 'https://example.com/sop' }],
+    };
+
+    const { ragService, makeNeonRequestSpy, chatSpy } = await setupNeonRagService({
+      neonResponses,
+      chatResponse,
+    });
+
+    const result = await ragService.generateRAGResponse('How do we maintain aseptic controls?', 'user-4');
+
+    expect(makeNeonRequestSpy).toHaveBeenCalledWith(
+      'search',
+      'user-4',
+      expect.objectContaining({ query: 'How do we maintain aseptic controls?' })
+    );
+    expect(chatSpy).toHaveBeenCalled();
+    expect(result.sources).toHaveLength(1);
+    expect(result.sources[0].metadata.citationNumber).toBe(1);
+    expect(result.answer).toContain('References');
+    expect(result.resources).toEqual(chatResponse.resources);
+  });
 });


### PR DESCRIPTION
## Summary
- default the RAG backend to the Neon-powered Netlify functions and adjust the app to avoid OpenAI vector store assumptions
- refresh the README to highlight the Neon document pipeline and required environment variables
- replace the ragService tests to exercise the Neon upload/search flow

## Testing
- CI=1 npm test -- --runTestsByPath src/services/ragService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8712362c0832a986a9c39c9281e91