### PR TITLE
Fix Neon RAG module syntax error

### DIFF
--- a/netlify/functions/neon-rag-fixed.js
+++ b/netlify/functions/neon-rag-fixed.js
@@ -41,9 +41,6 @@ function resolveConnectionString() {
     error.statusCode = 500;
     throw error;
   }
-  return userId;
-}
-
   if (!/sslmode=/i.test(connectionString)) {
     console.warn('Connection string missing sslmode parameter; Neon recommends sslmode=require');
   }
@@ -215,8 +212,6 @@ function normalizeDocumentTypeValue({ mimeType, filename, allowedTypes }) {
     xml: 'xml',
     'application/xml': 'xml',
   };
-}
-
   for (const candidate of mimeCandidates) {
     const mapped = canonicalMap[candidate];
     if (mapped && allowedTypes.includes(mapped)) {


### PR DESCRIPTION
## Summary
- remove an extra closing brace in `normalizeDocumentTypeValue` so the helper logic stays within the function scope
- allow the Neon RAG Netlify function to load without a syntax error that surfaced as 502 responses in production

## Testing
- `node --input-type=module -e "import('./netlify/functions/neon-rag-fixed.js').then(({ handler }) => console.log(typeof handler))"`


------
https://chatgpt.com/codex/tasks/task_e_68d95686e56c832a86483c4d5e32aa2d