### PR TITLE
Add Neon-backed document metadata pipeline

### DIFF
--- a/netlify/functions/neon-rag-fixed.js
+++ b/netlify/functions/neon-rag-fixed.js
@@ -18,6 +18,21 @@ const headers = {
 let sqlClientPromise = null;
 let ensuredSchemaPromise = null;
 let documentTypeOptionsPromise = null;
+
+function getFirstNonEmptyString(...values) {
+  for (const value of values) {
+    if (typeof value !== 'string') {
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return '';
+}
 function ensureFetchAvailable() {
   if (typeof globalThis.fetch === 'function') {
     return;
@@ -81,6 +96,9 @@ async function ensureRagSchema(sql) {
         file_size BIGINT,
         text_content TEXT,
         metadata JSONB DEFAULT '{}'::jsonb,
+        title TEXT,
+        summary TEXT,
+        version TEXT,
         created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
       )
@@ -116,6 +134,21 @@ async function ensureRagSchema(sql) {
     await sql`
       CREATE INDEX IF NOT EXISTS idx_rag_document_chunks_fts
         ON rag_document_chunks USING GIN (to_tsvector('english', chunk_text))
+    `;
+
+    await sql`
+      ALTER TABLE rag_documents
+        ADD COLUMN IF NOT EXISTS title TEXT
+    `;
+
+    await sql`
+      ALTER TABLE rag_documents
+        ADD COLUMN IF NOT EXISTS summary TEXT
+    `;
+
+    await sql`
+      ALTER TABLE rag_documents
+        ADD COLUMN IF NOT EXISTS version TEXT
     `;
   })().catch(error => {
     ensuredSchemaPromise = null;
@@ -314,12 +347,72 @@ function normalizeDocumentRow(row) {
   const metadata = parseMetadata(row.metadata);
   metadata.processingMode = 'neon-postgresql';
 
+  if (row.title && !metadata.title) {
+    metadata.title = row.title;
+  }
+
+  if (row.title && !metadata.fileTitle) {
+    metadata.fileTitle = row.title;
+  }
+
+  if (row.title && !metadata.documentTitle) {
+    metadata.documentTitle = row.title;
+  }
+
+  if (row.summary && !metadata.summary) {
+    metadata.summary = row.summary;
+  }
+
+  if (row.summary && !metadata.description) {
+    metadata.description = row.summary;
+  }
+
+  if (row.version && !metadata.version) {
+    metadata.version = row.version;
+  }
+
+  if (!metadata.fileName) {
+    metadata.fileName = row.filename;
+  }
+
+  const resolvedTitle = getFirstNonEmptyString(
+    row.title,
+    metadata.title,
+    metadata.fileTitle,
+    metadata.documentTitle,
+    row.filename,
+  );
+
+  if (resolvedTitle) {
+    metadata.title = metadata.title || resolvedTitle;
+    metadata.fileTitle = metadata.fileTitle || resolvedTitle;
+    metadata.documentTitle = metadata.documentTitle || resolvedTitle;
+    metadata.displayTitle = metadata.displayTitle || resolvedTitle;
+  }
+
+  const resolvedSummary = getFirstNonEmptyString(
+    row.summary,
+    metadata.summary,
+    metadata.description,
+  );
+
+  if (resolvedSummary) {
+    metadata.summary = metadata.summary || resolvedSummary;
+    metadata.description = metadata.description || resolvedSummary;
+    if (!metadata.displaySummary) {
+      metadata.displaySummary = resolvedSummary;
+    }
+  }
+
   return {
     id: row.id,
     filename: row.filename,
     originalFilename: row.original_filename || null,
     fileType: row.file_type || null,
     fileSize: row.file_size != null ? Number(row.file_size) : null,
+    title: resolvedTitle || null,
+    summary: resolvedSummary || null,
+    version: row.version || metadata.version || null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     metadata,
@@ -332,13 +425,59 @@ function buildSearchResult(row) {
   const metadata = parseMetadata(row.metadata);
   metadata.processingMode = 'neon-postgresql';
 
+  if (row.title && !metadata.title) {
+    metadata.title = row.title;
+  }
+
+  if (row.title && !metadata.documentTitle) {
+    metadata.documentTitle = row.title;
+  }
+
+  if (row.summary && !metadata.summary) {
+    metadata.summary = row.summary;
+  }
+
+  if (row.summary && !metadata.description) {
+    metadata.description = row.summary;
+  }
+
+  if (row.version && !metadata.version) {
+    metadata.version = row.version;
+  }
+
+  const resolvedTitle = getFirstNonEmptyString(
+    row.title,
+    metadata.title,
+    metadata.documentTitle,
+    metadata.fileTitle,
+    row.filename,
+  );
+
+  if (resolvedTitle) {
+    metadata.title = metadata.title || resolvedTitle;
+    metadata.documentTitle = metadata.documentTitle || resolvedTitle;
+  }
+
+  const resolvedSummary = getFirstNonEmptyString(
+    row.summary,
+    metadata.summary,
+    metadata.description,
+  );
+
+  if (resolvedSummary) {
+    metadata.summary = metadata.summary || resolvedSummary;
+    metadata.description = metadata.description || resolvedSummary;
+  }
+
   return {
     documentId: row.document_id,
     chunkId: row.id,
     chunkIndex: row.chunk_index,
     text: row.snippet || row.chunk_text,
     filename: row.filename,
-    documentTitle: metadata.title || metadata.documentTitle || row.filename,
+    documentTitle: resolvedTitle || row.filename,
+    summary: resolvedSummary || null,
+    version: row.version || metadata.version || null,
     score: Number(row.rank || 0),
     metadata,
   };
@@ -365,6 +504,9 @@ async function handleList(sql, userId) {
            d.file_type,
            d.file_size,
            d.metadata,
+           d.title,
+           d.summary,
+           d.version,
            d.created_at,
            d.updated_at,
            COUNT(c.id)::int AS chunk_count
@@ -448,6 +590,45 @@ async function handleUpload(sql, userId, payload = {}) {
   if (mimeType) {
     metadata.mimeType = mimeType;
   }
+
+  metadata.fileName = metadata.fileName || filename;
+
+  const normalizedTitle = getFirstNonEmptyString(
+    document.title,
+    metadata.title,
+    metadata.fileTitle,
+    metadata.documentTitle,
+    metadata.displayTitle,
+    filename,
+  );
+
+  const normalizedSummary = getFirstNonEmptyString(
+    document.summary,
+    metadata.summary,
+    metadata.description,
+  );
+
+  const normalizedVersion = getFirstNonEmptyString(
+    document.version,
+    metadata.version,
+  );
+
+  if (normalizedTitle) {
+    metadata.title = metadata.title || normalizedTitle;
+    metadata.fileTitle = metadata.fileTitle || normalizedTitle;
+    metadata.documentTitle = metadata.documentTitle || normalizedTitle;
+    metadata.displayTitle = metadata.displayTitle || normalizedTitle;
+  }
+
+  if (normalizedSummary) {
+    metadata.summary = metadata.summary || normalizedSummary;
+    metadata.description = metadata.description || normalizedSummary;
+  }
+
+  if (normalizedVersion) {
+    metadata.version = metadata.version || normalizedVersion;
+  }
+
   const metadataJson = JSON.stringify(metadata);
 
   const chunkSize = Number.isFinite(document.chunkSize) ? document.chunkSize : DEFAULT_CHUNK_SIZE;
@@ -469,7 +650,10 @@ async function handleUpload(sql, userId, payload = {}) {
         file_type,
         file_size,
         text_content,
-        metadata
+        metadata,
+        title,
+        summary,
+        version
       ) VALUES (
         ${userId},
         ${filename},
@@ -477,7 +661,10 @@ async function handleUpload(sql, userId, payload = {}) {
         ${normalizedDocumentType},
         ${Number.isFinite(document.size) ? Number(document.size) : null},
         ${text},
-        ${metadataJson}::jsonb
+        ${metadataJson}::jsonb,
+        ${normalizedTitle || null},
+        ${normalizedSummary || null},
+        ${normalizedVersion || null}
       )
       RETURNING id,
                 filename,
@@ -485,6 +672,9 @@ async function handleUpload(sql, userId, payload = {}) {
                 file_type,
                 file_size,
                 metadata,
+                title,
+                summary,
+                version,
                 created_at,
                 updated_at
     `;
@@ -551,11 +741,14 @@ async function handleSearch(sql, userId, payload = {}) {
            c.chunk_text,
            d.filename,
            d.metadata,
+           d.title,
+           d.summary,
+           d.version,
            ts_rank_cd(
              to_tsvector('english', c.chunk_text),
              plainto_tsquery('english', ${query})
            ) AS rank,
-           ts_headline(
+            ts_headline(
              'english',
              c.chunk_text,
              plainto_tsquery('english', ${query}),

--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -248,7 +248,9 @@ class RAGService {
       }
     }
 
-    ['fileName', 'title', 'description', 'category', 'version'].forEach(field => {
+    const textFields = ['fileName', 'fileTitle', 'title', 'description', 'summary', 'category', 'version'];
+
+    textFields.forEach(field => {
       if (typeof sanitized[field] === 'string') {
         sanitized[field] = sanitized[field].trim();
         if (!sanitized[field]) {
@@ -256,6 +258,47 @@ class RAGService {
         }
       }
     });
+
+    if (sanitized.summary && !sanitized.description) {
+      sanitized.description = sanitized.summary;
+    }
+
+    if (sanitized.description && !sanitized.summary) {
+      sanitized.summary = sanitized.description;
+    }
+
+    const resolvedTitle = getFirstNonEmptyString(
+      sanitized.title,
+      sanitized.fileTitle,
+      sanitized.documentTitle,
+      sanitized.displayTitle,
+    );
+
+    if (resolvedTitle) {
+      if (!sanitized.title) {
+        sanitized.title = resolvedTitle;
+      }
+      if (!sanitized.fileTitle) {
+        sanitized.fileTitle = resolvedTitle;
+      }
+      if (!sanitized.documentTitle) {
+        sanitized.documentTitle = resolvedTitle;
+      }
+      if (!sanitized.displayTitle) {
+        sanitized.displayTitle = resolvedTitle;
+      }
+    }
+
+    if (!sanitized.fileName) {
+      const fallbackFileName = getFirstNonEmptyString(
+        sanitized.filename,
+        sanitized.file_name,
+        sanitized.name,
+      );
+      if (fallbackFileName) {
+        sanitized.fileName = fallbackFileName;
+      }
+    }
 
     return sanitized;
   }
@@ -650,6 +693,46 @@ class RAGService {
       }
 
       const textContent = await this.extractTextFromFile(file);
+      const baseMetadata = {
+        ...sanitizedMetadata,
+      };
+
+      const normalizedTitle = getFirstNonEmptyString(
+        baseMetadata.title,
+        baseMetadata.fileTitle,
+        baseMetadata.documentTitle,
+        baseMetadata.displayTitle,
+        file.name,
+      );
+
+      const normalizedSummary = getFirstNonEmptyString(
+        baseMetadata.summary,
+        baseMetadata.description,
+      );
+
+      const normalizedVersion = getFirstNonEmptyString(
+        baseMetadata.version,
+        baseMetadata.documentVersion,
+      );
+
+      if (normalizedTitle) {
+        baseMetadata.title = baseMetadata.title || normalizedTitle;
+        baseMetadata.fileTitle = baseMetadata.fileTitle || normalizedTitle;
+        baseMetadata.documentTitle = baseMetadata.documentTitle || normalizedTitle;
+        baseMetadata.displayTitle = baseMetadata.displayTitle || normalizedTitle;
+      }
+
+      if (normalizedSummary) {
+        baseMetadata.summary = baseMetadata.summary || normalizedSummary;
+        baseMetadata.description = baseMetadata.description || normalizedSummary;
+      }
+
+      if (normalizedVersion) {
+        baseMetadata.version = baseMetadata.version || normalizedVersion;
+      }
+
+      baseMetadata.fileName = baseMetadata.fileName || file.name;
+
       const documentPayload = {
         filename: file.name,
         size: file.size,
@@ -657,9 +740,21 @@ class RAGService {
         text: textContent,
         metadata: {
           processingMode: 'neon-postgresql',
-          ...sanitizedMetadata,
+          ...baseMetadata,
         },
       };
+
+      if (normalizedTitle) {
+        documentPayload.title = normalizedTitle;
+      }
+
+      if (normalizedSummary) {
+        documentPayload.summary = normalizedSummary;
+      }
+
+      if (normalizedVersion) {
+        documentPayload.version = normalizedVersion;
+      }
 
       const response = await this.makeNeonRequest('upload', userId, {
         document: documentPayload,
@@ -669,9 +764,23 @@ class RAGService {
         this.clearDocumentMetadataCache(userId);
       }
 
+      const persistedDocument =
+        response?.document && typeof response.document === 'object'
+          ? response.document
+          : null;
+
+      const persistedMetadata =
+        persistedDocument?.metadata && typeof persistedDocument.metadata === 'object'
+          ? persistedDocument.metadata
+          : documentPayload.metadata;
+
       return {
         ...response,
-        metadata: documentPayload.metadata,
+        document: persistedDocument || {
+          ...documentPayload,
+          metadata: documentPayload.metadata,
+        },
+        metadata: persistedMetadata,
         storage: 'neon-postgresql',
       };
     }

--- a/src/services/ragService.test.js
+++ b/src/services/ragService.test.js
@@ -59,7 +59,7 @@ describe('ragService neon backend integration', () => {
 
     const result = await ragService.uploadDocument(
       file,
-      { title: '  Policy Overview ', tags: ' gmp , qa ' },
+      { title: '  Policy Overview ', description: ' Summary of the quality policy. ', version: ' v1 ', tags: ' gmp , qa ' },
       'user-1'
     );
 
@@ -69,9 +69,15 @@ describe('ragService neon backend integration', () => {
       expect.objectContaining({
         document: expect.objectContaining({
           filename: 'Policy.pdf',
+          title: 'Policy Overview',
+          summary: 'Summary of the quality policy.',
+          version: 'v1',
           metadata: expect.objectContaining({
             title: 'Policy Overview',
             tags: ['gmp', 'qa'],
+            summary: 'Summary of the quality policy.',
+            description: 'Summary of the quality policy.',
+            version: 'v1',
             processingMode: 'neon-postgresql',
           }),
         }),
@@ -80,6 +86,8 @@ describe('ragService neon backend integration', () => {
 
     expect(result.storage).toBe('neon-postgresql');
     expect(result.metadata.title).toBe('Policy Overview');
+    expect(result.metadata.summary).toBe('Summary of the quality policy.');
+    expect(result.metadata.version).toBe('v1');
     expect(result.metadata.tags).toEqual(['gmp', 'qa']);
   });
 


### PR DESCRIPTION
## Summary
- extend the Neon RAG function to persist document title, summary, and version columns alongside chunked text content
- normalize uploaded metadata on both the client service and Netlify document API so file titles and summaries are captured consistently
- return enriched document metadata from the Neon workflow so UI consumers can display summaries and versions for uploaded files

## Testing
- `CI=true npm test -- --runTestsByPath src/services/ragService.test.js src/rag-documents.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d96b912b78832ab272c6a74afbb0ae