### PR TITLE
Restore RAG toggle compatibility with automatic fallback

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -56,9 +56,10 @@ AcceleraQA is an AI-powered learning assistant tailored for pharmaceutical quali
 *As a learner, I want the assistant to cite relevant documents when available so I can trust the guidance.*
 
 **Acceptance Criteria**
-- When RAG is enabled and no new file upload is pending, the system issues a retrieval search using either the active document vector store or the configured backend before calling OpenAI chat completion.【F:src/App.js†L484-L519】
-- Assistant replies merge OpenAI-sourced references with internal attachments and admin-curated resources, deduplicating entries for clarity.【F:src/App.js†L501-L520】
+- When RAG is enabled and no new file upload is pending, the system issues a retrieval search using either the active document vector store or the configured backend before calling OpenAI chat completion.【F:src/App.js†L669-L714】
+- Assistant replies merge OpenAI-sourced references with internal attachments and admin-curated resources, deduplicating entries for clarity.【F:src/App.js†L720-L745】
 - The transcript displays up to three source cards per message with titles, snippets, and outbound links when available.【F:src/components/ChatArea.js†L854-L919】
+- If document search returns no answer or sources, the assistant automatically falls back to AI Knowledge, labels the message with the mode used, and retries document search on the next prompt.【F:src/App.js†L669-L717】【F:src/components/ChatArea.js†L713-L745】
 
 #### Story 2.3 – Enforce responsible usage throttling
 *As a system steward, I want to throttle rapid-fire prompts so that platform limits are respected.*

--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -684,8 +684,7 @@ const ChatArea = ({
   handleSendMessage,
   handleKeyPress,
   messagesEndRef,
-  ragEnabled,
-  setRAGEnabled,
+  lastResponseMode,
   isSaving,
   uploadedFile,
   setUploadedFile,
@@ -711,9 +710,14 @@ const ChatArea = ({
     }
   }, []);
 
+  const normalizedResponseMode =
+    lastResponseMode === 'document-search' ? 'document-search' : 'ai-knowledge';
+  const usedFallback = lastResponseMode === 'ai-knowledge-auto';
+  const manualOverrideActive = lastResponseMode === 'ai-knowledge-manual';
+
   return (
     <div className="h-full flex flex-col min-h-0 overflow-hidden bg-white rounded-lg shadow-sm border border-gray-200">
-      {/* Chat Header with RAG Toggle */}
+      {/* Chat Header */}
       <div className="flex-shrink-0 px-4 sm:px-6 py-3 sm:py-4 border-b border-gray-200 bg-gray-50 rounded-t-lg">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
@@ -727,42 +731,19 @@ const ChatArea = ({
               </div>
             )}
           </div>
-
-          {/* RAG Toggle Switch */}
-          <label
-            className="flex items-center space-x-2 cursor-pointer"
-            title={ragEnabled ? 'RAG enabled - searching uploaded documents' : 'RAG disabled - AI knowledge only'}
-          >
-            <input
-              type="checkbox"
-              className="sr-only"
-              checked={ragEnabled}
-              onChange={() => setRAGEnabled(!ragEnabled)}
-            />
-            <span
-              className={`relative inline-block h-5 w-10 rounded-full transition-colors ${
-                ragEnabled ? 'bg-purple-600' : 'bg-gray-300'
-              }`}
-            >
-              <span
-                className={`absolute left-1 top-1 h-3 w-3 rounded-full bg-white transition-transform ${
-                  ragEnabled ? 'translate-x-5' : ''
-                }`}
-              />
-            </span>
-            <span className="hidden sm:inline text-sm">
-              {ragEnabled ? 'Document Search' : 'AI Knowledge'}
-            </span>
-          </label>
         </div>
 
-        {/* RAG Status Description */}
-        {ragEnabled && (
-          <div className="mt-2 text-sm text-purple-600 bg-purple-50 px-3 py-1 rounded-md flex items-center space-x-2">
-            <Database className="h-3 w-3" />
-            <span>Searching uploaded documents for relevant context</span>
-          </div>
-        )}
+        {/* Document search status description */}
+        <div className="mt-2 text-sm text-purple-600 bg-purple-50 px-3 py-1 rounded-md flex items-center space-x-2">
+          <Database className="h-3 w-3" />
+          <span>
+            {manualOverrideActive
+              ? 'AI Knowledge is responding because Document Search has been manually disabled.'
+              : usedFallback
+                ? 'AI Knowledge responded automatically when no document answer was found. Document Search will be retried on your next message.'
+                : 'Document Search is prioritized with automatic fallback to AI Knowledge when needed.'}
+          </span>
+        </div>
       </div>
 
       {/* Messages Container */}


### PR DESCRIPTION
## Summary
- expose a deprecated global setRAGEnabled shim so legacy scripts can safely flip the preference while the UI prioritizes automatic fallback
- update the send-message pipeline to attempt document search first, fall back to AI Knowledge with explicit mode annotations, and surface manual overrides in the chat header
- document the automatic fallback behavior in the requirements reference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d97f7df984832a9818f55859d76430