### PR TITLE
Default to gpt-4o and remove admin model selector

### DIFF
--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -33,7 +33,7 @@ import { getToken, getTokenInfo } from '../services/authService';
 import { hasAdminRole } from '../utils/auth';
 import RAGConfigurationPage from './RAGConfigurationPage';
 import TrainingResourcesAdmin from './TrainingResourcesAdmin';
-import { MODEL_OPTIONS, getCurrentModel, setCurrentModel } from '../config/modelConfig';
+import { getCurrentModel } from '../config/modelConfig';
 import { getTokenUsageStats } from '../utils/tokenUsage';
 import { getRagBackendLabel, isNeonBackend } from '../config/ragConfig';
 
@@ -73,16 +73,10 @@ const AdminScreen = ({ user, onBack }) => {
   const [authStats, setAuthStats] = useState(null);
   const [systemHealth, setSystemHealth] = useState(null);
   const [error, setError] = useState(null);
-  const [chatModel, setChatModel] = useState(getCurrentModel());
+  const [chatModel] = useState(getCurrentModel());
   const [tokenUsage, setTokenUsage] = useState({ daily: [], monthly: [] });
   const ragBackendLabel = getRagBackendLabel();
   const neonBackendEnabled = isNeonBackend();
-
-  const handleModelChange = (e) => {
-    const model = e.target.value;
-    setChatModel(model);
-    setCurrentModel(model);
-  };
 
   // Check if user has admin role
   const isAdmin = hasAdminRole(user);
@@ -736,20 +730,12 @@ const AdminScreen = ({ user, onBack }) => {
             <div className="space-y-6">
               <div className="bg-white rounded-lg shadow p-6">
                 <h3 className="text-lg font-semibold text-gray-900 mb-4">AI Model Configuration</h3>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">
-                    Chat Model
-                    <select
-                      value={chatModel}
-                      onChange={handleModelChange}
-                      className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
-                    >
-                      {MODEL_OPTIONS.map(option => (
-                        <option key={option} value={option}>{option}</option>
-                      ))}
-                    </select>
-                  </label>
-                </div>
+                <p className="text-sm text-gray-700">
+                  Active chat model: <span className="font-semibold text-gray-900">{chatModel}</span>
+                </p>
+                <p className="mt-2 text-xs text-gray-500">
+                  Model selection is centrally managed and cannot be changed from this dashboard.
+                </p>
               </div>
 
               <div className="bg-white rounded-lg shadow p-6">

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -7,7 +7,7 @@ export const APP_CONFIG = {
 
 // OpenAI Configuration
 export const OPENAI_CONFIG = {
-  MODEL: 'chatgpt-4.1',
+  MODEL: 'gpt-4o',
   SUGGESTIONS_MODEL: 'gpt-4.1-mini',
   MAX_TOKENS: 1200,
   TEMPERATURE: 0.7,

--- a/src/config/modelConfig.js
+++ b/src/config/modelConfig.js
@@ -2,14 +2,21 @@ import { isStorageAvailable } from '../utils/storageUtils';
 
 export const MODEL_STORAGE_KEY = 'acceleraqa_ai_model';
 
-export const MODEL_OPTIONS = ['chatgpt-4.1', 'gpt-4.1-mini', 'gpt-4o', 'gpt-3.5-turbo'];
+export const MODEL_OPTIONS = ['gpt-4o'];
 
-export const DEFAULT_MODEL = 'chatgpt-4.1';
+export const DEFAULT_MODEL = 'gpt-4o';
 
 export function getCurrentModel() {
   try {
     if (typeof localStorage !== 'undefined' && isStorageAvailable()) {
-      return localStorage.getItem(MODEL_STORAGE_KEY) || DEFAULT_MODEL;
+      const storedModel = localStorage.getItem(MODEL_STORAGE_KEY);
+      if (storedModel && MODEL_OPTIONS.includes(storedModel)) {
+        return storedModel;
+      }
+      if (storedModel) {
+        localStorage.removeItem(MODEL_STORAGE_KEY);
+      }
+      return DEFAULT_MODEL;
     }
   } catch (error) {
     console.warn('Model config read failed:', error);
@@ -17,13 +24,6 @@ export function getCurrentModel() {
   return DEFAULT_MODEL;
 }
 
-export function setCurrentModel(model) {
-  if (!MODEL_OPTIONS.includes(model)) return;
-  try {
-    if (typeof localStorage !== 'undefined' && isStorageAvailable()) {
-      localStorage.setItem(MODEL_STORAGE_KEY, model);
-    }
-  } catch (error) {
-    console.warn('Model config write failed:', error);
-  }
+export function setCurrentModel() {
+  console.warn('setCurrentModel is deprecated. Model selection is fixed to the default.');
 }


### PR DESCRIPTION
## Summary
- set gpt-4o as the default chat model and ignore legacy selections
- remove the admin dashboard dropdown for choosing chat models and display the fixed selection message

## Testing
- npm test -- --watch=false --runTestsByPath src/components/AdminScreen.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9611db158832aac0e67e59f024ee4