### PR TITLE
Add admin blob browser and backend listing API

### DIFF
--- a/netlify/functions/admin-blob-list.js
+++ b/netlify/functions/admin-blob-list.js
@@ -1,0 +1,143 @@
+import { listBlobFiles } from '../lib/blob-helper.js';
+
+const headers = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-user-id, x-user-roles, x-user-organization',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Content-Type': 'application/json',
+};
+
+const ADMIN_ROLE_KEYWORDS = new Set(['admin', 'administrator', 'superadmin', 'system_admin', 'global_admin']);
+
+const getHeaderValue = (headersMap, key) => {
+  if (!headersMap) return null;
+  const direct = headersMap[key];
+  if (direct) return direct;
+  const lowerKey = key.toLowerCase();
+  if (headersMap[lowerKey]) return headersMap[lowerKey];
+  const upperKey = key.toUpperCase();
+  if (headersMap[upperKey]) return headersMap[upperKey];
+  return null;
+};
+
+const parseRoles = (rawValue) => {
+  if (!rawValue || typeof rawValue !== 'string') {
+    return [];
+  }
+
+  return rawValue
+    .split(/[;,]/)
+    .map((role) => role.split(/\s+/))
+    .flat()
+    .map((role) => (typeof role === 'string' ? role.trim().toLowerCase() : ''))
+    .filter(Boolean);
+};
+
+const extractUserRoles = (event, context) => {
+  const headerRoles =
+    getHeaderValue(event.headers, 'x-user-roles') ||
+    getHeaderValue(event.headers, 'x-user-role') ||
+    getHeaderValue(event.headers, 'x_roles');
+
+  let roles = parseRoles(headerRoles);
+
+  if (roles.length === 0) {
+    const metadataRoles = context?.clientContext?.user?.app_metadata?.roles;
+    if (Array.isArray(metadataRoles)) {
+      roles = metadataRoles
+        .map((role) => (typeof role === 'string' ? role.trim().toLowerCase() : ''))
+        .filter(Boolean);
+    }
+  }
+
+  if (roles.length === 0) {
+    const directRoles = context?.clientContext?.user?.roles;
+    if (Array.isArray(directRoles)) {
+      roles = directRoles
+        .map((role) => (typeof role === 'string' ? role.trim().toLowerCase() : ''))
+        .filter(Boolean);
+    }
+  }
+
+  return Array.from(new Set(roles));
+};
+
+const extractUserId = (event, context) => {
+  const headerUserId =
+    getHeaderValue(event.headers, 'x-user-id') ||
+    getHeaderValue(event.headers, 'x-userid') ||
+    getHeaderValue(event.headers, 'x_user_id');
+
+  if (headerUserId) {
+    return headerUserId;
+  }
+
+  const contextUser = context?.clientContext?.user?.sub;
+  if (contextUser) {
+    return contextUser;
+  }
+
+  return null;
+};
+
+const rolesIncludeAdmin = (roles = []) =>
+  roles.some((role) => ADMIN_ROLE_KEYWORDS.has((role || '').trim().toLowerCase()));
+
+export const handler = async (event, context) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({ ok: true }),
+    };
+  }
+
+  if (event.httpMethod !== 'GET') {
+    return {
+      statusCode: 405,
+      headers,
+      body: JSON.stringify({ error: 'Method not allowed' }),
+    };
+  }
+
+  try {
+    const roles = extractUserRoles(event, context);
+    if (!rolesIncludeAdmin(roles)) {
+      return {
+        statusCode: 403,
+        headers,
+        body: JSON.stringify({ error: 'Administrator privileges required' }),
+      };
+    }
+
+    const userId = extractUserId(event, context);
+    const query = event.queryStringParameters || {};
+    const limitParam = Number(query.limit);
+    const prefixParam = typeof query.prefix === 'string' ? query.prefix : '';
+
+    const result = await listBlobFiles({
+      prefix: prefixParam,
+      limit: Number.isFinite(limitParam) && limitParam > 0 ? Math.floor(limitParam) : undefined,
+    });
+
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({
+        ...result,
+        requestedBy: userId || null,
+        roles,
+      }),
+    };
+  } catch (error) {
+    console.error('Failed to list Netlify blob files:', error);
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({
+        error: 'Failed to list Netlify blob files',
+        message: error.message,
+      }),
+    };
+  }
+};

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -1,5 +1,5 @@
 // src/components/AdminScreen.js - Comprehensive Admin Dashboard
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { 
   ArrowLeft, 
   Users, 
@@ -16,7 +16,6 @@ import {
   Trash2,
   RefreshCw,
   Eye,
-  Server,
   Cloud,
   HardDrive,
   Zap,
@@ -36,6 +35,7 @@ import TrainingResourcesAdmin from './TrainingResourcesAdmin';
 import { getCurrentModel } from '../config/modelConfig';
 import { getTokenUsageStats } from '../utils/tokenUsage';
 import { getRagBackendLabel, isNeonBackend } from '../config/ragConfig';
+import blobAdminService from '../services/blobAdminService';
 
 export const checkStorageHealth = async () => {
   // Check browser storage capacity
@@ -65,6 +65,54 @@ export const checkStorageHealth = async () => {
   }
 };
 
+const formatBytes = (bytes) => {
+  if (bytes === 0) {
+    return '0 B';
+  }
+
+  if (!Number.isFinite(bytes) || bytes == null || bytes < 0) {
+    return '—';
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, exponent);
+  const decimals = value >= 10 || exponent === 0 ? 0 : 1;
+  return `${value.toFixed(decimals)} ${units[exponent]}`;
+};
+
+const formatDateTime = (value) => {
+  if (!value) {
+    return '—';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+};
+
+const formatMetadataValue = (value) => {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+
+  if (typeof value === 'object') {
+    try {
+      const stringified = JSON.stringify(value);
+      return stringified.length > 60 ? `${stringified.slice(0, 57)}…` : stringified;
+    } catch (error) {
+      console.warn('Failed to stringify metadata value for preview:', error);
+      return '[object]';
+    }
+  }
+
+  const text = String(value);
+  return text.length > 60 ? `${text.slice(0, 57)}…` : text;
+};
+
 const AdminScreen = ({ user, onBack }) => {
   const [activeTab, setActiveTab] = useState('overview');
   const [isLoading, setIsLoading] = useState(false);
@@ -75,18 +123,47 @@ const AdminScreen = ({ user, onBack }) => {
   const [error, setError] = useState(null);
   const [chatModel] = useState(getCurrentModel());
   const [tokenUsage, setTokenUsage] = useState({ daily: [], monthly: [] });
+  const [blobFiles, setBlobFiles] = useState([]);
+  const [blobMetadata, setBlobMetadata] = useState({ store: '', prefix: '', timestamp: null, total: null, truncated: false });
+  const [blobError, setBlobError] = useState(null);
+  const [isBlobLoading, setIsBlobLoading] = useState(false);
+  const [hasLoadedBlobInventory, setHasLoadedBlobInventory] = useState(false);
+  const [blobPrefixInput, setBlobPrefixInput] = useState('');
+  const [appliedBlobPrefix, setAppliedBlobPrefix] = useState('');
+  const [blobSearchTerm, setBlobSearchTerm] = useState('');
+  const [blobSort, setBlobSort] = useState('newest');
   const ragBackendLabel = getRagBackendLabel();
   const neonBackendEnabled = isNeonBackend();
 
   // Check if user has admin role
   const isAdmin = hasAdminRole(user);
 
-  // Load admin data on component mount
-  useEffect(() => {
-    if (isAdmin) {
-      loadAdminData();
+  const renderMetadataPreview = useCallback((metadata) => {
+    if (!metadata || typeof metadata !== 'object' || Object.keys(metadata).length === 0) {
+      return <span className="text-gray-400">No metadata</span>;
     }
-  }, [isAdmin]);
+
+    const entries = Object.entries(metadata);
+    const visibleEntries = entries.slice(0, 4);
+
+    return (
+      <div className="flex flex-wrap gap-1">
+        {visibleEntries.map(([key, value]) => (
+          <span
+            key={key}
+            className="px-2 py-0.5 bg-gray-100 border border-gray-200 rounded text-gray-700"
+          >
+            <span className="font-medium text-gray-800">{key}</span>: {formatMetadataValue(value)}
+          </span>
+        ))}
+        {entries.length > 4 && (
+          <span className="px-2 py-0.5 bg-gray-50 border border-dashed border-gray-200 rounded text-gray-500">
+            +{entries.length - 4} more
+          </span>
+        )}
+      </div>
+    );
+  }, []);
 
   const loadAdminData = useCallback(async () => {
     setIsLoading(true);
@@ -167,7 +244,7 @@ const AdminScreen = ({ user, onBack }) => {
     try {
       const tokenInfo = getTokenInfo();
       const token = await getToken();
-      
+
       return {
         tokenInfo,
         hasValidToken: !!token,
@@ -183,6 +260,84 @@ const AdminScreen = ({ user, onBack }) => {
       };
     }
   };
+
+  const loadBlobInventory = useCallback(
+    async (overridePrefix) => {
+      if (!isAdmin) {
+        return;
+      }
+
+      const sanitizedOverride =
+        typeof overridePrefix === 'string'
+          ? overridePrefix.trim().replace(/^\/+|\/+$/g, '')
+          : null;
+
+      const prefixToUse = sanitizedOverride !== null ? sanitizedOverride : appliedBlobPrefix;
+
+      if (sanitizedOverride !== null && sanitizedOverride !== appliedBlobPrefix) {
+        setAppliedBlobPrefix(sanitizedOverride);
+      }
+
+      setBlobError(null);
+      setIsBlobLoading(true);
+
+      try {
+        const response = await blobAdminService.listBlobs({
+          user,
+          prefix: prefixToUse || undefined,
+        });
+
+        const normalized = Array.isArray(response?.blobs)
+          ? response.blobs.map((blob) => ({
+              key: blob.key,
+              relativeKey: blob.relativeKey || blob.key,
+              userId: blob.userId || null,
+              documentId: blob.documentId || null,
+              filename: blob.filename || null,
+              size:
+                typeof blob.size === 'number' && Number.isFinite(blob.size)
+                  ? Number(blob.size)
+                  : null,
+              contentType: typeof blob.contentType === 'string' ? blob.contentType : null,
+              uploadedAt: typeof blob.uploadedAt === 'string' ? blob.uploadedAt : null,
+              etag: blob.etag || null,
+              metadata:
+                blob.metadata && typeof blob.metadata === 'object' ? blob.metadata : {},
+              segments: Array.isArray(blob.segments) ? blob.segments : [],
+            }))
+          : [];
+
+        setBlobFiles(normalized);
+        setBlobMetadata({
+          store: response?.store || '',
+          prefix: response?.prefix || prefixToUse || '',
+          timestamp: response?.timestamp || new Date().toISOString(),
+          total: typeof response?.total === 'number' ? response.total : normalized.length,
+          truncated: Boolean(response?.truncated),
+        });
+        setHasLoadedBlobInventory(true);
+      } catch (inventoryError) {
+        console.error('Failed to load Netlify blobs:', inventoryError);
+        setBlobError(inventoryError.message || 'Failed to load Netlify blob inventory.');
+        setHasLoadedBlobInventory(false);
+      } finally {
+        setIsBlobLoading(false);
+      }
+    },
+    [appliedBlobPrefix, isAdmin, user]
+  );
+
+  useEffect(() => {
+    if (isAdmin) {
+      loadAdminData();
+    }
+  }, [isAdmin, loadAdminData]);
+
+  useEffect(() => {
+    if (activeTab === 'blobStorage' && isAdmin && !hasLoadedBlobInventory && !isBlobLoading) {
+      loadBlobInventory();
+    }
+  }, [activeTab, hasLoadedBlobInventory, isAdmin, isBlobLoading, loadBlobInventory]);
 
   // System health check
   const getSystemHealth = async () => {
@@ -275,6 +430,9 @@ const AdminScreen = ({ user, onBack }) => {
   // Refresh data
   const handleRefresh = () => {
     loadAdminData();
+    if (activeTab === 'blobStorage') {
+      loadBlobInventory();
+    }
   };
 
   // Export system data
@@ -303,6 +461,24 @@ const AdminScreen = ({ user, onBack }) => {
     }
   };
 
+  const handleBlobPrefixSubmit = useCallback(
+    (event) => {
+      event.preventDefault();
+      const sanitized = blobPrefixInput.trim().replace(/^\/+|\/+$/g, '');
+      setBlobPrefixInput(sanitized);
+      loadBlobInventory(sanitized);
+    },
+    [blobPrefixInput, loadBlobInventory]
+  );
+
+  const handleBlobPrefixReset = useCallback(() => {
+    if (!blobPrefixInput && !appliedBlobPrefix) {
+      return;
+    }
+    setBlobPrefixInput('');
+    loadBlobInventory('');
+  }, [appliedBlobPrefix, blobPrefixInput, loadBlobInventory]);
+
   // Test system components
   const runSystemTests = async () => {
     setIsLoading(true);
@@ -327,6 +503,122 @@ const AdminScreen = ({ user, onBack }) => {
       setIsLoading(false);
     }
   };
+
+  const filteredBlobFiles = useMemo(() => {
+    const search = blobSearchTerm.trim().toLowerCase();
+    const files = Array.isArray(blobFiles) ? [...blobFiles] : [];
+
+    const getTime = (value) => {
+      if (!value) return 0;
+      const timestamp = new Date(value).getTime();
+      return Number.isNaN(timestamp) ? 0 : timestamp;
+    };
+
+    const sizeForLargest = (value) =>
+      Number.isFinite(value) && value >= 0 ? value : -1;
+
+    const sizeForSmallest = (value) =>
+      Number.isFinite(value) && value >= 0 ? value : Number.MAX_SAFE_INTEGER;
+
+    let result = files;
+
+    if (search) {
+      result = result.filter((file) => {
+        const searchTargets = [
+          file.key,
+          file.relativeKey,
+          file.userId,
+          file.documentId,
+          file.filename,
+          file.contentType,
+          file.etag,
+        ]
+          .filter(Boolean)
+          .map((value) => String(value).toLowerCase());
+
+        if (searchTargets.some((value) => value.includes(search))) {
+          return true;
+        }
+
+        if (file.metadata && typeof file.metadata === 'object') {
+          return Object.entries(file.metadata).some(([key, value]) => {
+            if (String(key).toLowerCase().includes(search)) {
+              return true;
+            }
+
+            if (value === null || value === undefined) {
+              return false;
+            }
+
+            const text = typeof value === 'object' ? JSON.stringify(value) : String(value);
+            return text.toLowerCase().includes(search);
+          });
+        }
+
+        return false;
+      });
+    }
+
+    const sorted = [...result];
+    sorted.sort((a, b) => {
+      switch (blobSort) {
+        case 'oldest':
+          return getTime(a.uploadedAt) - getTime(b.uploadedAt);
+        case 'largest':
+          return sizeForLargest(b.size) - sizeForLargest(a.size);
+        case 'smallest':
+          return sizeForSmallest(a.size) - sizeForSmallest(b.size);
+        case 'alphabetical':
+          return (a.relativeKey || a.key || '').localeCompare(
+            b.relativeKey || b.key || '',
+            undefined,
+            { sensitivity: 'base' }
+          );
+        case 'newest':
+        default:
+          return getTime(b.uploadedAt) - getTime(a.uploadedAt);
+      }
+    });
+
+    return sorted;
+  }, [blobFiles, blobSearchTerm, blobSort]);
+
+  const totalBlobSize = useMemo(
+    () =>
+      blobFiles.reduce(
+        (sum, file) =>
+          Number.isFinite(file?.size) && file.size >= 0 ? sum + Number(file.size) : sum,
+        0
+      ),
+    [blobFiles]
+  );
+
+  const uniqueBlobUsers = useMemo(() => {
+    const ids = new Set();
+    blobFiles.forEach((file) => {
+      if (file?.userId) {
+        ids.add(file.userId);
+      }
+    });
+    return ids.size;
+  }, [blobFiles]);
+
+  const uniqueBlobDocuments = useMemo(() => {
+    const ids = new Set();
+    blobFiles.forEach((file) => {
+      if (file?.documentId) {
+        ids.add(file.documentId);
+      }
+    });
+    return ids.size;
+  }, [blobFiles]);
+
+  const displayedBlobCount = filteredBlobFiles.length;
+  const blobStoreName = blobMetadata?.store || 'rag-documents';
+  const blobPrefixDisplay = blobMetadata?.prefix || (appliedBlobPrefix || '');
+  const blobLastUpdated = blobMetadata?.timestamp;
+  const blobTotalCount = typeof blobMetadata?.total === 'number' ? blobMetadata.total : blobFiles.length;
+  const blobInventoryTruncated = Boolean(blobMetadata?.truncated);
 
   // Don't render if user is not admin
   if (!isAdmin) {
@@ -430,6 +722,7 @@ const AdminScreen = ({ user, onBack }) => {
               { id: 'users', label: 'Users & Auth', icon: Users },
               { id: 'backend', label: 'Backend', icon: Database },
               { id: 'rag', label: 'RAG System', icon: FileText },
+              { id: 'blobStorage', label: 'Netlify Blobs', icon: Cloud },
               { id: 'ragConfig', label: 'My Resources', icon: Search },
               { id: 'system', label: 'System Health', icon: Activity },
               { id: 'usage', label: 'Token Usage', icon: BarChart3 },
@@ -720,6 +1013,213 @@ const AdminScreen = ({ user, onBack }) => {
           {activeTab === 'ragConfig' && (
             <div className="space-y-6">
               <RAGConfigurationPage user={user} onClose={() => setActiveTab('overview')} />
+            </div>
+          )}
+
+          {/* Netlify Blob Storage Tab */}
+          {activeTab === 'blobStorage' && (
+            <div className="space-y-6">
+              <div className="bg-white rounded-lg shadow p-6">
+                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-900 flex items-center">
+                      <Cloud className="h-5 w-5 text-blue-600 mr-2" />
+                      Netlify Blob Storage
+                    </h3>
+                    <p className="text-sm text-gray-600">
+                      Store <span className="font-medium text-gray-900">{blobStoreName}</span>
+                      {blobPrefixDisplay && (
+                        <>
+                          {' '}• Prefix{' '}
+                          <code className="text-xs bg-gray-100 border border-gray-200 px-1 py-0.5 rounded">
+                            {blobPrefixDisplay}
+                          </code>
+                        </>
+                      )}
+                    </p>
+                    <p className="text-xs text-gray-500 mt-1">
+                      Last refreshed {formatDateTime(blobLastUpdated)} • Showing {displayedBlobCount}
+                      {blobTotalCount != null && ` of ${blobTotalCount}`} files
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => loadBlobInventory(appliedBlobPrefix)}
+                      disabled={isBlobLoading}
+                      className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      <RefreshCw className={`h-4 w-4 ${isBlobLoading ? 'animate-spin' : ''}`} />
+                      <span>Refresh</span>
+                    </button>
+                  </div>
+                </div>
+
+                {blobError && (
+                  <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-4">
+                    <div className="flex items-start space-x-3">
+                      <AlertTriangle className="h-5 w-5 text-red-500 flex-shrink-0 mt-0.5" />
+                      <div>
+                        <h4 className="font-medium text-red-800">Unable to load Netlify blobs</h4>
+                        <p className="text-sm text-red-700 mt-1">{blobError}</p>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                <form
+                  onSubmit={handleBlobPrefixSubmit}
+                  className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6"
+                >
+                  <div className="md:col-span-2">
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Prefix filter
+                    </label>
+                    <div className="flex gap-2">
+                      <input
+                        type="text"
+                        value={blobPrefixInput}
+                        onChange={(event) => setBlobPrefixInput(event.target.value)}
+                        placeholder="rag-documents/user-id"
+                        className="flex-1 rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      />
+                      <button
+                        type="submit"
+                        className="px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                      >
+                        Apply
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleBlobPrefixReset}
+                        className="px-3 py-2 bg-gray-100 text-gray-700 rounded hover:bg-gray-200"
+                        disabled={!blobPrefixInput && !appliedBlobPrefix}
+                      >
+                        Reset
+                      </button>
+                    </div>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Search
+                    </label>
+                    <input
+                      type="text"
+                      value={blobSearchTerm}
+                      onChange={(event) => setBlobSearchTerm(event.target.value)}
+                      placeholder="Filter by key, user, metadata..."
+                      className="w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    />
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Sort by
+                    </label>
+                    <select
+                      value={blobSort}
+                      onChange={(event) => setBlobSort(event.target.value)}
+                      className="w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    >
+                      <option value="newest">Newest first</option>
+                      <option value="oldest">Oldest first</option>
+                      <option value="largest">Largest size</option>
+                      <option value="smallest">Smallest size</option>
+                      <option value="alphabetical">Alphabetical</option>
+                    </select>
+                  </div>
+                </form>
+
+                <div className="flex flex-wrap gap-4 text-sm text-gray-600 mb-4">
+                  <span>
+                    <span className="font-semibold text-gray-900">{blobFiles.length}</span> files loaded
+                  </span>
+                  <span>
+                    <span className="font-semibold text-gray-900">{formatBytes(totalBlobSize)}</span> total size
+                  </span>
+                  <span>
+                    <span className="font-semibold text-gray-900">{uniqueBlobUsers}</span> unique users
+                  </span>
+                  <span>
+                    <span className="font-semibold text-gray-900">{uniqueBlobDocuments}</span> unique documents
+                  </span>
+                  {blobInventoryTruncated && (
+                    <span className="text-yellow-600">
+                      Displaying first {displayedBlobCount} entries. Narrow the prefix to load more.
+                    </span>
+                  )}
+                </div>
+
+                <div className="border border-gray-200 rounded-lg overflow-hidden">
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full divide-y divide-gray-200 text-sm">
+                      <thead className="bg-gray-50">
+                        <tr>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-600">Blob Key</th>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-600">Size</th>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-600">Content Type</th>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-600">Uploaded</th>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-600">Metadata</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {isBlobLoading && filteredBlobFiles.length === 0 ? (
+                          <tr>
+                            <td colSpan={5} className="px-4 py-8 text-center text-gray-500">
+                              <RefreshCw className="h-5 w-5 inline-block animate-spin mr-2" />
+                              Loading Netlify blob inventory…
+                            </td>
+                          </tr>
+                        ) : filteredBlobFiles.length === 0 ? (
+                          <tr>
+                            <td colSpan={5} className="px-4 py-8 text-center text-gray-500">
+                              No blob files found for the selected filters.
+                            </td>
+                          </tr>
+                        ) : (
+                          filteredBlobFiles.map((file) => (
+                            <tr key={file.key} className="hover:bg-gray-50">
+                              <td className="px-4 py-3 align-top">
+                                <div className="font-medium text-gray-900 break-all">
+                                  {file.relativeKey || file.key}
+                                </div>
+                                <div className="mt-1 flex flex-wrap gap-2 text-xs text-gray-500">
+                                  {file.userId && (
+                                    <span className="px-2 py-0.5 bg-gray-100 border border-gray-200 rounded">
+                                      User: {file.userId}
+                                    </span>
+                                  )}
+                                  {file.documentId && (
+                                    <span className="px-2 py-0.5 bg-gray-100 border border-gray-200 rounded">
+                                      Doc: {file.documentId}
+                                    </span>
+                                  )}
+                                  {file.filename && (
+                                    <span className="px-2 py-0.5 bg-gray-100 border border-gray-200 rounded">
+                                      File: {file.filename}
+                                    </span>
+                                  )}
+                                  {file.etag && (
+                                    <span className="px-2 py-0.5 bg-gray-100 border border-gray-200 rounded">
+                                      ETag: {file.etag.slice(0, 10)}{file.etag.length > 10 ? '…' : ''}
+                                    </span>
+                                  )}
+                                </div>
+                              </td>
+                              <td className="px-4 py-3 align-top text-gray-900">{formatBytes(file.size)}</td>
+                              <td className="px-4 py-3 align-top text-gray-600">{file.contentType || '—'}</td>
+                              <td className="px-4 py-3 align-top text-gray-600">{formatDateTime(file.uploadedAt)}</td>
+                              <td className="px-4 py-3 align-top text-xs text-gray-600">
+                                {renderMetadataPreview(file.metadata)}
+                              </td>
+                            </tr>
+                          ))
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
             </div>
           )}
 

--- a/src/services/blobAdminService.js
+++ b/src/services/blobAdminService.js
@@ -1,0 +1,100 @@
+// src/services/blobAdminService.js - Admin-facing helper for Netlify Blob inventory
+import authService from './authService';
+
+const ADMIN_BLOB_FUNCTION =
+  process.env.REACT_APP_ADMIN_BLOB_FUNCTION || '/.netlify/functions/admin-blob-list';
+
+const sanitizeQueryParam = (value) => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value).trim();
+};
+
+const buildQueryString = (params = {}) => {
+  const entries = Object.entries(params).filter(([, value]) => value !== undefined && value !== null && value !== '');
+  if (entries.length === 0) {
+    return '';
+  }
+
+  const searchParams = new URLSearchParams();
+  entries.forEach(([key, value]) => {
+    searchParams.set(key, String(value));
+  });
+  return `?${searchParams.toString()}`;
+};
+
+const normalizeRoles = (roles = []) =>
+  Array.isArray(roles)
+    ? roles
+        .map((role) => (typeof role === 'string' ? role.trim() : ''))
+        .filter(Boolean)
+    : [];
+
+async function listBlobs({ user, prefix, limit } = {}) {
+  const currentUser = user || (await authService.getUser());
+  const userId = currentUser?.sub || (await authService.getUserId());
+
+  if (!userId) {
+    throw new Error('Administrator authentication is required to list Netlify blobs.');
+  }
+
+  let token;
+  try {
+    token = await authService.getToken();
+  } catch (error) {
+    throw new Error(`Authentication failed: ${error.message}`);
+  }
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    'x-user-id': userId,
+  };
+
+  const roles = normalizeRoles(currentUser?.roles);
+  if (roles.length > 0) {
+    headers['x-user-roles'] = roles.join(',');
+  }
+
+  if (typeof currentUser?.organization === 'string' && currentUser.organization.trim()) {
+    headers['x-user-organization'] = currentUser.organization.trim();
+  }
+
+  const numericLimit = Number(limit);
+  const queryString = buildQueryString({
+    prefix: sanitizeQueryParam(prefix),
+    limit: Number.isFinite(numericLimit) && numericLimit > 0 ? Math.floor(numericLimit) : undefined,
+  });
+
+  const endpoint = ADMIN_BLOB_FUNCTION;
+  let response;
+  try {
+    response = await fetch(`${endpoint}${queryString}`, {
+      method: 'GET',
+      headers,
+    });
+  } catch (error) {
+    throw new Error('Unable to reach Netlify blob inventory service.');
+  }
+
+  let data;
+  try {
+    data = await response.json();
+  } catch (error) {
+    throw new Error('Failed to parse Netlify blob inventory response.');
+  }
+
+  if (!response.ok) {
+    const message = typeof data?.error === 'string' ? data.error : data?.message;
+    throw new Error(message || `Request failed with status ${response.status}`);
+  }
+
+  return data;
+}
+
+const blobAdminService = {
+  listBlobs,
+};
+
+export default blobAdminService;


### PR DESCRIPTION
## Summary
- add a Netlify function that restricts blob listings to administrators and normalizes metadata coming from the blob store
- expose a blobAdminService for the React app and surface a Netlify Blobs tab inside the admin dashboard with filtering, sorting, and metadata previews
- extend blob helper utilities with metadata defaults, a listBlobFiles helper, and tests covering the listing behavior

## Testing
- `CI=1 npm test -- --runTestsByPath netlify/lib/blob-helper.test.js` *(fails: no tests found because Jest is configured to only load tests from src/)*

------
https://chatgpt.com/codex/tasks/task_e_68dd729f881c832a9904b09cd78d4756