### PR TITLE
Group Resource Center conversations by thread

### DIFF
--- a/src/components/ResourcesView.js
+++ b/src/components/ResourcesView.js
@@ -21,7 +21,11 @@ import {
 import learningSuggestionsService from '../services/learningSuggestionsService';
 import { FEATURE_FLAGS } from '../config/featureFlags';
 import ConversationList from './ConversationList';
-import { combineMessagesIntoConversations, mergeCurrentAndStoredMessages } from '../utils/messageUtils';
+import {
+  combineMessagesIntoConversations,
+  mergeCurrentAndStoredMessages,
+  groupConversationsByThread,
+} from '../utils/messageUtils';
 import ragService from '../services/ragService';
 
 const isGzipCompressed = (bytes) =>
@@ -367,7 +371,9 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate, 
 
   const conversations = useMemo(() => {
     const merged = mergeCurrentAndStoredMessages(messages, thirtyDayMessages);
-    return combineMessagesIntoConversations(merged).slice(-20).reverse();
+    const combined = combineMessagesIntoConversations(merged);
+    const threaded = groupConversationsByThread(combined);
+    return threaded.slice(0, 20);
   }, [messages, thirtyDayMessages]);
 
   const filteredConversations = useMemo(() => {

--- a/src/utils/messageUtils.test.js
+++ b/src/utils/messageUtils.test.js
@@ -1,4 +1,4 @@
-import { buildChatHistory } from './messageUtils';
+import { buildChatHistory, groupConversationsByThread } from './messageUtils';
 
 describe('buildChatHistory', () => {
   it('filters conversation to user and assistant roles in order', () => {
@@ -38,6 +38,128 @@ describe('buildChatHistory', () => {
     expect(buildChatHistory(messages)).toEqual([
       { role: 'user', content: 'Prior question?' },
       { role: 'assistant', content: 'Prior answer.' },
+    ]);
+  });
+});
+
+describe('groupConversationsByThread', () => {
+  let idCounter = 0;
+  const nextId = (prefix) => {
+    idCounter += 1;
+    return `${prefix}-${idCounter}`;
+  };
+
+  const baseUserMessage = (overrides = {}) => ({
+    id: nextId('user'),
+    role: 'user',
+    type: 'user',
+    timestamp: '2024-01-01T00:00:00.000Z',
+    conversationId: 'conv-1',
+    content: 'Question',
+    ...overrides,
+  });
+
+  const baseAiMessage = (overrides = {}) => ({
+    id: nextId('ai'),
+    role: 'assistant',
+    type: 'ai',
+    timestamp: '2024-01-01T00:05:00.000Z',
+    conversationId: 'conv-1',
+    content: 'Answer',
+    ...overrides,
+  });
+
+  it('aggregates multiple conversation cards with the same conversation id', () => {
+    const conversations = [
+      {
+        id: '1-2',
+        userContent: 'First question',
+        aiContent: 'First answer',
+        timestamp: '2024-01-01T00:05:00.000Z',
+        resources: [{ id: 'res-1', title: 'Doc 1' }],
+        originalUserMessage: baseUserMessage({ id: '1', content: 'First question' }),
+        originalAiMessage: baseAiMessage({ id: '2', content: 'First answer' }),
+      },
+      {
+        id: '3-4',
+        userContent: 'Follow-up question',
+        aiContent: 'Follow-up answer',
+        timestamp: '2024-01-02T00:05:00.000Z',
+        resources: [{ id: 'res-2', title: 'Doc 2' }],
+        originalUserMessage: baseUserMessage({
+          id: '3',
+          timestamp: '2024-01-02T00:00:00.000Z',
+          content: 'Follow-up question',
+        }),
+        originalAiMessage: baseAiMessage({
+          id: '4',
+          timestamp: '2024-01-02T00:05:00.000Z',
+          content: 'Follow-up answer',
+        }),
+      },
+      {
+        id: '5-6',
+        userContent: 'Another thread question',
+        aiContent: 'Another thread answer',
+        timestamp: '2024-01-03T00:10:00.000Z',
+        resources: [{ id: 'res-3', title: 'Doc 3' }],
+        originalUserMessage: baseUserMessage({
+          conversationId: 'conv-2',
+          id: '5',
+          timestamp: '2024-01-03T00:05:00.000Z',
+          content: 'Another thread question',
+        }),
+        originalAiMessage: baseAiMessage({
+          conversationId: 'conv-2',
+          id: '6',
+          timestamp: '2024-01-03T00:10:00.000Z',
+          content: 'Another thread answer',
+        }),
+      },
+    ];
+
+    const grouped = groupConversationsByThread(conversations);
+
+    expect(grouped).toHaveLength(2);
+    expect(grouped[0].id).toBe('conv-2');
+    expect(grouped[0].userContent).toBe('Another thread question');
+    expect(grouped[0].resources).toEqual([{ id: 'res-3', title: 'Doc 3' }]);
+
+    const conv1 = grouped.find((item) => item.id === 'conv-1');
+    expect(conv1).toBeDefined();
+    expect(conv1.userContent).toBe('Follow-up question');
+    expect(conv1.aiContent).toBe('Follow-up answer');
+    expect(conv1.conversationCount).toBe(2);
+    expect(conv1.resources).toHaveLength(2);
+  });
+
+  it('retains standalone cards without conversation identifiers', () => {
+    const loneConversation = {
+      id: 'solo-card',
+      userContent: 'Standalone question',
+      aiContent: 'Standalone answer',
+      timestamp: 1704153900000,
+      resources: null,
+      originalUserMessage: { id: 'solo-user', type: 'user' },
+      originalAiMessage: { id: 'solo-ai', type: 'ai' },
+    };
+
+    const grouped = groupConversationsByThread([loneConversation]);
+
+    expect(grouped).toEqual([
+      {
+        id: 'solo-card',
+        userContent: 'Standalone question',
+        aiContent: 'Standalone answer',
+        timestamp: 1704153900000,
+        resources: [],
+        isStudyNotes: false,
+        originalUserMessage: { id: 'solo-user', type: 'user' },
+        originalAiMessage: { id: 'solo-ai', type: 'ai' },
+        isCurrent: false,
+        isStored: false,
+        conversationCount: 1,
+      },
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- update the Resource Center conversation list to group cards by underlying conversation threads
- add utilities to normalize conversation previews and merge resources when aggregating threads
- cover the new grouping helper with unit tests for multi-message and standalone cases

## Testing
- CI=true npm test -- --runTestsByPath src/utils/messageUtils.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9211e3350832a8b1916507a9f6752