### PR TITLE
Restore RAG fallback state handling

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -685,7 +685,6 @@ const ChatArea = ({
   handleKeyPress,
   messagesEndRef,
   ragEnabled,
-  setRAGEnabled,
   isSaving,
   uploadedFile,
   setUploadedFile,
@@ -713,7 +712,7 @@ const ChatArea = ({
 
   return (
     <div className="h-full flex flex-col min-h-0 overflow-hidden bg-white rounded-lg shadow-sm border border-gray-200">
-      {/* Chat Header with RAG Toggle */}
+      {/* Chat Header */}
       <div className="flex-shrink-0 px-4 sm:px-6 py-3 sm:py-4 border-b border-gray-200 bg-gray-50 rounded-t-lg">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
@@ -727,42 +726,17 @@ const ChatArea = ({
               </div>
             )}
           </div>
-
-          {/* RAG Toggle Switch */}
-          <label
-            className="flex items-center space-x-2 cursor-pointer"
-            title={ragEnabled ? 'RAG enabled - searching uploaded documents' : 'RAG disabled - AI knowledge only'}
-          >
-            <input
-              type="checkbox"
-              className="sr-only"
-              checked={ragEnabled}
-              onChange={() => setRAGEnabled(!ragEnabled)}
-            />
-            <span
-              className={`relative inline-block h-5 w-10 rounded-full transition-colors ${
-                ragEnabled ? 'bg-purple-600' : 'bg-gray-300'
-              }`}
-            >
-              <span
-                className={`absolute left-1 top-1 h-3 w-3 rounded-full bg-white transition-transform ${
-                  ragEnabled ? 'translate-x-5' : ''
-                }`}
-              />
-            </span>
-            <span className="hidden sm:inline text-sm">
-              {ragEnabled ? 'Document Search' : 'AI Knowledge'}
-            </span>
-          </label>
         </div>
 
-        {/* RAG Status Description */}
-        {ragEnabled && (
-          <div className="mt-2 text-sm text-purple-600 bg-purple-50 px-3 py-1 rounded-md flex items-center space-x-2">
-            <Database className="h-3 w-3" />
-            <span>Searching uploaded documents for relevant context</span>
-          </div>
-        )}
+        {/* Document search status description */}
+        <div className="mt-2 text-sm text-purple-600 bg-purple-50 px-3 py-1 rounded-md flex items-center space-x-2">
+          <Database className="h-3 w-3" />
+          <span>
+            {ragEnabled
+              ? 'Document Search is prioritized with automatic fallback to AI Knowledge when needed.'
+              : 'AI Knowledge responded automatically when no document answer was found. Document Search will be retried on your next message.'}
+          </span>
+        </div>
       </div>
 
       {/* Messages Container */}


### PR DESCRIPTION
## Summary
- restore internal ragEnabled state so automatic fallback no longer references an undefined setter
- add defensive error handling around document search and toggle the header status message when AI Knowledge responds automatically

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d97f7df984832a9818f55859d76430