### PR TITLE
Disable conversation and resource storage features

### DIFF
--- a/src/services/conversationService.js
+++ b/src/services/conversationService.js
@@ -1,483 +1,52 @@
-// src/services/conversationService.js - Updated for persistent Netlify Blob storage
-import { getToken } from './authService';
-import { deriveThreadIdAssignments } from '../utils/messageUtils';
-
-const API_BASE_URL = '/.netlify/functions';
+// src/services/conversationService.js
+// Conversation persistence has been disabled to prevent storing chat history.
 
 class ConversationService {
   constructor() {
-    this.apiUrl = `${API_BASE_URL}/conversations-blob`;
     this.isInitialized = false;
     this.userId = null;
     this.cachedConversations = null;
-    this.cacheKeyPrefix = 'acceleraqa_conversations_';
   }
 
-  /**
-   * Initialize the service with user authentication
-   */
   async initialize(user) {
-    if (user && user.sub) {
-      this.userId = user.sub;
-      this.isInitialized = true;
-      console.log('ConversationService initialized for user:', this.userId);
+    this.userId = user?.sub || null;
+    this.isInitialized = Boolean(this.userId);
+    if (this.isInitialized) {
+      console.info('Conversation storage disabled - initialization acknowledged for user:', this.userId);
+    } else {
+      console.info('Conversation storage disabled - no user provided.');
     }
+    return this.isInitialized;
   }
 
   getCacheKey() {
-    return `${this.cacheKeyPrefix}${this.userId}`;
+    return this.userId ? `disabled_conversations_${this.userId}` : 'disabled_conversations_anonymous';
   }
 
-  /**
-   * Make authenticated request to Netlify function
-   */
-  async makeAuthenticatedRequest(endpoint, options = {}) {
-    try {
-      // Get Auth0 token
-      const token = await getToken();
-      
-      const defaultHeaders = {
-        'Content-Type': 'application/json',
-      };
-
-      // Add user ID and authorization
-      if (token) {
-        defaultHeaders['Authorization'] = `Bearer ${token}`;
-        
-        // Extract user ID from token for header
-        try {
-          const tokenParts = token.split('.');
-          if (tokenParts.length === 3) {
-            const payload = JSON.parse(atob(tokenParts[1]));
-            if (payload.sub) {
-              defaultHeaders['x-user-id'] = payload.sub;
-            }
-          }
-        } catch (parseError) {
-          console.warn('Could not parse token for user ID:', parseError);
-        }
-      }
-
-      // Fallback to stored user ID
-      if (!defaultHeaders['x-user-id'] && this.userId) {
-        defaultHeaders['x-user-id'] = this.userId;
-      }
-
-      const response = await fetch(endpoint, {
-        ...options,
-        headers: {
-          ...defaultHeaders,
-          ...options.headers,
-        },
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || `HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      return await response.json();
-    } catch (error) {
-      console.error('API request failed:', error);
-      throw error;
-    }
+  async saveConversation() {
+    console.info('Conversation storage is disabled. Skipping save operation.');
+    return { success: false, disabled: true };
   }
 
-  /**
-   * Save a conversation to Netlify Blob storage
-   * @param {Object[]} messages - Array of messages in the conversation
-   * @param {Object} metadata - Optional metadata about the conversation
-   * @returns {Promise<Object>} - Save result
-   */
-  async saveConversation(messages, metadata = {}) {
-    if (!this.isInitialized) {
-      throw new Error('ConversationService not initialized');
-    }
-
-    console.log('Saving conversation to Netlify Blob...', { 
-      messageCount: messages.length,
-      userId: this.userId 
-    });
-    
-    try {
-      // Filter out invalid messages
-      const validMessages = messages
-        .filter(msg =>
-          msg && msg.id && (msg.type || msg.role) && msg.content && msg.timestamp
-        )
-        .map(msg => ({
-          ...msg,
-          type: msg.type || (msg.role === 'assistant' ? 'ai' : msg.role),
-          role: msg.role || (msg.type === 'ai' ? 'assistant' : msg.type || 'user')
-        }));
-
-      if (validMessages.length === 0) {
-        console.warn('No valid messages to save');
-        return { success: false, error: 'No valid messages' };
-      }
-
-      const threadAssignments = deriveThreadIdAssignments(validMessages);
-      const lastAssignment = threadAssignments[threadAssignments.length - 1] || null;
-      const metadataConversationId = metadata?.conversationId || metadata?.threadId;
-      const conversationIdCandidates = [
-        metadataConversationId,
-        ...validMessages
-          .map(msg => msg.conversationId || msg.conversationThreadId || msg.threadId)
-          .filter(Boolean),
-        lastAssignment
-      ].filter(Boolean);
-
-      const resolvedConversationId = conversationIdCandidates[0] || `conv_${Date.now()}`;
-
-      const normalizedMessages = validMessages.map((msg, index) => {
-        const assignment = threadAssignments[index] || resolvedConversationId;
-        return {
-          id: msg.id,
-          type: msg.type,
-          role: msg.role,
-          content: msg.content,
-          timestamp: msg.timestamp,
-          resources: msg.resources || [],
-          sources: msg.sources || [],
-          isStudyNotes: msg.isStudyNotes || false,
-          conversationId: msg.conversationId || assignment,
-          conversationThreadId: msg.conversationThreadId || assignment,
-          threadId: msg.threadId || assignment
-        };
-      });
-
-      const targetThreadId = metadataConversationId || lastAssignment || resolvedConversationId;
-      const threadMessages = normalizedMessages.filter((_, index) => {
-        const assignment = threadAssignments[index] || resolvedConversationId;
-        return assignment === targetThreadId;
-      });
-
-      const messagesToPersist = threadMessages.length > 0 ? threadMessages : normalizedMessages;
-
-      // Analyze messages for RAG usage
-      const ragMessages = messagesToPersist.filter(msg =>
-        msg.sources && msg.sources.length > 0
-      );
-
-      const ragDocuments = [...new Set(
-        ragMessages.flatMap(msg =>
-          msg.sources?.map(source => source.documentId) || []
-        )
-      )];
-
-      const payload = {
-        conversationId: resolvedConversationId,
-        messages: messagesToPersist,
-        metadata: {
-          ...metadata,
-          topics: this.extractTopics(messagesToPersist),
-          messageCount: messagesToPersist.length,
-          lastActivity: new Date().toISOString(),
-          ragUsed: ragMessages.length > 0,
-          ragDocuments: ragDocuments,
-          ragMessageCount: ragMessages.length,
-          threadId: targetThreadId,
-          conversationId: resolvedConversationId,
-          sessionId: metadata?.sessionId || Date.now().toString(),
-          userAgent: navigator.userAgent
-        }
-      };
-
-      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
-        method: 'POST',
-        body: JSON.stringify(payload),
-      });
-
-      console.log('Conversation saved successfully to Netlify Blob:', result);
-      
-      // Clear cached conversations to force reload
-      this.cachedConversations = null;
-
-      // Refresh local cache immediately for persistence
-      try {
-        await this.loadConversations(false);
-      } catch (cacheError) {
-        console.warn('Failed to refresh conversation cache:', cacheError);
-      }
-
-      return result;
-    } catch (error) {
-      console.error('Failed to save conversation to Netlify Blob:', error);
-      throw new Error(`Failed to save conversation: ${error.message}`);
-    }
+  async loadConversations() {
+    console.info('Conversation storage is disabled. Returning empty conversation history.');
+    return [];
   }
 
-  /**
-   * Load all conversations for the authenticated user from Netlify Blob
-   * @param {boolean} useCache - Whether to use cached data if available
-   * @returns {Promise<Object[]>} - Array of conversations converted to messages
-   */
-  async loadConversations(useCache = true) {
-    if (!this.isInitialized) {
-      console.warn('ConversationService not initialized, returning empty array');
-      return [];
-    }
-
-    // Return cached conversations if available and cache is enabled
-    if (useCache && this.cachedConversations) {
-      console.log('Returning cached conversations:', this.cachedConversations.length);
-      return this.cachedConversations;
-    }
-
-    console.log('Loading conversations from Netlify Blob for user:', this.userId);
-    
-    try {
-      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
-        method: 'GET',
-      });
-
-      console.log(`Loaded ${result.total || 0} conversations from Netlify Blob`);
-      
-      // Convert server format back to message format
-      const messages = this.conversationsToMessages(result.conversations || []);
-
-      // Cache the results
-      this.cachedConversations = messages;
-
-      // Persist to local storage for offline access
-      if (typeof localStorage !== 'undefined') {
-        try {
-          localStorage.setItem(this.getCacheKey(), JSON.stringify(messages));
-        } catch (storageError) {
-          console.warn('Failed to cache conversations locally:', storageError);
-        }
-      }
-
-      return messages;
-    } catch (error) {
-      console.error('Failed to load conversations from Netlify Blob:', error);
-
-      // Attempt to load conversations from local storage cache
-      if (typeof localStorage !== 'undefined') {
-        try {
-          const stored = localStorage.getItem(this.getCacheKey());
-          if (stored) {
-            const messages = JSON.parse(stored);
-            this.cachedConversations = messages;
-            console.warn('Loaded conversations from local cache due to error');
-            return messages;
-          }
-        } catch (storageError) {
-          console.warn('Failed to load conversations from local cache:', storageError);
-        }
-      }
-
-      // Return empty array instead of throwing to allow app to continue
-      if (error.message.includes('401') || error.message.includes('authentication')) {
-        console.warn('Authentication required for loading conversations');
-        return [];
-      }
-
-      // For other errors, return empty array but log warning
-      console.warn('Returning empty conversations due to error:', error.message);
-      return [];
-    }
-  }
-
-  /**
-   * Delete all conversations for the authenticated user
-   * @returns {Promise<Object>} - Deletion result
-   */
   async clearConversations() {
-    if (!this.isInitialized) {
-      throw new Error('ConversationService not initialized');
-    }
-
-    console.log('Clearing all conversations from Netlify Blob for user:', this.userId);
-    
-    try {
-      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
-        method: 'DELETE',
-      });
-
-      console.log('All conversations cleared successfully from Netlify Blob');
-
-      // Clear cache
-      this.cachedConversations = null;
-
-      // Remove local cache
-      if (typeof localStorage !== 'undefined') {
-        try {
-          localStorage.removeItem(this.getCacheKey());
-        } catch (storageError) {
-          console.warn('Failed to remove local conversation cache:', storageError);
-        }
-      }
-
-      return result;
-    } catch (error) {
-      console.error('Failed to clear conversations from Netlify Blob:', error);
-      throw new Error(`Failed to clear conversations: ${error.message}`);
-    }
+    console.info('Conversation storage is disabled. Nothing to clear.');
+    return { success: true, cleared: 0, disabled: true };
   }
 
-  /**
-   * Auto-save current conversation with debouncing
-   * @param {Object[]} messages - Current conversation messages
-   * @param {Object} metadata - Optional metadata
-   */
-  async autoSaveConversation(messages, metadata = {}) {
-    if (!this.isInitialized || !messages || messages.length === 0) {
-      return;
-    }
-
-    // Clear any existing auto-save timeout
-    if (this.autoSaveTimeout) {
-      clearTimeout(this.autoSaveTimeout);
-    }
-
-    // Debounce auto-save by 3 seconds
-    this.autoSaveTimeout = setTimeout(async () => {
-      try {
-        // Only auto-save if we have a meaningful conversation
-        const nonWelcomeMessages = messages.filter(msg => 
-          !(msg.type === 'ai' && msg.content.includes('Welcome to AcceleraQA'))
-        );
-
-        if (nonWelcomeMessages.length >= 2) { // At least 1 user + 1 AI message
-          console.log('Auto-saving conversation...');
-          await this.saveConversation(messages, {
-            ...metadata,
-            autoSaved: true,
-            autoSaveTime: new Date().toISOString()
-          });
-        }
-      } catch (error) {
-        console.warn('Auto-save failed:', error);
-      }
-    }, 3000); // 3 second delay
+  autoSaveConversation() {
+    console.info('Conversation auto-save is disabled.');
+    return null;
   }
 
-  /**
-   * Convert server conversation format to client message format
-   * @param {Object[]} conversations - Server conversation objects
-   * @returns {Object[]} - Array of messages
-   */
-  conversationsToMessages(conversations) {
-    if (!Array.isArray(conversations)) {
-      return [];
-    }
-
-    // Flatten all messages from all conversations
-    const allMessages = conversations.flatMap(conversation => 
-      (conversation.messages || []).map(msg => ({
-        ...msg,
-        isStored: true,
-        isCurrent: false,
-        conversationId: conversation.id,
-        conversationCreated: conversation.created_at,
-        ragUsed: conversation.used_rag || false,
-        ragDocuments: conversation.rag_documents_referenced || []
-      }))
-    );
-
-    // Sort by timestamp
-    allMessages.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
-
-    console.log(`Converted ${conversations.length} conversations to ${allMessages.length} messages`);
-    return allMessages;
-  }
-
-  /**
-   * Extract topics from messages for metadata
-   * @param {Object[]} messages - Array of messages
-   * @returns {string[]} - Array of topics
-   */
-  extractTopics(messages) {
-    const topics = new Set();
-    
-    messages.forEach(msg => {
-      if (msg.type === 'user' && msg.content) {
-        // Simple topic extraction from user messages
-        const content = msg.content.toLowerCase();
-        
-        // Common pharmaceutical topics
-        const pharmaTopics = [
-          'gmp', 'gcp', 'glp', 'validation', 'capa', 'fda', 'ich', 
-          'regulatory', 'compliance', 'quality', 'manufacturing',
-          'clinical', 'laboratory', 'cfr', 'part 11', 'audit'
-        ];
-        
-        pharmaTopics.forEach(topic => {
-          if (content.includes(topic)) {
-            topics.add(topic.toUpperCase());
-          }
-        });
-      }
-    });
-    
-    return Array.from(topics);
-  }
-
-  /**
-   * Check if the service is available and user is authenticated
-   * @returns {Promise<boolean>} - Whether service is available
-   */
-  async isServiceAvailable() {
-    try {
-      console.log('Checking conversation service availability...');
-      
-      // First try the test blob function
-      const testResponse = await fetch('/.netlify/functions/test-blob', {
-        method: 'GET'
-      });
-      
-      if (!testResponse.ok) {
-        console.warn('Test blob function not available:', testResponse.status);
-        return false;
-      }
-      
-      const testResult = await testResponse.json();
-      console.log('Test blob function result:', testResult);
-      
-      if (!testResult.summary?.overallSuccess) {
-        console.warn('Blob functionality not working properly:', testResult);
-        return false;
-      }
-      
-      // Now try the actual conversations endpoint
-      const response = await this.makeAuthenticatedRequest(this.apiUrl, {
-        method: 'GET',
-      });
-      
-      console.log('Conversation service is available');
-      return true;
-    } catch (error) {
-      console.warn('Conversation service not available:', error.message);
-      return false;
-    }
-  }
-
-  /**
-   * Get conversation statistics including RAG usage
-   * @returns {Promise<Object>} - Conversation statistics
-   */
   async getConversationStats() {
-    if (!this.isInitialized) {
-      return this.getEmptyStats();
-    }
-
-    try {
-      const result = await this.makeAuthenticatedRequest(`${this.apiUrl}/stats`, {
-        method: 'GET',
-      });
-
-      return result.stats || this.getEmptyStats();
-    } catch (error) {
-      console.error('Failed to get conversation stats:', error);
-      return this.getEmptyStats();
-    }
+    return this.getEmptyStats();
   }
 
-  /**
-   * Get empty stats object
-   * @returns {Object} - Empty statistics
-   */
   getEmptyStats() {
     return {
       totalConversations: 0,
@@ -489,56 +58,49 @@ class ConversationService {
     };
   }
 
-  /**
-   * Get cache status
-   * @returns {Object} - Cache information
-   */
+  async isServiceAvailable() {
+    // Persistence endpoints are intentionally disabled.
+    return false;
+  }
+
   getCacheStatus() {
     return {
       isInitialized: this.isInitialized,
       userId: this.userId,
-      hasCachedConversations: !!this.cachedConversations,
-      cachedMessageCount: this.cachedConversations?.length || 0,
-      lastCacheTime: this.lastCacheTime || null
+      hasCachedConversations: false,
+      cachedMessageCount: 0,
+      lastCacheTime: null,
     };
   }
 
-  /**
-   * Cleanup method to clear timeouts and cache
-   */
   cleanup() {
-    if (this.autoSaveTimeout) {
-      clearTimeout(this.autoSaveTimeout);
-      this.autoSaveTimeout = null;
-    }
     this.cachedConversations = null;
     this.isInitialized = false;
     this.userId = null;
   }
 }
 
-// Create singleton instance
 const conversationService = new ConversationService();
 
 export default conversationService;
 
-// Export convenience functions
-export const initializeConversationService = (user) => 
+export const initializeConversationService = (user) =>
   conversationService.initialize(user);
 
-export const saveConversation = (messages, metadata) => 
+export const saveConversation = (messages, metadata) =>
   conversationService.saveConversation(messages, metadata);
 
-export const loadConversations = (useCache = true) => 
+export const loadConversations = (useCache = true) =>
   conversationService.loadConversations(useCache);
 
-export const clearConversations = () => 
+export const clearConversations = () =>
   conversationService.clearConversations();
 
-export const autoSaveConversation = (messages, metadata) => 
+export const autoSaveConversation = (messages, metadata) =>
   conversationService.autoSaveConversation(messages, metadata);
 
 export const getConversationStats = () =>
   conversationService.getConversationStats();
+
 export const isServiceAvailable = () =>
   conversationService.isServiceAvailable();

--- a/src/services/neonService.js
+++ b/src/services/neonService.js
@@ -1,505 +1,48 @@
-// src/services/neonService.js - FIXED VERSION
-import { getToken, getUserId } from './authService';
-import { deriveThreadIdAssignments } from '../utils/messageUtils';
+// src/services/neonService.js
+// Remote conversation and resource persistence have been disabled.
 
 class NeonService {
   constructor() {
-    this.apiUrl = '/.netlify/functions/neon-db';
     this.isInitialized = false;
     this.userId = null;
     this.cachedConversations = null;
   }
 
-  /**
-   * Initialize the service with user authentication
-   */
   async initialize(user) {
-    if (user && user.sub) {
-      this.userId = user.sub;
-      this.isInitialized = true;
-      console.log('NeonService initialized for user:', this.userId);
+    this.userId = user?.sub || null;
+    this.isInitialized = Boolean(this.userId);
+    if (this.isInitialized) {
+      console.info('Neon conversation storage disabled - initialization acknowledged for user:', this.userId);
+    } else {
+      console.info('Neon conversation storage disabled - no user provided.');
     }
+    return this.isInitialized;
   }
 
-  /**
-   * FIXED: Enhanced authenticated request with better error handling
-   */
-  async makeAuthenticatedRequest(endpoint, options = {}) {
-    try {
-      console.log('=== NEON SERVICE AUTHENTICATED REQUEST ===');
-      console.log('Endpoint:', endpoint);
-      console.log('Options action:', options.body ? JSON.parse(options.body).action : 'N/A');
-      
-      const defaultHeaders = {
-        'Content-Type': 'application/json',
-      };
-
-      // CRITICAL FIX: Always try to get fresh token and user ID
-      let token = null;
-      let userId = null;
-
-      try {
-        // Get token first
-        token = await getToken();
-        console.log('Token retrieved:', !!token);
-        console.log('Token length:', token?.length || 0);
-        
-        if (token) {
-          defaultHeaders['Authorization'] = `Bearer ${token}`;
-          console.log('Added Authorization header');
-        }
-      } catch (tokenError) {
-        console.error('Failed to get token:', tokenError);
-        throw new Error(`Authentication failed: ${tokenError.message}`);
-      }
-
-      try {
-        // Get user ID using the new helper function
-        userId = await getUserId();
-        console.log('User ID retrieved:', userId ? userId.substring(0, 10) + '...' : 'null');
-        
-        if (userId) {
-          defaultHeaders['x-user-id'] = userId;
-          console.log('Added x-user-id header');
-        } else {
-          throw new Error('User ID not available');
-        }
-      } catch (userIdError) {
-        console.error('Failed to get user ID:', userIdError);
-        throw new Error(`User identification failed: ${userIdError.message}`);
-      }
-
-      // Fallback to stored user ID if available
-      if (!defaultHeaders['x-user-id'] && this.userId) {
-        defaultHeaders['x-user-id'] = this.userId;
-        console.log('Using stored user ID as fallback');
-      }
-
-      // Add debugging headers
-      defaultHeaders['X-Requested-With'] = 'XMLHttpRequest';
-      defaultHeaders['X-Client-Version'] = '2.1.0';
-      defaultHeaders['X-Timestamp'] = new Date().toISOString();
-
-      console.log('Request headers prepared:', Object.keys(defaultHeaders));
-      console.log('Has Authorization:', !!defaultHeaders['Authorization']);
-      console.log('Has x-user-id:', !!defaultHeaders['x-user-id']);
-
-      const response = await fetch(endpoint, {
-        ...options,
-        headers: {
-          ...defaultHeaders,
-          ...options.headers,
-        },
-      });
-
-      console.log('Response status:', response.status);
-      console.log('Response ok:', response.ok);
-
-      if (!response.ok) {
-        console.error('Request failed with status:', response.status);
-        
-        let errorData;
-        try {
-          errorData = await response.json();
-          console.error('Error response data:', errorData);
-        } catch (parseError) {
-          console.error('Could not parse error response:', parseError);
-          errorData = { 
-            error: `HTTP ${response.status}: ${response.statusText}`,
-            details: 'Could not parse error response'
-          };
-        }
-
-        // Enhanced error messages
-        if (response.status === 401) {
-          throw new Error(`Authentication failed: ${errorData.error || 'Unauthorized'}. Please try signing out and signing in again.`);
-        } else if (response.status === 403) {
-          throw new Error(`Access forbidden: ${errorData.error || 'Insufficient permissions'}`);
-        } else if (response.status >= 500) {
-          throw new Error(`Server error: ${errorData.error || 'Internal server error'}. Please try again later.`);
-        } else {
-          throw new Error(errorData.error || `Request failed with status ${response.status}`);
-        }
-      }
-
-      const result = await response.json();
-      console.log('Request successful, response keys:', Object.keys(result));
-      console.log('=== NEON REQUEST COMPLETED ===');
-      return result;
-
-    } catch (error) {
-      console.error('=== NEON REQUEST FAILED ===');
-      console.error('Error type:', error.constructor.name);
-      console.error('Error message:', error.message);
-      console.error('============================');
-      throw error;
-    }
+  async saveConversation() {
+    console.info('Neon conversation storage is disabled. Skipping save operation.');
+    return { success: false, disabled: true };
   }
 
-  /**
-   * Save a conversation to Neon database
-   */
-  async saveConversation(messages, metadata = {}) {
-    if (!this.isInitialized) {
-      throw new Error('NeonService not initialized');
-    }
-
-    console.log('Saving conversation to Neon...', { 
-      messageCount: messages.length,
-      userId: this.userId 
-    });
-    
-    try {
-      const validMessages = messages
-        .filter(msg =>
-          msg &&
-          msg.id &&
-          (msg.type || msg.role) &&
-          msg.content &&
-          msg.timestamp
-        )
-        .map(msg => {
-          const normalizedType = msg.type || (msg.role === 'assistant' ? 'ai' : msg.role);
-          const normalizedRole = msg.role || (normalizedType === 'ai' ? 'assistant' : 'user');
-          return {
-            ...msg,
-            type: normalizedType,
-            role: normalizedRole,
-          };
-        });
-
-      if (validMessages.length === 0) {
-        console.warn('No valid messages to save');
-        return { success: false, error: 'No valid messages' };
-      }
-
-      const threadAssignments = deriveThreadIdAssignments(validMessages);
-      const lastAssignment = threadAssignments[threadAssignments.length - 1] || null;
-      const metadataConversationId = metadata?.conversationId || metadata?.threadId;
-      const conversationIdCandidates = [
-        metadataConversationId,
-        ...validMessages
-          .map(msg => msg.conversationId || msg.conversationThreadId || msg.threadId)
-          .filter(Boolean),
-        lastAssignment
-      ].filter(Boolean);
-
-      const resolvedConversationId = conversationIdCandidates[0] || `conv_${Date.now()}`;
-
-      const normalizedMessages = validMessages.map((msg, index) => {
-        const assignment = threadAssignments[index] || resolvedConversationId;
-        return {
-          id: msg.id,
-          type: msg.type,
-          role: msg.role,
-          content: msg.content,
-          timestamp: msg.timestamp,
-          resources: msg.resources || [],
-          sources: msg.sources || [],
-          isStudyNotes: msg.isStudyNotes || false,
-          conversationId: msg.conversationId || assignment,
-          conversationThreadId: msg.conversationThreadId || assignment,
-          threadId: msg.threadId || assignment,
-        };
-      });
-
-      const targetThreadId = metadataConversationId || lastAssignment || resolvedConversationId;
-      const threadMessages = normalizedMessages.filter((_, index) => {
-        const assignment = threadAssignments[index] || resolvedConversationId;
-        return assignment === targetThreadId;
-      });
-
-      const messagesToPersist = threadMessages.length > 0 ? threadMessages : normalizedMessages;
-
-      const ragMessages = messagesToPersist.filter(
-        msg => msg.sources && msg.sources.length > 0
-      );
-
-      const ragDocuments = [...new Set(
-        ragMessages.flatMap(msg =>
-          msg.sources?.map(source => source.documentId) || []
-        )
-      )];
-
-      const payload = {
-        action: 'save_conversation',
-        data: {
-          conversationId: resolvedConversationId,
-          messages: messagesToPersist,
-          metadata: {
-            ...metadata,
-            topics: this.extractTopics(messagesToPersist),
-            messageCount: messagesToPersist.length,
-            lastActivity: new Date().toISOString(),
-            ragUsed: ragMessages.length > 0,
-            ragDocuments: ragDocuments,
-            ragMessageCount: ragMessages.length,
-            threadId: targetThreadId,
-            conversationId: resolvedConversationId,
-            sessionId: metadata?.sessionId || Date.now().toString(),
-            userAgent: navigator.userAgent
-          }
-        }
-      };
-
-      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
-        method: 'POST',
-        body: JSON.stringify(payload),
-      });
-
-      console.log('Conversation saved successfully to Neon:', result);
-      
-      this.cachedConversations = null;
-      
-      return result;
-    } catch (error) {
-      console.error('Failed to save conversation to Neon:', error);
-      throw new Error(`Failed to save conversation: ${error.message}`);
-    }
+  async loadConversations() {
+    console.info('Neon conversation storage is disabled. Returning empty history.');
+    return [];
   }
 
-  /**
-   * Load all conversations from Neon database
-   */
-  async loadConversations(useCache = true) {
-    if (!this.isInitialized) {
-      console.warn('NeonService not initialized, returning empty array');
-      return [];
-    }
-
-    if (useCache && this.cachedConversations) {
-      console.log('Returning cached conversations:', this.cachedConversations.length);
-      return this.cachedConversations;
-    }
-
-    console.log('Loading conversations from Neon for user:', this.userId);
-    
-    try {
-      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
-        method: 'POST',
-        body: JSON.stringify({
-          action: 'get_conversations'
-        })
-      });
-
-      console.log(`Loaded ${result.total || 0} conversations from Neon`);
-      
-      const messages = this.conversationsToMessages(result.conversations || []);
-      
-      this.cachedConversations = messages;
-      
-      return messages;
-    } catch (error) {
-      console.error('Failed to load conversations from Neon:', error);
-      
-      if (error.message.includes('Authentication failed') || error.message.includes('401')) {
-        console.warn('Authentication required for loading conversations');
-        return [];
-      }
-      
-      console.warn('Returning empty conversations due to error:', error.message);
-      return [];
-    }
-  }
-
-  /**
-   * Delete all conversations from Neon database
-   */
   async clearConversations() {
-    if (!this.isInitialized) {
-      throw new Error('NeonService not initialized');
-    }
-
-    console.log('Clearing all conversations from Neon for user:', this.userId);
-    
-    try {
-      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
-        method: 'POST',
-        body: JSON.stringify({
-          action: 'clear_conversations'
-        })
-      });
-
-      console.log('All conversations cleared successfully from Neon');
-      
-      this.cachedConversations = null;
-      
-      return result;
-    } catch (error) {
-      console.error('Failed to clear conversations from Neon:', error);
-      throw new Error(`Failed to clear conversations: ${error.message}`);
-    }
+    console.info('Neon conversation storage is disabled. Nothing to clear.');
+    return { success: true, cleared: 0, disabled: true };
   }
 
-  /**
-   * Auto-save current conversation with debouncing
-   */
-  async autoSaveConversation(messages, metadata = {}) {
-    if (!this.isInitialized || !messages || messages.length === 0) {
-      return;
-    }
-
-    if (this.autoSaveTimeout) {
-      clearTimeout(this.autoSaveTimeout);
-    }
-
-    this.autoSaveTimeout = setTimeout(async () => {
-      try {
-        const nonWelcomeMessages = messages.filter(msg => {
-          const msgType = msg.type || msg.role;
-          return !(msgType === 'ai' && msg.content.includes('Welcome to AcceleraQA'));
-        });
-
-        if (nonWelcomeMessages.length >= 2) {
-          console.log('Auto-saving conversation to Neon...');
-          await this.saveConversation(messages, {
-            ...metadata,
-            autoSaved: true,
-            autoSaveTime: new Date().toISOString()
-          });
-        }
-      } catch (error) {
-        console.warn('Auto-save to Neon failed:', error);
-      }
-    }, 3000);
+  autoSaveConversation() {
+    console.info('Neon auto-save is disabled.');
+    return null;
   }
 
-  /**
-   * Convert server conversation format to client message format
-   */
-  conversationsToMessages(conversations) {
-    if (!Array.isArray(conversations)) {
-      return [];
-    }
-
-    const allMessages = conversations.flatMap(conversation =>
-      (conversation.messages || []).map(msg => ({
-        ...msg,
-        type: msg.type === 'assistant' ? 'ai' : msg.type,
-        role: msg.role || (msg.type === 'assistant' || msg.type === 'ai' ? 'assistant' : 'user'),
-        isStored: true,
-        isCurrent: false,
-        conversationId: conversation.id,
-        conversationCreated: conversation.created_at,
-        ragUsed: conversation.used_rag || false,
-        ragDocuments: conversation.rag_documents_referenced || []
-      }))
-    );
-
-    allMessages.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
-
-    console.log(`Converted ${conversations.length} conversations to ${allMessages.length} messages`);
-    return allMessages;
-  }
-
-  /**
-   * Extract topics from messages for metadata
-   */
-  extractTopics(messages) {
-    const topics = new Set();
-    
-    messages.forEach(msg => {
-      const msgType = msg.type || msg.role;
-      if (msgType === 'user' && msg.content) {
-        const content = msg.content.toLowerCase();
-        
-        const pharmaTopics = [
-          'gmp', 'gcp', 'glp', 'validation', 'capa', 'fda', 'ich', 
-          'regulatory', 'compliance', 'quality', 'manufacturing',
-          'clinical', 'laboratory', 'cfr', 'part 11', 'audit'
-        ];
-        
-        pharmaTopics.forEach(topic => {
-          if (content.includes(topic)) {
-            topics.add(topic.toUpperCase());
-          }
-        });
-      }
-    });
-    
-    return Array.from(topics);
-  }
-
-  /**
-   * External resources management
-   */
-  async addTrainingResource(resource) {
-    try {
-      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
-        method: 'POST',
-        body: JSON.stringify({
-          action: 'add_training_resource',
-          data: resource
-        })
-      });
-      return result.resource;
-    } catch (error) {
-      console.error('Failed to add external resource:', error);
-      throw error;
-    }
-  }
-
-  async getTrainingResources() {
-    try {
-      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
-        method: 'POST',
-        body: JSON.stringify({ action: 'get_training_resources' })
-      });
-      return result.resources || [];
-    } catch (error) {
-      console.error('Failed to load external resources:', error);
-      return [];
-    }
-  }
-
-  /**
-   * Check if the service is available
-   */
-  async isServiceAvailable() {
-    try {
-      console.log('Checking Neon service availability...');
-
-      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
-        method: 'POST',
-        body: JSON.stringify({
-          action: 'health_check'
-        })
-      });
-
-      console.log('Neon service is available');
-      return { ok: true };
-    } catch (error) {
-      console.warn('Neon service not available:', error.message);
-      return { ok: false, error: error.message };
-    }
-  }
-
-  /**
-   * Get conversation statistics including RAG usage
-   */
   async getConversationStats() {
-    if (!this.isInitialized) {
-      return this.getEmptyStats();
-    }
-
-    try {
-      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
-        method: 'POST',
-        body: JSON.stringify({
-          action: 'get_stats'
-        })
-      });
-
-      return result.stats || this.getEmptyStats();
-    } catch (error) {
-      console.error('Failed to get conversation stats from Neon:', error);
-      return this.getEmptyStats();
-    }
+    return this.getEmptyStats();
   }
 
-  /**
-   * Get empty stats object
-   */
   getEmptyStats() {
     return {
       totalConversations: 0,
@@ -511,27 +54,32 @@ class NeonService {
     };
   }
 
-  /**
-   * Get cache status
-   */
+  async isServiceAvailable() {
+    // Service endpoints are intentionally disabled.
+    return { ok: false, error: 'Conversation storage service is disabled.' };
+  }
+
+  async addTrainingResource() {
+    console.info('Neon training resource storage is disabled.');
+    return null;
+  }
+
+  async getTrainingResources() {
+    console.info('Neon training resource storage is disabled. Returning empty list.');
+    return [];
+  }
+
   getCacheStatus() {
     return {
       isInitialized: this.isInitialized,
       userId: this.userId,
-      hasCachedConversations: !!this.cachedConversations,
-      cachedMessageCount: this.cachedConversations?.length || 0,
-      lastCacheTime: this.lastCacheTime || null
+      hasCachedConversations: false,
+      cachedMessageCount: 0,
+      lastCacheTime: null,
     };
   }
 
-  /**
-   * Cleanup method
-   */
   cleanup() {
-    if (this.autoSaveTimeout) {
-      clearTimeout(this.autoSaveTimeout);
-      this.autoSaveTimeout = null;
-    }
     this.cachedConversations = null;
     this.isInitialized = false;
     this.userId = null;
@@ -542,20 +90,19 @@ const neonService = new NeonService();
 
 export default neonService;
 
-// Export convenience functions
-export const initializeNeonService = (user) => 
+export const initializeNeonService = (user) =>
   neonService.initialize(user);
 
-export const saveConversation = (messages, metadata) => 
+export const saveConversation = (messages, metadata) =>
   neonService.saveConversation(messages, metadata);
 
-export const loadConversations = (useCache = true) => 
+export const loadConversations = (useCache = true) =>
   neonService.loadConversations(useCache);
 
-export const clearConversations = () => 
+export const clearConversations = () =>
   neonService.clearConversations();
 
-export const autoSaveConversation = (messages, metadata) => 
+export const autoSaveConversation = (messages, metadata) =>
   neonService.autoSaveConversation(messages, metadata);
 
 export const getConversationStats = () =>


### PR DESCRIPTION
## Summary
- disable the conversation service so chat history is never persisted to local storage or remote APIs
- stub the Neon service and training resource service to keep resource data in-memory only for the current session
- short-circuit storage utilities so attempts to load or save conversations immediately return with no persistence

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d95d6f0a98832a9f20a632506020e4