### PR TITLE
Fix resource center thread aggregation for multi-exchange conversations

### DIFF
--- a/src/components/ConversationList.js
+++ b/src/components/ConversationList.js
@@ -5,45 +5,116 @@ import { MessageSquare } from 'lucide-react';
  * Displays a list of recent conversations and notifies parent when one is selected
  */
 const ConversationList = memo(({ conversations = [], onSelect = () => {} }) => {
+  const toThreadMessages = (conversation) => {
+    if (
+      Array.isArray(conversation.threadMessages) &&
+      conversation.threadMessages.length > 0
+    ) {
+      return conversation.threadMessages;
+    }
+    return [conversation];
+  };
+
+  const formatTimestamp = (timestamp) => {
+    if (!timestamp) {
+      return '';
+    }
+
+    const value = typeof timestamp === 'number' ? timestamp : Date.parse(timestamp);
+    if (Number.isNaN(value)) {
+      return '';
+    }
+
+    const date = new Date(value);
+    return date.toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
 
   if (!conversations.length) {
-    return (
-      <p className="text-sm text-gray-500">No conversations yet.</p>
-    );
+    return <p className="text-sm text-gray-500">No conversations yet.</p>;
   }
 
   const handleClick = (conv) => {
+    const threadMessages = toThreadMessages(conv);
+    const identifierSource = threadMessages.find((message) =>
+      message?.originalAiMessage?.conversationId ||
+      message?.originalUserMessage?.conversationId
+    ) || conv;
+
     const conversationId =
-      conv.originalAiMessage?.conversationId ||
-      conv.originalUserMessage?.conversationId;
+      identifierSource?.originalAiMessage?.conversationId ||
+      identifierSource?.originalUserMessage?.conversationId;
+
     if (conversationId) {
       onSelect(conversationId);
     }
   };
 
   return (
-    <ul className="space-y-2" data-testid="conversation-list">
-      {conversations.map(conv => (
-        <li
-          key={conv.id}
-          className="flex items-center space-x-2 p-2 hover:bg-gray-50 rounded cursor-pointer"
-          onClick={() => handleClick(conv)}
-          role="button"
-          tabIndex={0}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              handleClick(conv);
-            }
-          }}
-        >
+    <ul className="space-y-3" data-testid="conversation-list">
+      {conversations.map((conv) => {
+        const threadMessages = toThreadMessages(conv);
+        const timestampLabel = formatTimestamp(conv.timestamp);
+        const exchangeCount = Math.max(
+          threadMessages.length,
+          conv.conversationCount || 0,
+        );
+        const exchangeLabel = exchangeCount > 1
+          ? `${exchangeCount} exchanges`
+          : 'Single exchange';
 
-          <MessageSquare className="h-4 w-4 text-gray-400" />
-          <span className="text-sm text-gray-700 truncate">
-            {(conv.userContent || conv.aiContent || '').slice(0, 40)}
-          </span>
-        </li>
-      ))}
+        return (
+          <li
+            key={conv.id}
+            className="p-3 bg-gray-50 hover:bg-gray-100 rounded-lg border border-gray-200 cursor-pointer focus-within:ring-2 focus-within:ring-green-200"
+            onClick={() => handleClick(conv)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleClick(conv);
+              }
+            }}
+          >
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center space-x-2">
+                <MessageSquare className="h-4 w-4 text-gray-500" />
+                <span className="text-sm font-medium text-gray-700">{exchangeLabel}</span>
+              </div>
+              {timestampLabel && (
+                <span className="text-xs text-gray-500">{timestampLabel}</span>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              {threadMessages.map((message, index) => (
+                <div
+                  key={`${message.id || 'message'}-${index}`}
+                  className="rounded-md bg-white border border-gray-200 p-2 shadow-sm"
+                >
+                  {message.userContent && (
+                    <p className="text-xs text-gray-700 whitespace-pre-wrap break-words">
+                      <span className="font-semibold text-gray-900">You:</span>{' '}
+                      {message.userContent}
+                    </p>
+                  )}
+                  {message.aiContent && (
+                    <p className="mt-1 text-xs text-gray-700 whitespace-pre-wrap break-words">
+                      <span className="font-semibold text-gray-900">AcceleraQA:</span>{' '}
+                      {message.aiContent}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </li>
+        );
+      })}
     </ul>
   );
 });

--- a/src/components/ConversationList.test.js
+++ b/src/components/ConversationList.test.js
@@ -6,11 +6,27 @@ import ConversationList from './ConversationList';
 describe('ConversationList', () => {
   it('invokes onSelect with conversation id when item clicked', async () => {
     const conversation = {
-      id: '1-2',
-      userContent: 'Hello',
-      aiContent: 'Hi there',
-      originalUserMessage: { conversationId: 'conv1' },
-      originalAiMessage: { conversationId: 'conv1' }
+      id: 'conv1',
+      userContent: 'Follow-up question',
+      aiContent: 'Follow-up answer',
+      timestamp: '2024-01-01T00:05:00.000Z',
+      conversationCount: 2,
+      threadMessages: [
+        {
+          id: '1-2',
+          userContent: 'Hello',
+          aiContent: 'Hi there',
+          originalUserMessage: { id: '1', conversationId: 'conv1' },
+          originalAiMessage: { id: '2', conversationId: 'conv1' },
+        },
+        {
+          id: '3-4',
+          userContent: 'Follow-up question',
+          aiContent: 'Follow-up answer',
+          originalUserMessage: { id: '3', conversationId: 'conv1' },
+          originalAiMessage: { id: '4', conversationId: 'conv1' },
+        },
+      ],
     };
 
     const onSelect = jest.fn();
@@ -25,6 +41,9 @@ describe('ConversationList', () => {
     });
 
     const item = container.querySelector('li');
+    expect(item.textContent).toContain('Hello');
+    expect(item.textContent).toContain('Follow-up answer');
+
     await act(async () => {
       item.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });

--- a/src/components/ResourcesView.js
+++ b/src/components/ResourcesView.js
@@ -379,10 +379,20 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate, 
   const filteredConversations = useMemo(() => {
     if (!conversationSearchTerm.trim()) return conversations;
     const term = conversationSearchTerm.trim().toLowerCase();
-    return conversations.filter(conv =>
-      (typeof conv.userContent === 'string' && conv.userContent.toLowerCase().includes(term)) ||
-      (typeof conv.aiContent === 'string' && conv.aiContent.toLowerCase().includes(term))
-    );
+
+    const matchesThread = (conversation) => {
+      const threadMessages = Array.isArray(conversation.threadMessages) && conversation.threadMessages.length
+        ? conversation.threadMessages
+        : [conversation];
+
+      return threadMessages.some((message) => {
+        const userText = typeof message.userContent === 'string' ? message.userContent.toLowerCase() : '';
+        const aiText = typeof message.aiContent === 'string' ? message.aiContent.toLowerCase() : '';
+        return userText.includes(term) || aiText.includes(term);
+      });
+    };
+
+    return conversations.filter(matchesThread);
   }, [conversations, conversationSearchTerm]);
 
   const getResourceKey = useCallback((resource, index = 0) => {


### PR DESCRIPTION
## Summary
- propagate conversation identifiers while combining messages and normalizing threads so multi-turn sessions stay grouped
- allow thread grouping to fall back to combined conversation metadata and adjust the list label to count thread messages
- ensure stored conversations without message ids receive deterministic fallback keys so all exchanges persist through merges
- expand unit coverage for conversation id propagation, thread aggregation, and merge fallbacks

## Testing
- npm test -- --runTestsByPath src/utils/messageUtils.test.js src/components/ConversationList.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d92b30d908832a85919ea6c94ce9df