### PR TITLE
Fix Neon connection string resolution

### DIFF
--- a/netlify/functions/neon-rag-fixed.js
+++ b/netlify/functions/neon-rag-fixed.js
@@ -41,9 +41,6 @@ function resolveConnectionString() {
     error.statusCode = 500;
     throw error;
   }
-  return userId;
-}
-
   if (!/sslmode=/i.test(connectionString)) {
     console.warn('Connection string missing sslmode parameter; Neon recommends sslmode=require');
   }


### PR DESCRIPTION
## Summary
- ensure the Neon RAG Netlify function returns the resolved database connection string
- keep the sslmode warning and return the proper connection string to avoid undefined connections

## Testing
- not run (serverless function change only)


------
https://chatgpt.com/codex/tasks/task_e_68d95686e56c832a86483c4d5e32aa2d