### PR TITLE
Trim S3 credentials before signing requests

### DIFF
--- a/netlify/lib/s3-helper.test.js
+++ b/netlify/lib/s3-helper.test.js
@@ -140,5 +140,38 @@ describe('S3 credential normalization', () => {
     expect(requestOptions.headers.Authorization).not.toContain('Credential=AKIAEXAMPLE   /');
     expect(requestOptions.headers.Authorization).toBe(requestOptions.headers.Authorization.trim());
   });
+
+  test('propagates trimmed credentials in headers and error payloads on failure', async () => {
+    const responseBody = 'InvalidToken: session-token   ';
+    const textMock = jest.fn().mockResolvedValue(responseBody);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: textMock,
+      headers: { get: () => null },
+    });
+
+    const module = await import('./s3-helper.js');
+
+    await expect(
+      module.uploadDocumentToS3({
+        body: Buffer.from('payload'),
+        contentType: 'application/octet-stream',
+        userId: 'user',
+        documentId: 'doc',
+        filename: 'file.txt',
+      })
+    ).rejects.toMatchObject({
+      statusCode: 403,
+      responseBody: 'InvalidToken: session-token',
+    });
+
+    expect(textMock).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [, requestOptions] = global.fetch.mock.calls[0];
+    expect(requestOptions.headers['x-amz-security-token']).toBe('session-token');
+    expect(requestOptions.headers.Authorization).toMatch(/^AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE\//);
+    expect(requestOptions.headers.Authorization).not.toContain('Credential=AKIAEXAMPLE   /');
+  });
 });
 


### PR DESCRIPTION
## Summary
- trim S3 access key, secret, and session token environment variables before returning them from the helper
- ensure the signing routine reuses the sanitized credentials and trims response payloads on failed uploads
- extend the S3 helper tests to cover trimmed credentials in both success and failure paths

## Testing
- CI=true npm test -- s3-helper --watch=false *(fails: CRA test matcher excludes netlify directory)*
- NODE_OPTIONS=--experimental-vm-modules npx jest netlify/lib/s3-helper.test.js --runInBand *(fails: Jest CLI not configured for ESM imports in this project)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe8deb984832a804de8f75de5cfe3