### PR TITLE
Fix duplicate helper declarations in S3 helper

### DIFF
--- a/netlify/lib/s3-helper.js
+++ b/netlify/lib/s3-helper.js
@@ -143,30 +143,6 @@ const buildCredentialCandidate = ({ accessKeyId, secretAccessKey, sessionToken }
 
 };
 
-const trimCredentialValue = (value) => {
-  if (value == null) {
-    return null;
-  }
-
-  const trimmed = String(value).trim();
-  return trimmed ? trimmed : null;
-};
-
-const buildCredentialCandidate = ({ accessKeyId, secretAccessKey, sessionToken }) => {
-  const sanitizedAccessKeyId = trimCredentialValue(accessKeyId);
-  const sanitizedSecretAccessKey = trimCredentialValue(secretAccessKey);
-
-  if (!sanitizedAccessKeyId || !sanitizedSecretAccessKey) {
-    return null;
-  }
-
-  return {
-    accessKeyId: sanitizedAccessKeyId,
-    secretAccessKey: sanitizedSecretAccessKey,
-    sessionToken: trimCredentialValue(sessionToken),
-  };
-};
-
 const readCredentialCandidate = ({
   label,
   accessKeyEnv,


### PR DESCRIPTION
## Summary
- remove the duplicated trimCredentialValue and buildCredentialCandidate helpers in the Netlify S3 helper to prevent redeclaration errors during the build

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc5d28dc7c832a922ea38a3f9e63a0