### PR TITLE
Track automatic fallback mode without RAG toggle

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -684,8 +684,7 @@ const ChatArea = ({
   handleSendMessage,
   handleKeyPress,
   messagesEndRef,
-  ragEnabled,
-  setRAGEnabled,
+  lastResponseMode,
   isSaving,
   uploadedFile,
   setUploadedFile,
@@ -711,9 +710,13 @@ const ChatArea = ({
     }
   }, []);
 
+  const normalizedResponseMode =
+    lastResponseMode === 'ai-knowledge' ? 'ai-knowledge' : 'document-search';
+  const usedFallback = normalizedResponseMode === 'ai-knowledge';
+
   return (
     <div className="h-full flex flex-col min-h-0 overflow-hidden bg-white rounded-lg shadow-sm border border-gray-200">
-      {/* Chat Header with RAG Toggle */}
+      {/* Chat Header */}
       <div className="flex-shrink-0 px-4 sm:px-6 py-3 sm:py-4 border-b border-gray-200 bg-gray-50 rounded-t-lg">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
@@ -727,42 +730,17 @@ const ChatArea = ({
               </div>
             )}
           </div>
-
-          {/* RAG Toggle Switch */}
-          <label
-            className="flex items-center space-x-2 cursor-pointer"
-            title={ragEnabled ? 'RAG enabled - searching uploaded documents' : 'RAG disabled - AI knowledge only'}
-          >
-            <input
-              type="checkbox"
-              className="sr-only"
-              checked={ragEnabled}
-              onChange={() => setRAGEnabled(!ragEnabled)}
-            />
-            <span
-              className={`relative inline-block h-5 w-10 rounded-full transition-colors ${
-                ragEnabled ? 'bg-purple-600' : 'bg-gray-300'
-              }`}
-            >
-              <span
-                className={`absolute left-1 top-1 h-3 w-3 rounded-full bg-white transition-transform ${
-                  ragEnabled ? 'translate-x-5' : ''
-                }`}
-              />
-            </span>
-            <span className="hidden sm:inline text-sm">
-              {ragEnabled ? 'Document Search' : 'AI Knowledge'}
-            </span>
-          </label>
         </div>
 
-        {/* RAG Status Description */}
-        {ragEnabled && (
-          <div className="mt-2 text-sm text-purple-600 bg-purple-50 px-3 py-1 rounded-md flex items-center space-x-2">
-            <Database className="h-3 w-3" />
-            <span>Searching uploaded documents for relevant context</span>
-          </div>
-        )}
+        {/* Document search status description */}
+        <div className="mt-2 text-sm text-purple-600 bg-purple-50 px-3 py-1 rounded-md flex items-center space-x-2">
+          <Database className="h-3 w-3" />
+          <span>
+            {usedFallback
+              ? 'AI Knowledge responded automatically when no document answer was found. Document Search will be retried on your next message.'
+              : 'Document Search is prioritized with automatic fallback to AI Knowledge when needed.'}
+          </span>
+        </div>
       </div>
 
       {/* Messages Container */}


### PR DESCRIPTION
## Summary
- replace the old ragEnabled toggle with a lastResponseMode state that records whether Document Search or AI Knowledge produced the last reply
- reset the recorded mode when the session is cleared or ends so the UI defaults to prioritizing Document Search on the next turn
- update ChatArea to display the automatic fallback status based on the last response instead of a manual toggle

## Testing
- npm run build *(fails: existing ESLint errors complaining that `globalThis` is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68d97f7df984832a9818f55859d76430