### PR TITLE
Persist chat threads in blob storage

### DIFF
--- a/src/services/conversationService.js
+++ b/src/services/conversationService.js
@@ -1,5 +1,6 @@
 // src/services/conversationService.js - Updated for persistent Netlify Blob storage
 import { getToken } from './authService';
+import { deriveThreadIdAssignments } from '../utils/messageUtils';
 
 const API_BASE_URL = '/.netlify/functions';
 
@@ -100,46 +101,85 @@ class ConversationService {
     
     try {
       // Filter out invalid messages
-      const validMessages = messages.filter(msg => 
-        msg && msg.id && msg.type && msg.content && msg.timestamp
-      );
+      const validMessages = messages
+        .filter(msg =>
+          msg && msg.id && (msg.type || msg.role) && msg.content && msg.timestamp
+        )
+        .map(msg => ({
+          ...msg,
+          type: msg.type || (msg.role === 'assistant' ? 'ai' : msg.role),
+          role: msg.role || (msg.type === 'ai' ? 'assistant' : msg.type || 'user')
+        }));
 
       if (validMessages.length === 0) {
         console.warn('No valid messages to save');
         return { success: false, error: 'No valid messages' };
       }
 
+      const threadAssignments = deriveThreadIdAssignments(validMessages);
+      const lastAssignment = threadAssignments[threadAssignments.length - 1] || null;
+      const metadataConversationId = metadata?.conversationId || metadata?.threadId;
+      const conversationIdCandidates = [
+        metadataConversationId,
+        ...validMessages
+          .map(msg => msg.conversationId || msg.conversationThreadId || msg.threadId)
+          .filter(Boolean),
+        lastAssignment
+      ].filter(Boolean);
+
+      const resolvedConversationId = conversationIdCandidates[0] || `conv_${Date.now()}`;
+
+      const normalizedMessages = validMessages.map((msg, index) => {
+        const assignment = threadAssignments[index] || resolvedConversationId;
+        return {
+          id: msg.id,
+          type: msg.type,
+          role: msg.role,
+          content: msg.content,
+          timestamp: msg.timestamp,
+          resources: msg.resources || [],
+          sources: msg.sources || [],
+          isStudyNotes: msg.isStudyNotes || false,
+          conversationId: msg.conversationId || assignment,
+          conversationThreadId: msg.conversationThreadId || assignment,
+          threadId: msg.threadId || assignment
+        };
+      });
+
+      const targetThreadId = metadataConversationId || lastAssignment || resolvedConversationId;
+      const threadMessages = normalizedMessages.filter((_, index) => {
+        const assignment = threadAssignments[index] || resolvedConversationId;
+        return assignment === targetThreadId;
+      });
+
+      const messagesToPersist = threadMessages.length > 0 ? threadMessages : normalizedMessages;
+
       // Analyze messages for RAG usage
-      const ragMessages = validMessages.filter(msg => 
+      const ragMessages = messagesToPersist.filter(msg =>
         msg.sources && msg.sources.length > 0
       );
-      
+
       const ragDocuments = [...new Set(
-        ragMessages.flatMap(msg => 
+        ragMessages.flatMap(msg =>
           msg.sources?.map(source => source.documentId) || []
         )
       )];
 
       const payload = {
-        messages: validMessages.map(msg => ({
-          id: msg.id,
-          type: msg.type,
-          content: msg.content,
-          timestamp: msg.timestamp,
-          resources: msg.resources || [],
-          sources: msg.sources || [],
-          isStudyNotes: msg.isStudyNotes || false
-        })),
+        conversationId: resolvedConversationId,
+        messages: messagesToPersist,
         metadata: {
-          topics: this.extractTopics(validMessages),
-          messageCount: validMessages.length,
+          ...metadata,
+          topics: this.extractTopics(messagesToPersist),
+          messageCount: messagesToPersist.length,
           lastActivity: new Date().toISOString(),
           ragUsed: ragMessages.length > 0,
           ragDocuments: ragDocuments,
           ragMessageCount: ragMessages.length,
-          sessionId: Date.now().toString(),
-          userAgent: navigator.userAgent,
-          ...metadata
+          threadId: targetThreadId,
+          conversationId: resolvedConversationId,
+          sessionId: metadata?.sessionId || Date.now().toString(),
+          userAgent: navigator.userAgent
         }
       };
 


### PR DESCRIPTION
## Summary
- derive and include conversation thread identifiers when saving chats so subsequent saves map to the same record
- update the Netlify conversations function to upsert existing thread records, merge messages, and adjust statistics increments
- align the Neon conversation service with the same thread-aware payload structure for consistency

## Testing
- npm test -- --runTestsByPath src/services/learningSuggestionsService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9564b7ef8832aaabef3d7c419d2cd