### PR TITLE
Enable Neon document downloads

### DIFF
--- a/src/components/ResourcesView.js
+++ b/src/components/ResourcesView.js
@@ -712,7 +712,9 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate, 
       if (viewerRequestRef.current !== requestId) return;
       if (!response) throw new Error('No response received from download request');
 
-      const responseUrl = typeof response.downloadUrl === 'string' ? response.downloadUrl.trim() : '';
+      const responseUrl = [response.downloadUrl, response.url, response.blobUrl]
+        .map(value => (typeof value === 'string' ? value.trim() : ''))
+        .find(candidate => !!candidate) || '';
 
       if (responseUrl) {
         setViewerState({
@@ -751,6 +753,16 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate, 
 
       // Fallback: backend returned base64 content; build a blob URL
       const base64Content = typeof response.content === 'string' ? response.content.trim() : '';
+      const encoding = typeof response.encoding === 'string' ? response.encoding.trim().toLowerCase() : 'base64';
+
+      if (!base64Content) {
+        throw new Error('Document content payload is empty.');
+      }
+
+      if (encoding && encoding !== 'base64') {
+        throw new Error(`Unsupported document encoding: ${encoding}`);
+      }
+
       const byteArray = await decodeBase64ToUint8Array(base64Content);
       if (!byteArray) throw new Error('Unable to decode document content');
 

--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -1068,10 +1068,6 @@ class RAGService {
   }
 
   async downloadDocument(documentReference, userId) {
-    if (this.isNeonBackend()) {
-      throw new Error('Document downloads are not supported when using the Neon backend');
-    }
-
     const reference =
       typeof documentReference === 'string'
         ? { documentId: documentReference }

--- a/src/services/ragService.test.js
+++ b/src/services/ragService.test.js
@@ -118,6 +118,24 @@ describe('ragService neon backend integration', () => {
     );
   });
 
+  test('downloadDocument delegates to document metadata endpoint for Neon backend', async () => {
+    const { ragService, makeNeonRequestSpy } = await setupNeonRagService();
+
+    const metadataSpy = jest
+      .spyOn(ragService, 'makeDocumentMetadataRequest')
+      .mockResolvedValue({ downloadUrl: 'https://example.com/doc.pdf', filename: 'doc.pdf' });
+
+    const result = await ragService.downloadDocument({ documentId: 'doc-42' }, 'user-9');
+
+    expect(metadataSpy).toHaveBeenCalledWith(
+      'download_document',
+      'user-9',
+      expect.objectContaining({ documentId: 'doc-42' })
+    );
+    expect(makeNeonRequestSpy).not.toHaveBeenCalledWith('download_document', expect.anything(), expect.anything());
+    expect(result).toEqual(expect.objectContaining({ downloadUrl: 'https://example.com/doc.pdf' }));
+  });
+
   test('getDocuments returns Neon document list', async () => {
     const neonResponses = {
       list: () => ({


### PR DESCRIPTION
## Summary
- allow Neon document downloads to call the shared document metadata endpoint
- update the resource viewer to recognize additional download URL fields and validate returned encodings
- add test coverage confirming Neon downloads use the metadata endpoint

## Testing
- CI=true npm test -- src/services/ragService.test.js src/components/ResourcesView.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd1bd53830832a9b4ebf86a038e069