### PR TITLE
Handle S3 access failures with configurable prefixes

### DIFF
--- a/netlify/functions/neon-rag-fixed.js
+++ b/netlify/functions/neon-rag-fixed.js
@@ -1,6 +1,8 @@
 
 import { neon, neonConfig } from '@neondatabase/serverless';
 
+import { uploadDocumentToS3 } from '../lib/s3-helper.js';
+
 export const config = {
   nodeRuntime: 'nodejs18.x',
 };
@@ -13,6 +15,82 @@ const headers = {
   'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-user-id',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Content-Type': 'application/json',
+};
+
+const getS3BucketName = () =>
+  process.env.RAG_S3_BUCKET ||
+  process.env.S3_BUCKET ||
+  process.env.AWS_S3_BUCKET ||
+  process.env.AWS_BUCKET_NAME ||
+  '';
+
+const getS3KeyPrefix = () => {
+  const candidates = [
+    process.env.RAG_S3_PREFIX,
+    process.env.S3_KEY_PREFIX,
+    process.env.AWS_S3_PREFIX,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') {
+      continue;
+    }
+
+    const trimmed = candidate.trim().replace(/^\/+|\/+$/g, '');
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return 'rag-documents';
+};
+
+const isAccessDeniedError = (error) => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const code = error.name || error.Code || error.code;
+  const status = error.$metadata?.httpStatusCode || error.statusCode;
+  const message = typeof error.message === 'string' ? error.message : '';
+
+  return (
+    code === 'AccessDenied' ||
+    code === 'Forbidden' ||
+    status === 403 ||
+    /access\s*denied/i.test(message)
+  );
+};
+
+const buildS3UploadError = (error) => {
+  const bucket = getS3BucketName();
+  const prefix = getS3KeyPrefix();
+  const accessDenied = isAccessDeniedError(error);
+  const baseMessage = accessDenied
+    ? 'Access denied when uploading document to S3.'
+    : 'Failed to upload document to S3.';
+
+  const guidanceParts = [];
+  if (bucket) {
+    guidanceParts.push(`bucket "${bucket}"`);
+  }
+  if (prefix) {
+    guidanceParts.push(`prefix "${prefix}"`);
+  }
+
+  const guidance = guidanceParts.length
+    ? ` Confirm the configured IAM role allows s3:PutObject on ${guidanceParts.join(' and ')}.`
+    : '';
+
+  const detail = error && typeof error.message === 'string' && error.message
+    ? ` Details: ${error.message}`
+    : '';
+
+  const friendlyError = new Error(`${baseMessage}${guidance}${detail}`.trim());
+  const fallbackStatus = error?.$metadata?.httpStatusCode || error?.statusCode || 502;
+  const normalizedStatus = Number.isFinite(fallbackStatus) ? Number(fallbackStatus) : 502;
+  friendlyError.statusCode = accessDenied ? 403 : Math.min(Math.max(normalizedStatus, 400), 599);
+  return friendlyError;
 };
 
 let sqlClientPromise = null;
@@ -375,6 +453,13 @@ function normalizeDocumentRow(row) {
     metadata.fileName = row.filename;
   }
 
+  const storageLocation =
+    metadata.storage && typeof metadata.storage === 'object' ? { ...metadata.storage } : null;
+
+  if (storageLocation) {
+    metadata.storage = storageLocation;
+  }
+
   const resolvedTitle = getFirstNonEmptyString(
     row.title,
     metadata.title,
@@ -417,7 +502,8 @@ function normalizeDocumentRow(row) {
     updatedAt: row.updated_at,
     metadata,
     chunkCount: row.chunk_count != null ? Number(row.chunk_count) : undefined,
-    storage: 'neon-postgresql',
+    storage: storageLocation?.provider || 'neon-postgresql',
+    storageLocation,
   };
 }
 
@@ -911,6 +997,58 @@ async function handleUpload(sql, userId, payload = {}) {
     metadata.version = metadata.version || normalizedVersion;
   }
 
+  const encoding = typeof document.encoding === 'string' ? document.encoding.trim().toLowerCase() : '';
+  let contentBuffer = null;
+  if (typeof document.content === 'string' && document.content.trim()) {
+    if (encoding && encoding !== 'base64') {
+      const error = new Error(`Unsupported document encoding: ${encoding}`);
+      error.statusCode = 400;
+      throw error;
+    }
+
+    try {
+      contentBuffer = Buffer.from(document.content.trim(), 'base64');
+    } catch (bufferError) {
+      const error = new Error('Failed to decode document content');
+      error.statusCode = 400;
+      throw error;
+    }
+  }
+
+  let storageLocation = null;
+  if (contentBuffer && contentBuffer.length > 0) {
+    try {
+      storageLocation = await uploadDocumentToS3({
+        body: contentBuffer,
+        contentType: mimeType || 'application/octet-stream',
+        userId,
+        documentId: document.documentId || document.id || payload.documentId || filename,
+        filename,
+        metadata: {
+          'x-user-id': userId,
+          'x-document-filename': filename,
+        },
+      });
+    } catch (error) {
+      console.error('Failed to upload document content to S3', error);
+      throw buildS3UploadError(error);
+    }
+
+    metadata.storage = {
+      provider: 's3',
+      bucket: storageLocation.bucket,
+      region: storageLocation.region,
+      key: storageLocation.key,
+      url: storageLocation.url,
+      etag: storageLocation.etag || null,
+      size: storageLocation.size ?? contentBuffer.length,
+    };
+  }
+
+  const resolvedFileSize = Number.isFinite(document.size)
+    ? Number(document.size)
+    : storageLocation?.size ?? (contentBuffer ? contentBuffer.length : null);
+
   const metadataJson = JSON.stringify(metadata);
 
   const chunkSize = Number.isFinite(document.chunkSize) ? document.chunkSize : DEFAULT_CHUNK_SIZE;
@@ -941,7 +1079,7 @@ async function handleUpload(sql, userId, payload = {}) {
         ${filename},
         ${normalizedOriginalFilename || filename},
         ${normalizedDocumentType},
-        ${Number.isFinite(document.size) ? Number(document.size) : null},
+        ${resolvedFileSize},
         ${text},
         ${metadataJson}::jsonb,
         ${normalizedTitle || null},
@@ -1000,6 +1138,7 @@ async function handleUpload(sql, userId, payload = {}) {
       message: 'Document stored',
       document: responseDocument,
       chunks: chunks.length,
+      storageLocation: responseDocument.storageLocation || storageLocation,
     }),
   };
 }
@@ -1174,4 +1313,9 @@ export const handler = async (event) => {
       }),
     };
   }
+};
+
+export const __testHelpers = {
+  handleUpload,
+  normalizeDocumentRow,
 };

--- a/netlify/functions/rag-documents.js
+++ b/netlify/functions/rag-documents.js
@@ -1,6 +1,8 @@
 import { neon } from '@neondatabase/serverless';
 import { randomUUID } from 'crypto';
 
+import { uploadDocumentToS3 } from '../lib/s3-helper.js';
+
 const headers = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-user-id',
@@ -137,18 +139,25 @@ const createResponse = (statusCode, body) => ({
   body: JSON.stringify(body),
 });
 
-const mapDocumentRow = (row) => ({
-  id: row.document_id,
-  fileId: row.file_id,
-  filename: row.filename,
-  type: row.content_type,
-  size: row.size == null ? 0 : Number(row.size),
-  metadata: row.metadata || {},
-  chunks: row.chunks == null ? 0 : Number(row.chunks),
-  vectorStoreId: row.vector_store_id || null,
-  createdAt: row.created_at,
-  updatedAt: row.updated_at,
-});
+const mapDocumentRow = (row) => {
+  const metadata = row.metadata && typeof row.metadata === 'object' ? { ...row.metadata } : {};
+  const storageLocation =
+    metadata.storage && typeof metadata.storage === 'object' ? { ...metadata.storage } : null;
+
+  return {
+    id: row.document_id,
+    fileId: row.file_id,
+    filename: row.filename,
+    type: row.content_type,
+    size: row.size == null ? 0 : Number(row.size),
+    metadata,
+    chunks: row.chunks == null ? 0 : Number(row.chunks),
+    vectorStoreId: row.vector_store_id || null,
+    storageLocation,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+};
 
 const estimateBinarySizeFromBase64 = (base64 = '') => {
   if (!base64) return 0;
@@ -366,21 +375,57 @@ const handleSaveDocument = async (sql, userId, payload) => {
     document.metadata && typeof document.metadata === 'object' ? document.metadata : {}
   );
 
-  let contentBase64 = null;
+  let contentBuffer = null;
   let contentEncoding = null;
+  let storageLocation = null;
   try {
     const normalizedContent = normalizeDocumentContent(document);
-    contentBase64 = normalizedContent.base64;
-    contentEncoding = normalizedContent.encoding;
-    if (normalizedContent.truncated) {
-      console.warn(`Document content for ${documentId} exceeded persistence limit and will not be persisted locally.`);
+    if (normalizedContent.base64) {
+      contentBuffer = Buffer.from(normalizedContent.base64, 'base64');
+      contentEncoding = normalizedContent.encoding;
+    } else if (normalizedContent.truncated) {
+      console.warn(
+        `Document content for ${documentId} exceeded persistence limit and will not be persisted locally. Uploading original payload skipped.`
+      );
     }
   } catch (contentError) {
     console.warn('Unable to normalize document content for persistence:', contentError);
   }
 
+  if (contentBuffer) {
+    try {
+      storageLocation = await uploadDocumentToS3({
+        body: contentBuffer,
+        contentType: document.type || document.contentType || document.mimeType || 'application/octet-stream',
+        documentId,
+        userId,
+        filename: document.filename || document.name,
+        metadata: {
+          'x-user-id': userId,
+          'x-document-id': documentId,
+        },
+      });
+    } catch (uploadError) {
+      console.error('Failed to upload document content to S3:', uploadError);
+      storageLocation = null;
+    }
+  }
+
   const numericSize = Number.isFinite(Number(document.size)) ? Number(document.size) : null;
-  const resolvedSize = numericSize ?? (contentBase64 ? estimateBinarySizeFromBase64(contentBase64) : 0);
+  const resolvedSize =
+    numericSize ?? (storageLocation?.size != null ? Number(storageLocation.size) : contentBuffer?.length ?? 0);
+
+  if (storageLocation) {
+    normalizedMetadata.storage = {
+      provider: 's3',
+      bucket: storageLocation.bucket,
+      region: storageLocation.region,
+      key: storageLocation.key,
+      url: storageLocation.url,
+      etag: storageLocation.etag || null,
+      size: storageLocation.size ?? contentBuffer?.length ?? numericSize ?? null,
+    };
+  }
 
   const rows = await sql`
     INSERT INTO rag_user_documents (
@@ -405,8 +450,8 @@ const handleSaveDocument = async (sql, userId, payload) => {
       ${normalizedMetadata},
       ${document.chunks ?? 0},
       ${vectorStoreId},
-      ${contentBase64},
-      ${contentEncoding}
+      ${storageLocation ? null : contentBuffer ? contentBuffer.toString('base64') : null},
+      ${storageLocation ? null : contentEncoding}
     )
     ON CONFLICT (document_id) DO UPDATE
     SET user_id = EXCLUDED.user_id,
@@ -423,8 +468,10 @@ const handleSaveDocument = async (sql, userId, payload) => {
     RETURNING document_id, file_id, filename, content_type, size, metadata, chunks, vector_store_id, created_at, updated_at
   `;
 
+  const mapped = mapDocumentRow(rows[0]);
   return createResponse(200, {
-    document: mapDocumentRow(rows[0]),
+    document: mapped,
+    storageLocation: mapped.storageLocation || storageLocation,
   });
 };
 
@@ -568,6 +615,9 @@ const handleDownloadDocument = async (sql, userId, payload) => {
     return createResponse(404, { error: 'Document not found for this user' });
   }
 
+  const metadata = record.metadata && typeof record.metadata === 'object' ? record.metadata : {};
+  const storageLocation = metadata.storage && typeof metadata.storage === 'object' ? metadata.storage : null;
+
   if (record.content_base64) {
     const encoding = record.content_encoding || DEFAULT_CONTENT_ENCODING;
     const derivedSize = estimateBinarySizeFromBase64(record.content_base64);
@@ -580,7 +630,20 @@ const handleDownloadDocument = async (sql, userId, payload) => {
       size: record.size == null ? derivedSize : Number(record.size),
       encoding,
       content: record.content_base64,
-      metadata: record.metadata || {},
+      metadata,
+      storageLocation,
+    });
+  }
+
+  if (storageLocation) {
+    return createResponse(200, {
+      documentId: record.document_id,
+      fileId: record.file_id,
+      filename: record.filename,
+      contentType: record.content_type || 'application/octet-stream',
+      size: record.size == null ? Number(storageLocation.size || 0) : Number(record.size),
+      storageLocation,
+      metadata,
     });
   }
 
@@ -640,7 +703,8 @@ const handleDownloadDocument = async (sql, userId, payload) => {
     size: record.size == null ? computedSize : Number(record.size),
     encoding: DEFAULT_CONTENT_ENCODING,
     content: base64Content,
-    metadata: record.metadata || {},
+    metadata,
+    storageLocation,
   });
 };
 
@@ -791,4 +855,5 @@ export const __testHelpers = {
   downloadDocumentContentFromOpenAI,
   isJsonLikeContentType,
   payloadContainsVectorStoreDescriptor,
+  handleSaveDocument,
 };

--- a/netlify/lib/s3-helper.js
+++ b/netlify/lib/s3-helper.js
@@ -1,0 +1,198 @@
+let cachedClient = null;
+let cachedRegion = null;
+let s3ModulePromise = null;
+
+const DEFAULT_KEY_PREFIX = 'rag-documents';
+
+const sanitizeKeySegment = (value, fallback) => {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+  return trimmed.replace(/[^a-zA-Z0-9._\-\/]+/g, '-');
+};
+
+const resolveS3Config = () => {
+  const bucket =
+    process.env.RAG_S3_BUCKET ||
+    process.env.S3_BUCKET ||
+    process.env.AWS_S3_BUCKET ||
+    process.env.AWS_BUCKET_NAME;
+  const region =
+    process.env.RAG_S3_REGION ||
+    process.env.AWS_REGION ||
+    process.env.AWS_DEFAULT_REGION;
+
+  if (!bucket) {
+    throw new Error('RAG_S3_BUCKET (or S3 bucket environment variable) is required for document storage');
+  }
+
+  if (!region) {
+    throw new Error('RAG_S3_REGION (or AWS region environment variable) is required for document storage');
+  }
+
+  return { bucket, region };
+};
+
+const loadS3Module = async () => {
+  if (!s3ModulePromise) {
+    s3ModulePromise = import('@aws-sdk/client-s3');
+  }
+  return s3ModulePromise;
+};
+
+const getS3Client = async (region) => {
+  const { S3Client } = await loadS3Module();
+  if (!cachedClient || cachedRegion !== region) {
+    cachedClient = new S3Client({ region });
+    cachedRegion = region;
+  }
+  return cachedClient;
+};
+
+const sanitizeKeyPrefix = (prefix) => {
+  if (typeof prefix !== 'string') {
+    return '';
+  }
+
+  return prefix
+    .split('/')
+    .map(segment => sanitizeKeySegment(segment, ''))
+    .filter(Boolean)
+    .join('/');
+};
+
+const getConfiguredKeyPrefix = () => {
+  const candidates = [
+    process.env.RAG_S3_PREFIX,
+    process.env.S3_KEY_PREFIX,
+    process.env.AWS_S3_PREFIX,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') {
+      continue;
+    }
+
+    const trimmed = candidate.trim().replace(/^\/+|\/+$/g, '');
+    if (!trimmed) {
+      continue;
+    }
+
+    const sanitized = sanitizeKeyPrefix(trimmed);
+    if (sanitized) {
+      return sanitized;
+    }
+  }
+
+  return DEFAULT_KEY_PREFIX;
+};
+
+const buildObjectKey = ({ userId, documentId, filename }) => {
+  const segments = [];
+
+  const configuredPrefix = getConfiguredKeyPrefix();
+  if (configuredPrefix) {
+    segments.push(configuredPrefix);
+  }
+
+  const normalizedUserId = sanitizeKeySegment(userId, 'anonymous');
+  segments.push(normalizedUserId);
+
+  const normalizedDocumentId = sanitizeKeySegment(documentId, Date.now().toString(36));
+  segments.push(normalizedDocumentId);
+
+  const safeFilename = sanitizeKeySegment(filename, 'document');
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  segments.push(`${timestamp}-${safeFilename}`);
+
+  return segments.filter(Boolean).join('/');
+};
+
+const buildS3Url = ({ bucket, region, key }) => {
+  const encodedKey = key
+    .split('/')
+    .map(part => encodeURIComponent(part))
+    .join('/');
+  const baseUrl = region === 'us-east-1'
+    ? `https://${bucket}.s3.amazonaws.com`
+    : `https://${bucket}.s3.${region}.amazonaws.com`;
+  return `${baseUrl}/${encodedKey}`;
+};
+
+export const uploadDocumentToS3 = async ({
+  body,
+  contentType,
+  userId,
+  documentId,
+  filename,
+  metadata = {},
+}) => {
+  if (!body) {
+    throw new Error('S3 upload body is required');
+  }
+
+  const { bucket, region } = resolveS3Config();
+  if (typeof globalThis?.__UPLOAD_DOCUMENT_TO_S3_MOCK__ === 'function') {
+    return await globalThis.__UPLOAD_DOCUMENT_TO_S3_MOCK__({
+      body,
+      contentType: contentType || 'application/octet-stream',
+      userId,
+      documentId,
+      filename,
+      metadata,
+      bucket,
+      region,
+    });
+  }
+  const client = await getS3Client(region);
+
+  const key = buildObjectKey({ userId, documentId, filename });
+
+  const { PutObjectCommand } = await loadS3Module();
+  const size = Buffer.isBuffer(body)
+    ? body.length
+    : ArrayBuffer.isView(body)
+      ? body.byteLength
+      : typeof body === 'string'
+        ? Buffer.byteLength(body)
+        : null;
+  const putObjectCommand = new PutObjectCommand({
+    Bucket: bucket,
+    Key: key,
+    Body: body,
+    ContentType: contentType || 'application/octet-stream',
+    ...(typeof size === 'number' ? { ContentLength: size } : {}),
+    Metadata: Object.fromEntries(
+      Object.entries(metadata || {})
+        .filter(([metaKey, metaValue]) =>
+          typeof metaKey === 'string' && metaKey.trim() && typeof metaValue === 'string'
+        )
+        .map(([metaKey, metaValue]) => [metaKey.toLowerCase(), metaValue])
+    ),
+  });
+
+  const response = await client.send(putObjectCommand);
+  const etag = typeof response.ETag === 'string' ? response.ETag.replace(/"/g, '') : null;
+  const url = buildS3Url({ bucket, region, key });
+
+  return {
+    bucket,
+    region,
+    key,
+    url,
+    etag,
+    size,
+  };
+};
+
+export const __internal = {
+  resolveS3Config,
+  getConfiguredKeyPrefix,
+  buildObjectKey,
+  buildS3Url,
+  sanitizeKeySegment,
+};

--- a/netlify/lib/s3-helper.test.js
+++ b/netlify/lib/s3-helper.test.js
@@ -1,0 +1,40 @@
+import { jest } from '@jest/globals';
+
+describe('s3-helper key prefix', () => {
+  afterEach(() => {
+    delete process.env.RAG_S3_PREFIX;
+    delete process.env.S3_KEY_PREFIX;
+    delete process.env.AWS_S3_PREFIX;
+    jest.resetModules();
+  });
+
+  test('uses configured prefix when building object keys', async () => {
+    jest.resetModules();
+    process.env.RAG_S3_PREFIX = 'allowed/uploads';
+
+    const { __internal } = await import('./s3-helper.js');
+    const key = __internal.buildObjectKey({
+      userId: 'auth0|example',
+      documentId: 'doc id',
+      filename: 'Quarterly Report.pdf',
+    });
+
+    expect(key.split('/').slice(0, 2).join('/')).toBe('allowed/uploads');
+    expect(key).toContain('auth0-example');
+    expect(key).toMatch(/\.pdf$/);
+  });
+
+  test('falls back to default prefix when override is empty', async () => {
+    jest.resetModules();
+    process.env.RAG_S3_PREFIX = '   ';
+
+    const { __internal } = await import('./s3-helper.js');
+    const key = __internal.buildObjectKey({
+      userId: 'user',
+      documentId: 'doc',
+      filename: 'file.txt',
+    });
+
+    expect(key.startsWith('rag-documents/')).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://acceleraqa.com",
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
+    "@aws-sdk/client-s3": "^3.637.0",
     "@netlify/blobs": "^6.4.0",
     "@neondatabase/serverless": "^0.9.0",
     "jsonwebtoken": "^9.0.0",

--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -1177,6 +1177,28 @@ const RAGConfigurationPage = ({ user, onClose }) => {
                                           <span className="font-medium text-gray-600">Original:</span> {doc.metadata.originalFilename} (converted from {describeConversionSource(doc.metadata.conversion) || 'the uploaded format'})
                                         </p>
                                       )}
+                                      {doc.metadata?.storage && (
+                                        <p className="text-xs text-gray-500 mt-1 space-y-0.5">
+                                          <span className="font-medium text-gray-600">Storage:</span>{' '}
+                                          {doc.metadata.storage.url ? (
+                                            <a
+                                              href={doc.metadata.storage.url}
+                                              target="_blank"
+                                              rel="noopener noreferrer"
+                                              className="text-blue-600 hover:text-blue-500 underline"
+                                            >
+                                              View object
+                                            </a>
+                                          ) : (
+                                            <span className="text-gray-600">S3 object</span>
+                                          )}
+                                          {doc.metadata.storage.key && (
+                                            <span className="block text-[11px] text-gray-400 break-all">
+                                              Key: {doc.metadata.storage.key}
+                                            </span>
+                                          )}
+                                        </p>
+                                      )}
                                     </div>
                                   </div>
                                 </td>

--- a/src/neon-rag-fixed.test.js
+++ b/src/neon-rag-fixed.test.js
@@ -1,0 +1,138 @@
+import { jest } from '@jest/globals';
+
+const uploadDocumentToS3Mock = jest.fn();
+
+let handleUpload;
+
+const loadModule = async () => {
+  jest.resetModules();
+  uploadDocumentToS3Mock.mockReset();
+  uploadDocumentToS3Mock.mockResolvedValue({
+    bucket: 'test-bucket',
+    region: 'us-east-1',
+    key: 'rag-documents/user/doc-1',
+    url: 'https://test-bucket.s3.amazonaws.com/rag-documents/user/doc-1',
+    etag: 'etag-123',
+    size: 4,
+  });
+
+  process.env.RAG_S3_BUCKET = 'test-bucket';
+  process.env.RAG_S3_REGION = 'us-east-1';
+  global.__UPLOAD_DOCUMENT_TO_S3_MOCK__ = uploadDocumentToS3Mock;
+
+  const module = await import('../netlify/functions/neon-rag-fixed.js');
+  handleUpload = module.__testHelpers.handleUpload;
+};
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+  await loadModule();
+});
+
+afterEach(() => {
+  delete process.env.RAG_S3_BUCKET;
+  delete process.env.RAG_S3_REGION;
+  delete global.__UPLOAD_DOCUMENT_TO_S3_MOCK__;
+});
+
+describe('neon-rag-fixed handleUpload', () => {
+  test('uploads binary payload to S3 and persists storage metadata', async () => {
+    const capturedMetadata = [];
+    const sqlMock = jest.fn(async (strings, ...values) => {
+      const query = strings.join(' ');
+      if (query.includes('SELECT enumlabel')) {
+        return [];
+      }
+      if (query.includes('INSERT INTO rag_documents')) {
+        const metadataJson = values[6];
+        const metadata = metadataJson ? JSON.parse(metadataJson) : {};
+        capturedMetadata.push(metadata);
+        return [
+          {
+            id: 42,
+            filename: values[1],
+            original_filename: values[2],
+            file_type: values[3],
+            file_size: values[4],
+            metadata,
+            title: values[7],
+            summary: values[8],
+            version: values[9],
+            created_at: '2024-01-01T00:00:00.000Z',
+            updated_at: '2024-01-01T00:00:00.000Z',
+          },
+        ];
+      }
+      if (query.includes('INSERT INTO rag_document_chunks')) {
+        return [];
+      }
+      return [];
+    });
+
+    const payload = {
+      document: {
+        documentId: 'doc-1',
+        filename: 'Policy.pdf',
+        text: 'Document body',
+        type: 'application/pdf',
+        content: Buffer.from('fake').toString('base64'),
+        encoding: 'base64',
+        metadata: { category: 'Policy' },
+      },
+    };
+
+    const response = await handleUpload(sqlMock, 'user-123', payload);
+
+    expect(uploadDocumentToS3Mock).toHaveBeenCalledTimes(1);
+    const uploadArgs = uploadDocumentToS3Mock.mock.calls[0][0];
+    expect(uploadArgs.userId).toBe('user-123');
+    expect(uploadArgs.documentId).toBe('doc-1');
+    expect(uploadArgs.filename).toBe('Policy.pdf');
+    expect(uploadArgs.body.equals(Buffer.from('fake'))).toBe(true);
+
+    expect(capturedMetadata[0].storage).toEqual(
+      expect.objectContaining({ provider: 's3', bucket: 'test-bucket', key: expect.any(String) })
+    );
+
+    const parsed = JSON.parse(response.body);
+    expect(parsed.storageLocation).toEqual(
+      expect.objectContaining({ bucket: 'test-bucket', key: expect.stringContaining('rag-documents/user') })
+    );
+    expect(parsed.document.metadata.storage).toEqual(
+      expect.objectContaining({ provider: 's3', url: expect.stringContaining('https://test-bucket.s3.amazonaws.com') })
+    );
+  });
+
+  test('surfaces helpful message when S3 denies access', async () => {
+    uploadDocumentToS3Mock.mockRejectedValueOnce(
+      Object.assign(new Error('Access Denied'), {
+        name: 'AccessDenied',
+        $metadata: { httpStatusCode: 403 },
+      })
+    );
+
+    const sqlMock = jest.fn(async (strings) => {
+      const query = strings.join(' ');
+      if (query.includes('SELECT enumlabel')) {
+        return [];
+      }
+      return [];
+    });
+
+    const payload = {
+      document: {
+        documentId: 'doc-1',
+        filename: 'Policy.pdf',
+        text: 'Document body',
+        type: 'application/pdf',
+        content: Buffer.from('fake').toString('base64'),
+        encoding: 'base64',
+      },
+    };
+
+    await expect(handleUpload(sqlMock, 'user-123', payload)).rejects.toMatchObject({
+      message: expect.stringContaining('Access denied when uploading document to S3'),
+      statusCode: 403,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- allow Netlify S3 uploads to respect a configurable key prefix, set the content length on PutObject, and expose helpers for tests
- harden the Neon upload handler to catch S3 failures, surface an actionable 403 for access-denied responses, and preserve prior metadata behavior
- expand the Jest suite with coverage for the new prefix logic, the S3 access-denied path, and environment cleanup

## Testing
- CI=1 npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d99e80e454832a9dcf505be5e418c4