### PR TITLE
Fix Netlify blob path encoding

### DIFF
--- a/src/components/ResourcesView.js
+++ b/src/components/ResourcesView.js
@@ -344,14 +344,34 @@ export const buildNetlifyBlobDownloadUrl = (storageLocation = {}) => {
     if (typeof input !== 'string') {
       return '';
     }
+
     const trimmed = input.trim().replace(/^\/+/, '');
     if (!trimmed) {
       return '';
     }
+
     return trimmed
       .split('/')
       .filter(Boolean)
-      .map(segment => encodeURIComponent(segment))
+      .map((segment) => {
+        const safeSegment = segment.trim();
+        if (!safeSegment) {
+          return '';
+        }
+
+        let decodedSegment = safeSegment;
+        try {
+          decodedSegment = decodeURIComponent(safeSegment);
+        } catch (decodeError) {
+          // If the segment is not a valid encoded URI component we fall back to the raw value.
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn('Unable to decode Netlify Blob path segment:', decodeError);
+          }
+        }
+
+        return encodeURIComponent(decodedSegment);
+      })
+      .filter(Boolean)
       .join('/');
   };
 

--- a/src/components/ResourcesView.test.js
+++ b/src/components/ResourcesView.test.js
@@ -495,6 +495,16 @@ describe('buildNetlifyBlobDownloadUrl', () => {
     expect(url).toBe('/.netlify/blobs/blob/rag-documents/rag-documents/user/file.pdf');
   });
 
+  it('avoids double encoding already escaped path segments', () => {
+    const url = buildNetlifyBlobDownloadUrl({ path: 'rag-documents/user/My%20File%20(1).pdf' });
+    expect(url).toBe('/.netlify/blobs/blob/rag-documents/user/My%20File%20(1).pdf');
+  });
+
+  it('preserves encoded forward slashes within segments', () => {
+    const url = buildNetlifyBlobDownloadUrl({ key: 'rag-documents/user/some%2Fnested%2Fname.txt' });
+    expect(url).toBe('/.netlify/blobs/blob/rag-documents/user/some%2Fnested%2Fname.txt');
+  });
+
   it('returns empty string when metadata is incomplete', () => {
     expect(buildNetlifyBlobDownloadUrl()).toBe('');
     expect(buildNetlifyBlobDownloadUrl({})).toBe('');


### PR DESCRIPTION
## Summary
- prevent double-encoding of Netlify blob path segments when building download URLs
- add tests covering escaped path segments and encoded forward slashes in blob keys

## Testing
- npm test -- --runTestsByPath src/components/ResourcesView.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd4f6cb6fc832aaef5d3318d3eeb95