### PR TITLE
Fix admin blob previews blocked by CSP

### DIFF
--- a/netlify/functions/admin-blob-list.js
+++ b/netlify/functions/admin-blob-list.js
@@ -1,0 +1,171 @@
+import { listBlobFiles, getBlobFile } from '../lib/blob-helper.js';
+
+const headers = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-user-id, x-user-roles, x-user-organization',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Content-Type': 'application/json',
+};
+
+const ADMIN_ROLE_KEYWORDS = new Set(['admin', 'administrator', 'superadmin', 'system_admin', 'global_admin']);
+
+const getHeaderValue = (headersMap, key) => {
+  if (!headersMap) return null;
+  const direct = headersMap[key];
+  if (direct) return direct;
+  const lowerKey = key.toLowerCase();
+  if (headersMap[lowerKey]) return headersMap[lowerKey];
+  const upperKey = key.toUpperCase();
+  if (headersMap[upperKey]) return headersMap[upperKey];
+  return null;
+};
+
+const parseRoles = (rawValue) => {
+  if (!rawValue || typeof rawValue !== 'string') {
+    return [];
+  }
+
+  return rawValue
+    .split(/[;,]/)
+    .map((role) => role.split(/\s+/))
+    .flat()
+    .map((role) => (typeof role === 'string' ? role.trim().toLowerCase() : ''))
+    .filter(Boolean);
+};
+
+const extractUserRoles = (event, context) => {
+  const headerRoles =
+    getHeaderValue(event.headers, 'x-user-roles') ||
+    getHeaderValue(event.headers, 'x-user-role') ||
+    getHeaderValue(event.headers, 'x_roles');
+
+  let roles = parseRoles(headerRoles);
+
+  if (roles.length === 0) {
+    const metadataRoles = context?.clientContext?.user?.app_metadata?.roles;
+    if (Array.isArray(metadataRoles)) {
+      roles = metadataRoles
+        .map((role) => (typeof role === 'string' ? role.trim().toLowerCase() : ''))
+        .filter(Boolean);
+    }
+  }
+
+  if (roles.length === 0) {
+    const directRoles = context?.clientContext?.user?.roles;
+    if (Array.isArray(directRoles)) {
+      roles = directRoles
+        .map((role) => (typeof role === 'string' ? role.trim().toLowerCase() : ''))
+        .filter(Boolean);
+    }
+  }
+
+  return Array.from(new Set(roles));
+};
+
+const extractUserId = (event, context) => {
+  const headerUserId =
+    getHeaderValue(event.headers, 'x-user-id') ||
+    getHeaderValue(event.headers, 'x-userid') ||
+    getHeaderValue(event.headers, 'x_user_id');
+
+  if (headerUserId) {
+    return headerUserId;
+  }
+
+  const contextUser = context?.clientContext?.user?.sub;
+  if (contextUser) {
+    return contextUser;
+  }
+
+  return null;
+};
+
+const rolesIncludeAdmin = (roles = []) =>
+  roles.some((role) => ADMIN_ROLE_KEYWORDS.has((role || '').trim().toLowerCase()));
+
+export const handler = async (event, context) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({ ok: true }),
+    };
+  }
+
+  if (event.httpMethod !== 'GET') {
+    return {
+      statusCode: 405,
+      headers,
+      body: JSON.stringify({ error: 'Method not allowed' }),
+    };
+  }
+
+  try {
+    const roles = extractUserRoles(event, context);
+    if (!rolesIncludeAdmin(roles)) {
+      return {
+        statusCode: 403,
+        headers,
+        body: JSON.stringify({ error: 'Administrator privileges required' }),
+      };
+    }
+
+    const userId = extractUserId(event, context);
+    const query = event.queryStringParameters || {};
+    const limitParam = Number(query.limit);
+    const prefixParam = typeof query.prefix === 'string' ? query.prefix : '';
+    const keyParam = typeof query.key === 'string' ? query.key.trim() : '';
+
+    if (keyParam) {
+      const file = await getBlobFile({ key: keyParam });
+
+      if (!file) {
+        return {
+          statusCode: 404,
+          headers,
+          body: JSON.stringify({
+            error: 'Blob not found',
+            message: `No blob found for key ${keyParam}`,
+            requestedBy: userId || null,
+            roles,
+          }),
+        };
+      }
+
+      return {
+        statusCode: 200,
+        headers,
+        body: JSON.stringify({
+          ...file,
+          requestedBy: userId || null,
+          roles,
+        }),
+      };
+    }
+
+    const result = await listBlobFiles({
+      prefix: prefixParam,
+      limit: Number.isFinite(limitParam) && limitParam > 0 ? Math.floor(limitParam) : undefined,
+    });
+
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({
+        ...result,
+        requestedBy: userId || null,
+        roles,
+      }),
+    };
+  } catch (error) {
+    console.error('Failed to list Netlify blob files:', error);
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({
+        error: 'Failed to list Netlify blob files',
+        message: error.message,
+      }),
+    };
+  }
+};

--- a/netlify/lib/blob-helper.js
+++ b/netlify/lib/blob-helper.js
@@ -248,7 +248,20 @@ export const uploadDocumentToBlobStore = async ({
   const key = buildObjectKey({ userId, documentId, filename });
   const size = normalizedBody.length;
   const resolvedContentType = contentType || 'application/octet-stream';
-  const normalizedMetadata = normalizeMetadata(metadata);
+  const timestamp = new Date().toISOString();
+  const metadataWithDefaults = {
+    ...metadata,
+    'size-bytes': size,
+    size_bytes: size,
+    size,
+    sizeBytes: size,
+    'content-type': resolvedContentType,
+    contentType: resolvedContentType,
+    uploadedAt: timestamp,
+    'uploaded-at': timestamp,
+    uploaded_at: timestamp,
+  };
+  const normalizedMetadata = normalizeMetadata(metadataWithDefaults);
 
   await store.set(key, normalizedBody, {
     contentType: resolvedContentType,
@@ -263,6 +276,314 @@ export const uploadDocumentToBlobStore = async ({
     url: null,
     size,
     contentType: resolvedContentType,
+  };
+};
+
+const decodeMetadataValue = (value) => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  if (trimmed === 'true') {
+    return true;
+  }
+
+  if (trimmed === 'false') {
+    return false;
+  }
+
+  const numeric = Number(trimmed);
+  if (!Number.isNaN(numeric)) {
+    return numeric;
+  }
+
+  if (
+    (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+    (trimmed.startsWith('[') && trimmed.endsWith(']'))
+  ) {
+    try {
+      return JSON.parse(trimmed);
+    } catch (error) {
+      console.warn('Failed to parse blob metadata JSON value:', error);
+    }
+  }
+
+  return trimmed;
+};
+
+const decodeMetadataObject = (metadata) => {
+  if (!metadata || typeof metadata !== 'object') {
+    return {};
+  }
+
+  const decoded = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    decoded[key] = decodeMetadataValue(value);
+  }
+  return decoded;
+};
+
+const firstNonEmptyString = (...values) => {
+  for (const value of values) {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return null;
+};
+
+const firstFiniteNumber = (...values) => {
+  for (const value of values) {
+    const numeric = typeof value === 'number' ? value : Number(value);
+    if (Number.isFinite(numeric)) {
+      return numeric;
+    }
+  }
+  return null;
+};
+
+const firstValidTimestamp = (...values) => {
+  for (const value of values) {
+    if (!value) {
+      continue;
+    }
+
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toISOString();
+    }
+  }
+  return null;
+};
+
+const deriveKeySegments = (key, prefix) => {
+  const normalizedKey = typeof key === 'string' ? key : '';
+  const normalizedPrefix = typeof prefix === 'string' ? prefix.replace(/^\/+|\/+$/g, '') : '';
+
+  let relativeKey = normalizedKey;
+  if (normalizedPrefix && normalizedKey.startsWith(`${normalizedPrefix}/`)) {
+    relativeKey = normalizedKey.slice(normalizedPrefix.length + 1);
+  }
+
+  const segments = relativeKey.split('/').filter(Boolean);
+  const [userId = null, documentId = null, ...rest] = segments;
+  const filename = rest.length > 0 ? rest.join('/') : segments[segments.length - 1] || null;
+
+  return {
+    relativeKey,
+    segments,
+    userId,
+    documentId,
+    filename,
+  };
+};
+
+export const getBlobFile = async ({ key } = {}) => {
+  if (typeof key !== 'string') {
+    throw new Error('A blob key is required to download a file from Netlify Blobs.');
+  }
+
+  const trimmedKey = key.trim();
+  if (!trimmedKey) {
+    throw new Error('A blob key is required to download a file from Netlify Blobs.');
+  }
+
+  const normalizedKey = trimmedKey.replace(/^\/+/, '');
+  const store = getBlobStoreInstance();
+  const storeName = getConfiguredStore();
+  const configuredPrefix = getConfiguredPrefix();
+
+  const result = await store.getWithMetadata(normalizedKey, { type: 'arrayBuffer' });
+  if (!result) {
+    return null;
+  }
+
+  const buffer = Buffer.from(result.data);
+  const decodedMetadata = decodeMetadataObject(result.metadata || {});
+  const storageMetadata =
+    decodedMetadata.storage && typeof decodedMetadata.storage === 'object'
+      ? decodedMetadata.storage
+      : null;
+
+  const derived = deriveKeySegments(normalizedKey, configuredPrefix);
+
+  const size = firstFiniteNumber(
+    decodedMetadata['size-bytes'],
+    decodedMetadata.size_bytes,
+    decodedMetadata.sizeBytes,
+    decodedMetadata.size,
+    decodedMetadata['content-length'],
+    decodedMetadata['x-size-bytes'],
+    storageMetadata?.size,
+    buffer.length
+  );
+
+  const contentType =
+    firstNonEmptyString(
+      decodedMetadata['content-type'],
+      decodedMetadata.contentType,
+      storageMetadata?.contentType
+    ) || 'application/octet-stream';
+
+  const uploadedAt = firstValidTimestamp(
+    decodedMetadata.uploadedAt,
+    decodedMetadata['uploaded-at'],
+    decodedMetadata.uploaded_at,
+    storageMetadata?.uploadedAt,
+    storageMetadata?.uploaded_at
+  );
+
+  const userId = firstNonEmptyString(
+    decodedMetadata['x-user-id'],
+    decodedMetadata.userId,
+    decodedMetadata.user_id,
+    derived.userId
+  );
+
+  const documentId = firstNonEmptyString(
+    decodedMetadata['x-document-id'],
+    decodedMetadata.documentId,
+    decodedMetadata.document_id,
+    derived.documentId
+  );
+
+  const etag = firstNonEmptyString(
+    result.etag,
+    decodedMetadata.etag,
+    decodedMetadata.ETag,
+    decodedMetadata['etag'],
+    decodedMetadata['ETag']
+  );
+
+  return {
+    key: normalizedKey,
+    store: storeName,
+    relativeKey: derived.relativeKey,
+    userId: userId || null,
+    documentId: documentId || null,
+    filename: derived.filename || null,
+    size: Number.isFinite(size) ? size : buffer.length,
+    contentType,
+    uploadedAt,
+    metadata: decodedMetadata,
+    etag: etag || null,
+    data: buffer.toString('base64'),
+    encoding: 'base64',
+  };
+};
+
+export const listBlobFiles = async ({ prefix, limit } = {}) => {
+  const store = getBlobStoreInstance();
+  const storeName = getConfiguredStore();
+
+  const sanitizedPrefix = typeof prefix === 'string'
+    ? sanitizePathPrefix(prefix.replace(/^\/+|\/+$/g, ''))
+    : '';
+
+  const resolvedPrefix = sanitizedPrefix || getConfiguredPrefix();
+  const listOptions = {};
+  if (resolvedPrefix) {
+    listOptions.prefix = `${resolvedPrefix}/`;
+  }
+
+  const listResult = await store.list(listOptions);
+  const blobs = Array.isArray(listResult?.blobs) ? listResult.blobs : [];
+
+  const numericLimit = Number(limit);
+  const maxEntries = Number.isFinite(numericLimit) && numericLimit > 0
+    ? Math.floor(numericLimit)
+    : blobs.length;
+  const limitedBlobs = maxEntries < blobs.length ? blobs.slice(0, maxEntries) : blobs;
+  const metadataResults = await Promise.allSettled(
+    limitedBlobs.map(({ key }) => store.getMetadata(key))
+  );
+
+  const items = limitedBlobs.map((blob, index) => {
+    const metadataEntry = metadataResults[index];
+    const metadata =
+      metadataEntry.status === 'fulfilled' && metadataEntry.value?.metadata
+        ? metadataEntry.value.metadata
+        : {};
+    const decodedMetadata = decodeMetadataObject(metadata);
+    const derived = deriveKeySegments(blob.key, resolvedPrefix);
+    const storageMetadata =
+      decodedMetadata.storage && typeof decodedMetadata.storage === 'object'
+        ? decodedMetadata.storage
+        : null;
+
+    const size = firstFiniteNumber(
+      decodedMetadata['size-bytes'],
+      decodedMetadata.size_bytes,
+      decodedMetadata.sizeBytes,
+      decodedMetadata.size,
+      decodedMetadata['content-length'],
+      decodedMetadata['x-size-bytes'],
+      storageMetadata?.size
+    );
+
+    const contentType = firstNonEmptyString(
+      decodedMetadata['content-type'],
+      decodedMetadata.contentType,
+      storageMetadata?.contentType
+    );
+
+    const uploadedAt = firstValidTimestamp(
+      decodedMetadata.uploadedAt,
+      decodedMetadata['uploaded-at'],
+      decodedMetadata.uploaded_at,
+      storageMetadata?.uploadedAt,
+      storageMetadata?.uploaded_at
+    );
+
+    const userId = firstNonEmptyString(
+      decodedMetadata['x-user-id'],
+      decodedMetadata.userId,
+      decodedMetadata.user_id,
+      derived.userId
+    );
+
+    const documentId = firstNonEmptyString(
+      decodedMetadata['x-document-id'],
+      decodedMetadata.documentId,
+      decodedMetadata.document_id,
+      derived.documentId
+    );
+
+    return {
+      key: blob.key,
+      etag: blob.etag || null,
+      userId: userId || null,
+      documentId: documentId || null,
+      size: Number.isFinite(size) ? size : null,
+      contentType: contentType || null,
+      uploadedAt,
+      metadata: decodedMetadata,
+      relativeKey: derived.relativeKey,
+      segments: derived.segments,
+      filename: derived.filename,
+    };
+  });
+
+  return {
+    store: storeName,
+    prefix: resolvedPrefix,
+    blobs: items,
+    count: items.length,
+    total: blobs.length,
+    truncated: items.length < blobs.length,
+    timestamp: new Date().toISOString(),
   };
 };
 

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -1,5 +1,5 @@
 // src/components/AdminScreen.js - Comprehensive Admin Dashboard
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { 
   ArrowLeft, 
   Users, 
@@ -16,14 +16,14 @@ import {
   Trash2,
   RefreshCw,
   Eye,
-  Server,
   Cloud,
   HardDrive,
   Zap,
   Bug,
   Monitor,
   Search,
-  BookOpen
+  BookOpen,
+  X
 } from 'lucide-react';
 
 // Import services
@@ -36,6 +36,7 @@ import TrainingResourcesAdmin from './TrainingResourcesAdmin';
 import { getCurrentModel } from '../config/modelConfig';
 import { getTokenUsageStats } from '../utils/tokenUsage';
 import { getRagBackendLabel, isNeonBackend } from '../config/ragConfig';
+import blobAdminService from '../services/blobAdminService';
 
 export const checkStorageHealth = async () => {
   // Check browser storage capacity
@@ -65,6 +66,133 @@ export const checkStorageHealth = async () => {
   }
 };
 
+const formatBytes = (bytes) => {
+  if (bytes === 0) {
+    return '0 B';
+  }
+
+  if (!Number.isFinite(bytes) || bytes == null || bytes < 0) {
+    return '—';
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, exponent);
+  const decimals = value >= 10 || exponent === 0 ? 0 : 1;
+  return `${value.toFixed(decimals)} ${units[exponent]}`;
+};
+
+const formatDateTime = (value) => {
+  if (!value) {
+    return '—';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+};
+
+const formatMetadataValue = (value) => {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+
+  if (typeof value === 'object') {
+    try {
+      const stringified = JSON.stringify(value);
+      return stringified.length > 60 ? `${stringified.slice(0, 57)}…` : stringified;
+    } catch (error) {
+      console.warn('Failed to stringify metadata value for preview:', error);
+      return '[object]';
+    }
+  }
+
+  const text = String(value);
+  return text.length > 60 ? `${text.slice(0, 57)}…` : text;
+};
+
+const TEXT_PREVIEW_BYTE_LIMIT = 200 * 1024; // 200KB of text content for preview rendering
+
+const getFileExtension = (filename) => {
+  if (typeof filename !== 'string') {
+    return '';
+  }
+
+  const lastDot = filename.lastIndexOf('.');
+  if (lastDot === -1 || lastDot === filename.length - 1) {
+    return '';
+  }
+
+  return filename.slice(lastDot + 1).trim().toLowerCase();
+};
+
+const determinePreviewType = (contentType, filename) => {
+  const normalizedType = (contentType || '').toLowerCase();
+  const extension = getFileExtension(filename);
+
+  if (normalizedType.startsWith('image/') || ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg'].includes(extension)) {
+    return 'image';
+  }
+
+  if (normalizedType === 'application/pdf' || extension === 'pdf') {
+    return 'pdf';
+  }
+
+  if (normalizedType.startsWith('video/') || ['mp4', 'webm', 'ogg', 'mov'].includes(extension)) {
+    return 'video';
+  }
+
+  if (normalizedType.startsWith('audio/') || ['mp3', 'wav', 'm4a', 'ogg'].includes(extension)) {
+    return 'audio';
+  }
+
+  if (
+    normalizedType.startsWith('text/') ||
+    /json|xml|csv|yaml|yml|javascript|typescript|markdown/.test(normalizedType) ||
+    ['json', 'xml', 'csv', 'yaml', 'yml', 'md', 'txt', 'log', 'js', 'ts'].includes(extension)
+  ) {
+    return 'text';
+  }
+
+  return 'unsupported';
+};
+
+const decodeTextPreview = (bytes, contentType, filename) => {
+  if (!(bytes instanceof Uint8Array)) {
+    return { text: null, truncated: false };
+  }
+
+  const limitedBytes = bytes.length > TEXT_PREVIEW_BYTE_LIMIT ? bytes.slice(0, TEXT_PREVIEW_BYTE_LIMIT) : bytes;
+  let decoded = null;
+
+  try {
+    decoded = new TextDecoder('utf-8', { fatal: false }).decode(limitedBytes);
+  } catch (error) {
+    console.warn('Failed to decode blob bytes for preview:', error);
+    return { text: null, truncated: false };
+  }
+
+  const normalizedType = (contentType || '').toLowerCase();
+  const extension = getFileExtension(filename);
+
+  if (/json/.test(normalizedType) || extension === 'json') {
+    try {
+      const parsed = JSON.parse(decoded);
+      decoded = JSON.stringify(parsed, null, 2);
+    } catch (error) {
+      // Ignore JSON parse errors and fall back to raw text
+    }
+  }
+
+  return {
+    text: decoded,
+    truncated: bytes.length > TEXT_PREVIEW_BYTE_LIMIT,
+  };
+};
+
 const AdminScreen = ({ user, onBack }) => {
   const [activeTab, setActiveTab] = useState('overview');
   const [isLoading, setIsLoading] = useState(false);
@@ -75,18 +203,98 @@ const AdminScreen = ({ user, onBack }) => {
   const [error, setError] = useState(null);
   const [chatModel] = useState(getCurrentModel());
   const [tokenUsage, setTokenUsage] = useState({ daily: [], monthly: [] });
+  const [blobFiles, setBlobFiles] = useState([]);
+  const [blobMetadata, setBlobMetadata] = useState({ store: '', prefix: '', timestamp: null, total: null, truncated: false });
+  const [blobError, setBlobError] = useState(null);
+  const [isBlobLoading, setIsBlobLoading] = useState(false);
+  const [hasLoadedBlobInventory, setHasLoadedBlobInventory] = useState(false);
+  const [blobPrefixInput, setBlobPrefixInput] = useState('');
+  const [appliedBlobPrefix, setAppliedBlobPrefix] = useState('');
+  const [blobSearchTerm, setBlobSearchTerm] = useState('');
+  const [blobSort, setBlobSort] = useState('newest');
+  const [downloadingBlobKeys, setDownloadingBlobKeys] = useState(() => new Set());
+  const [blobPreview, setBlobPreview] = useState(null);
   const ragBackendLabel = getRagBackendLabel();
   const neonBackendEnabled = isNeonBackend();
 
   // Check if user has admin role
   const isAdmin = hasAdminRole(user);
 
-  // Load admin data on component mount
-  useEffect(() => {
-    if (isAdmin) {
-      loadAdminData();
+  const releasePreviewObjectUrl = useCallback((objectUrl) => {
+    if (!objectUrl) {
+      return;
     }
-  }, [isAdmin]);
+
+    if (typeof window !== 'undefined' && typeof window.URL?.revokeObjectURL === 'function') {
+      window.URL.revokeObjectURL(objectUrl);
+    }
+  }, []);
+
+  const closeBlobPreview = useCallback(() => {
+    setBlobPreview((previous) => {
+      if (previous?.objectUrl) {
+        releasePreviewObjectUrl(previous.objectUrl);
+      }
+      return null;
+    });
+  }, [releasePreviewObjectUrl]);
+
+  useEffect(() => {
+    return () => {
+      if (blobPreview?.objectUrl) {
+        releasePreviewObjectUrl(blobPreview.objectUrl);
+      }
+    };
+  }, [blobPreview, releasePreviewObjectUrl]);
+
+  useEffect(() => {
+    if (!blobPreview) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        closeBlobPreview();
+      }
+    };
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('keydown', handleKeyDown);
+    }
+
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('keydown', handleKeyDown);
+      }
+    };
+  }, [blobPreview, closeBlobPreview]);
+
+  const renderMetadataPreview = useCallback((metadata) => {
+    if (!metadata || typeof metadata !== 'object' || Object.keys(metadata).length === 0) {
+      return <span className="text-gray-400">No metadata</span>;
+    }
+
+    const entries = Object.entries(metadata);
+    const visibleEntries = entries.slice(0, 4);
+
+    return (
+      <div className="flex flex-wrap gap-1">
+        {visibleEntries.map(([key, value]) => (
+          <span
+            key={key}
+            className="px-2 py-0.5 bg-gray-100 border border-gray-200 rounded text-gray-700"
+          >
+            <span className="font-medium text-gray-800">{key}</span>: {formatMetadataValue(value)}
+          </span>
+        ))}
+        {entries.length > 4 && (
+          <span className="px-2 py-0.5 bg-gray-50 border border-dashed border-gray-200 rounded text-gray-500">
+            +{entries.length - 4} more
+          </span>
+        )}
+      </div>
+    );
+  }, []);
 
   const loadAdminData = useCallback(async () => {
     setIsLoading(true);
@@ -167,7 +375,7 @@ const AdminScreen = ({ user, onBack }) => {
     try {
       const tokenInfo = getTokenInfo();
       const token = await getToken();
-      
+
       return {
         tokenInfo,
         hasValidToken: !!token,
@@ -183,6 +391,84 @@ const AdminScreen = ({ user, onBack }) => {
       };
     }
   };
+
+  const loadBlobInventory = useCallback(
+    async (overridePrefix) => {
+      if (!isAdmin) {
+        return;
+      }
+
+      const sanitizedOverride =
+        typeof overridePrefix === 'string'
+          ? overridePrefix.trim().replace(/^\/+|\/+$/g, '')
+          : null;
+
+      const prefixToUse = sanitizedOverride !== null ? sanitizedOverride : appliedBlobPrefix;
+
+      if (sanitizedOverride !== null && sanitizedOverride !== appliedBlobPrefix) {
+        setAppliedBlobPrefix(sanitizedOverride);
+      }
+
+      setBlobError(null);
+      setIsBlobLoading(true);
+
+      try {
+        const response = await blobAdminService.listBlobs({
+          user,
+          prefix: prefixToUse || undefined,
+        });
+
+        const normalized = Array.isArray(response?.blobs)
+          ? response.blobs.map((blob) => ({
+              key: blob.key,
+              relativeKey: blob.relativeKey || blob.key,
+              userId: blob.userId || null,
+              documentId: blob.documentId || null,
+              filename: blob.filename || null,
+              size:
+                typeof blob.size === 'number' && Number.isFinite(blob.size)
+                  ? Number(blob.size)
+                  : null,
+              contentType: typeof blob.contentType === 'string' ? blob.contentType : null,
+              uploadedAt: typeof blob.uploadedAt === 'string' ? blob.uploadedAt : null,
+              etag: blob.etag || null,
+              metadata:
+                blob.metadata && typeof blob.metadata === 'object' ? blob.metadata : {},
+              segments: Array.isArray(blob.segments) ? blob.segments : [],
+            }))
+          : [];
+
+        setBlobFiles(normalized);
+        setBlobMetadata({
+          store: response?.store || '',
+          prefix: response?.prefix || prefixToUse || '',
+          timestamp: response?.timestamp || new Date().toISOString(),
+          total: typeof response?.total === 'number' ? response.total : normalized.length,
+          truncated: Boolean(response?.truncated),
+        });
+        setHasLoadedBlobInventory(true);
+      } catch (inventoryError) {
+        console.error('Failed to load Netlify blobs:', inventoryError);
+        setBlobError(inventoryError.message || 'Failed to load Netlify blob inventory.');
+        setHasLoadedBlobInventory(false);
+      } finally {
+        setIsBlobLoading(false);
+      }
+    },
+    [appliedBlobPrefix, isAdmin, user]
+  );
+
+  useEffect(() => {
+    if (isAdmin) {
+      loadAdminData();
+    }
+  }, [isAdmin, loadAdminData]);
+
+  useEffect(() => {
+    if (activeTab === 'blobStorage' && isAdmin && !hasLoadedBlobInventory && !isBlobLoading) {
+      loadBlobInventory();
+    }
+  }, [activeTab, hasLoadedBlobInventory, isAdmin, isBlobLoading, loadBlobInventory]);
 
   // System health check
   const getSystemHealth = async () => {
@@ -275,6 +561,9 @@ const AdminScreen = ({ user, onBack }) => {
   // Refresh data
   const handleRefresh = () => {
     loadAdminData();
+    if (activeTab === 'blobStorage') {
+      loadBlobInventory();
+    }
   };
 
   // Export system data
@@ -303,6 +592,150 @@ const AdminScreen = ({ user, onBack }) => {
     }
   };
 
+  const handleBlobPrefixSubmit = useCallback(
+    (event) => {
+      event.preventDefault();
+      const sanitized = blobPrefixInput.trim().replace(/^\/+|\/+$/g, '');
+      setBlobPrefixInput(sanitized);
+      loadBlobInventory(sanitized);
+    },
+    [blobPrefixInput, loadBlobInventory]
+  );
+
+  const handleBlobPrefixReset = useCallback(() => {
+    if (!blobPrefixInput && !appliedBlobPrefix) {
+      return;
+    }
+    setBlobPrefixInput('');
+    loadBlobInventory('');
+  }, [appliedBlobPrefix, blobPrefixInput, loadBlobInventory]);
+
+  const markBlobDownloading = useCallback(
+    (key, isDownloading) => {
+      if (!key) {
+        return;
+      }
+
+      setDownloadingBlobKeys((previous) => {
+        const next = new Set(previous);
+        if (isDownloading) {
+          next.add(key);
+        } else {
+          next.delete(key);
+        }
+        return next;
+      });
+    },
+    [setDownloadingBlobKeys]
+  );
+
+  const openBlobPreviewInNewTab = useCallback(() => {
+    if (!blobPreview?.objectUrl) {
+      return;
+    }
+
+    if (typeof window !== 'undefined' && typeof window.open === 'function') {
+      window.open(blobPreview.objectUrl, '_blank', 'noopener,noreferrer');
+    }
+  }, [blobPreview]);
+
+  const handleBlobDownload = useCallback(
+    async (file) => {
+      if (!file?.key) {
+        setBlobError('Unable to download file: missing blob key.');
+        return;
+      }
+
+      if (
+        typeof window === 'undefined' ||
+        typeof window.URL?.createObjectURL !== 'function' ||
+        typeof document === 'undefined'
+      ) {
+        setBlobError('File downloads are not supported in this environment.');
+        return;
+      }
+
+      const blobKey = file.key;
+      markBlobDownloading(blobKey, true);
+      setBlobError(null);
+
+      try {
+        const result = await blobAdminService.downloadBlob({ key: blobKey });
+
+        if (result.encoding && result.encoding !== 'base64') {
+          throw new Error(`Unsupported blob encoding: ${result.encoding}`);
+        }
+
+        const base64Data = result.data;
+        if (typeof base64Data !== 'string' || !base64Data) {
+          throw new Error('Received an empty blob payload.');
+        }
+
+        let binaryString;
+        if (typeof window !== 'undefined' && typeof window.atob === 'function') {
+          binaryString = window.atob(base64Data);
+        } else if (typeof atob === 'function') {
+          binaryString = atob(base64Data);
+        } else if (typeof Buffer !== 'undefined') {
+          binaryString = Buffer.from(base64Data, 'base64').toString('binary');
+        } else {
+          throw new Error('Base64 decoding is not supported in this environment.');
+        }
+
+        const byteLength = binaryString.length;
+        const bytes = new Uint8Array(byteLength);
+        for (let index = 0; index < byteLength; index += 1) {
+          bytes[index] = binaryString.charCodeAt(index);
+        }
+
+        const contentType = result.contentType || file.contentType || 'application/octet-stream';
+        const blob = new Blob([bytes], { type: contentType });
+        const objectUrl = window.URL.createObjectURL(blob);
+        const previewType = determinePreviewType(contentType, downloadName);
+        let textPreview = { text: null, truncated: false };
+
+        if (previewType === 'text') {
+          textPreview = decodeTextPreview(bytes, contentType, downloadName);
+        }
+        const anchor = document.createElement('a');
+        anchor.href = objectUrl;
+        const downloadName =
+          result.filename ||
+          file.filename ||
+          result.relativeKey ||
+          file.relativeKey ||
+          blobKey.split('/').pop() ||
+          'download';
+        anchor.download = downloadName;
+        document.body.appendChild(anchor);
+        anchor.click();
+        document.body.removeChild(anchor);
+        setBlobPreview((previous) => {
+          if (previous?.objectUrl) {
+            releasePreviewObjectUrl(previous.objectUrl);
+          }
+
+          return {
+            objectUrl,
+            filename: downloadName,
+            contentType,
+            size: Number.isFinite(file?.size) ? file.size : bytes.length,
+            key: blobKey,
+            downloadedAt: new Date().toISOString(),
+            previewType,
+            textPreview,
+          };
+        });
+      } catch (error) {
+        console.error('Failed to download blob file:', error);
+        setBlobError(error.message || 'Failed to download file from Netlify blobs.');
+      } finally {
+        markBlobDownloading(blobKey, false);
+      }
+    },
+    [markBlobDownloading, releasePreviewObjectUrl, setBlobError]
+  );
+
   // Test system components
   const runSystemTests = async () => {
     setIsLoading(true);
@@ -327,6 +760,122 @@ const AdminScreen = ({ user, onBack }) => {
       setIsLoading(false);
     }
   };
+
+  const filteredBlobFiles = useMemo(() => {
+    const search = blobSearchTerm.trim().toLowerCase();
+    const files = Array.isArray(blobFiles) ? [...blobFiles] : [];
+
+    const getTime = (value) => {
+      if (!value) return 0;
+      const timestamp = new Date(value).getTime();
+      return Number.isNaN(timestamp) ? 0 : timestamp;
+    };
+
+    const sizeForLargest = (value) =>
+      Number.isFinite(value) && value >= 0 ? value : -1;
+
+    const sizeForSmallest = (value) =>
+      Number.isFinite(value) && value >= 0 ? value : Number.MAX_SAFE_INTEGER;
+
+    let result = files;
+
+    if (search) {
+      result = result.filter((file) => {
+        const searchTargets = [
+          file.key,
+          file.relativeKey,
+          file.userId,
+          file.documentId,
+          file.filename,
+          file.contentType,
+          file.etag,
+        ]
+          .filter(Boolean)
+          .map((value) => String(value).toLowerCase());
+
+        if (searchTargets.some((value) => value.includes(search))) {
+          return true;
+        }
+
+        if (file.metadata && typeof file.metadata === 'object') {
+          return Object.entries(file.metadata).some(([key, value]) => {
+            if (String(key).toLowerCase().includes(search)) {
+              return true;
+            }
+
+            if (value === null || value === undefined) {
+              return false;
+            }
+
+            const text = typeof value === 'object' ? JSON.stringify(value) : String(value);
+            return text.toLowerCase().includes(search);
+          });
+        }
+
+        return false;
+      });
+    }
+
+    const sorted = [...result];
+    sorted.sort((a, b) => {
+      switch (blobSort) {
+        case 'oldest':
+          return getTime(a.uploadedAt) - getTime(b.uploadedAt);
+        case 'largest':
+          return sizeForLargest(b.size) - sizeForLargest(a.size);
+        case 'smallest':
+          return sizeForSmallest(a.size) - sizeForSmallest(b.size);
+        case 'alphabetical':
+          return (a.relativeKey || a.key || '').localeCompare(
+            b.relativeKey || b.key || '',
+            undefined,
+            { sensitivity: 'base' }
+          );
+        case 'newest':
+        default:
+          return getTime(b.uploadedAt) - getTime(a.uploadedAt);
+      }
+    });
+
+    return sorted;
+  }, [blobFiles, blobSearchTerm, blobSort]);
+
+  const totalBlobSize = useMemo(
+    () =>
+      blobFiles.reduce(
+        (sum, file) =>
+          Number.isFinite(file?.size) && file.size >= 0 ? sum + Number(file.size) : sum,
+        0
+      ),
+    [blobFiles]
+  );
+
+  const uniqueBlobUsers = useMemo(() => {
+    const ids = new Set();
+    blobFiles.forEach((file) => {
+      if (file?.userId) {
+        ids.add(file.userId);
+      }
+    });
+    return ids.size;
+  }, [blobFiles]);
+
+  const uniqueBlobDocuments = useMemo(() => {
+    const ids = new Set();
+    blobFiles.forEach((file) => {
+      if (file?.documentId) {
+        ids.add(file.documentId);
+      }
+    });
+    return ids.size;
+  }, [blobFiles]);
+
+  const displayedBlobCount = filteredBlobFiles.length;
+  const blobStoreName = blobMetadata?.store || 'rag-documents';
+  const blobPrefixDisplay = blobMetadata?.prefix || (appliedBlobPrefix || '');
+  const blobLastUpdated = blobMetadata?.timestamp;
+  const blobTotalCount = typeof blobMetadata?.total === 'number' ? blobMetadata.total : blobFiles.length;
+  const blobInventoryTruncated = Boolean(blobMetadata?.truncated);
 
   // Don't render if user is not admin
   if (!isAdmin) {
@@ -430,6 +979,7 @@ const AdminScreen = ({ user, onBack }) => {
               { id: 'users', label: 'Users & Auth', icon: Users },
               { id: 'backend', label: 'Backend', icon: Database },
               { id: 'rag', label: 'RAG System', icon: FileText },
+              { id: 'blobStorage', label: 'Netlify Blobs', icon: Cloud },
               { id: 'ragConfig', label: 'My Resources', icon: Search },
               { id: 'system', label: 'System Health', icon: Activity },
               { id: 'usage', label: 'Token Usage', icon: BarChart3 },
@@ -723,6 +1273,229 @@ const AdminScreen = ({ user, onBack }) => {
             </div>
           )}
 
+          {/* Netlify Blob Storage Tab */}
+          {activeTab === 'blobStorage' && (
+            <div className="space-y-6">
+              <div className="bg-white rounded-lg shadow p-6">
+                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-900 flex items-center">
+                      <Cloud className="h-5 w-5 text-blue-600 mr-2" />
+                      Netlify Blob Storage
+                    </h3>
+                    <p className="text-sm text-gray-600">
+                      Store <span className="font-medium text-gray-900">{blobStoreName}</span>
+                      {blobPrefixDisplay && (
+                        <>
+                          {' '}• Prefix{' '}
+                          <code className="text-xs bg-gray-100 border border-gray-200 px-1 py-0.5 rounded">
+                            {blobPrefixDisplay}
+                          </code>
+                        </>
+                      )}
+                    </p>
+                    <p className="text-xs text-gray-500 mt-1">
+                      Last refreshed {formatDateTime(blobLastUpdated)} • Showing {displayedBlobCount}
+                      {blobTotalCount != null && ` of ${blobTotalCount}`} files
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => loadBlobInventory(appliedBlobPrefix)}
+                      disabled={isBlobLoading}
+                      className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      <RefreshCw className={`h-4 w-4 ${isBlobLoading ? 'animate-spin' : ''}`} />
+                      <span>Refresh</span>
+                    </button>
+                  </div>
+                </div>
+
+                {blobError && (
+                  <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-4">
+                    <div className="flex items-start space-x-3">
+                      <AlertTriangle className="h-5 w-5 text-red-500 flex-shrink-0 mt-0.5" />
+                      <div>
+                        <h4 className="font-medium text-red-800">Unable to load Netlify blobs</h4>
+                        <p className="text-sm text-red-700 mt-1">{blobError}</p>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                <form
+                  onSubmit={handleBlobPrefixSubmit}
+                  className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6"
+                >
+                  <div className="md:col-span-2">
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Prefix filter
+                    </label>
+                    <div className="flex gap-2">
+                      <input
+                        type="text"
+                        value={blobPrefixInput}
+                        onChange={(event) => setBlobPrefixInput(event.target.value)}
+                        placeholder="rag-documents/user-id"
+                        className="flex-1 rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      />
+                      <button
+                        type="submit"
+                        className="px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                      >
+                        Apply
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleBlobPrefixReset}
+                        className="px-3 py-2 bg-gray-100 text-gray-700 rounded hover:bg-gray-200"
+                        disabled={!blobPrefixInput && !appliedBlobPrefix}
+                      >
+                        Reset
+                      </button>
+                    </div>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Search
+                    </label>
+                    <input
+                      type="text"
+                      value={blobSearchTerm}
+                      onChange={(event) => setBlobSearchTerm(event.target.value)}
+                      placeholder="Filter by key, user, metadata..."
+                      className="w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    />
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Sort by
+                    </label>
+                    <select
+                      value={blobSort}
+                      onChange={(event) => setBlobSort(event.target.value)}
+                      className="w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    >
+                      <option value="newest">Newest first</option>
+                      <option value="oldest">Oldest first</option>
+                      <option value="largest">Largest size</option>
+                      <option value="smallest">Smallest size</option>
+                      <option value="alphabetical">Alphabetical</option>
+                    </select>
+                  </div>
+                </form>
+
+                <div className="flex flex-wrap gap-4 text-sm text-gray-600 mb-4">
+                  <span>
+                    <span className="font-semibold text-gray-900">{blobFiles.length}</span> files loaded
+                  </span>
+                  <span>
+                    <span className="font-semibold text-gray-900">{formatBytes(totalBlobSize)}</span> total size
+                  </span>
+                  <span>
+                    <span className="font-semibold text-gray-900">{uniqueBlobUsers}</span> unique users
+                  </span>
+                  <span>
+                    <span className="font-semibold text-gray-900">{uniqueBlobDocuments}</span> unique documents
+                  </span>
+                  {blobInventoryTruncated && (
+                    <span className="text-yellow-600">
+                      Displaying first {displayedBlobCount} entries. Narrow the prefix to load more.
+                    </span>
+                  )}
+                </div>
+
+                <div className="border border-gray-200 rounded-lg overflow-hidden">
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full divide-y divide-gray-200 text-sm">
+                      <thead className="bg-gray-50">
+                        <tr>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-600">Blob Key</th>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-600">Size</th>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-600">Content Type</th>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-600">Uploaded</th>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-600">Metadata</th>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-600">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {isBlobLoading && filteredBlobFiles.length === 0 ? (
+                          <tr>
+                            <td colSpan={6} className="px-4 py-8 text-center text-gray-500">
+                              <RefreshCw className="h-5 w-5 inline-block animate-spin mr-2" />
+                              Loading Netlify blob inventory…
+                            </td>
+                          </tr>
+                        ) : filteredBlobFiles.length === 0 ? (
+                          <tr>
+                            <td colSpan={6} className="px-4 py-8 text-center text-gray-500">
+                              No blob files found for the selected filters.
+                            </td>
+                          </tr>
+                        ) : (
+                          filteredBlobFiles.map((file) => (
+                            <tr key={file.key} className="hover:bg-gray-50">
+                              <td className="px-4 py-3 align-top">
+                                <div className="font-medium text-gray-900 break-all">
+                                  {file.relativeKey || file.key}
+                                </div>
+                                <div className="mt-1 flex flex-wrap gap-2 text-xs text-gray-500">
+                                  {file.userId && (
+                                    <span className="px-2 py-0.5 bg-gray-100 border border-gray-200 rounded">
+                                      User: {file.userId}
+                                    </span>
+                                  )}
+                                  {file.documentId && (
+                                    <span className="px-2 py-0.5 bg-gray-100 border border-gray-200 rounded">
+                                      Doc: {file.documentId}
+                                    </span>
+                                  )}
+                                  {file.filename && (
+                                    <span className="px-2 py-0.5 bg-gray-100 border border-gray-200 rounded">
+                                      File: {file.filename}
+                                    </span>
+                                  )}
+                                  {file.etag && (
+                                    <span className="px-2 py-0.5 bg-gray-100 border border-gray-200 rounded">
+                                      ETag: {file.etag.slice(0, 10)}{file.etag.length > 10 ? '…' : ''}
+                                    </span>
+                                  )}
+                                </div>
+                              </td>
+                              <td className="px-4 py-3 align-top text-gray-900">{formatBytes(file.size)}</td>
+                              <td className="px-4 py-3 align-top text-gray-600">{file.contentType || '—'}</td>
+                              <td className="px-4 py-3 align-top text-gray-600">{formatDateTime(file.uploadedAt)}</td>
+                              <td className="px-4 py-3 align-top text-xs text-gray-600">
+                                {renderMetadataPreview(file.metadata)}
+                              </td>
+                              <td className="px-4 py-3 align-top">
+                                <button
+                                  type="button"
+                                  onClick={() => handleBlobDownload(file)}
+                                  className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-blue-600 border border-blue-200 rounded hover:bg-blue-50 disabled:opacity-60 disabled:cursor-not-allowed"
+                                  disabled={downloadingBlobKeys.has(file.key)}
+                                >
+                                  {downloadingBlobKeys.has(file.key) ? (
+                                    <RefreshCw className="h-4 w-4 animate-spin" />
+                                  ) : (
+                                    <Download className="h-4 w-4" />
+                                  )}
+                                  <span>{downloadingBlobKeys.has(file.key) ? 'Preparing…' : 'Download'}</span>
+                                </button>
+                              </td>
+                            </tr>
+                          ))
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
           {/* System Health Tab */}
           {activeTab === 'system' && (
             <div className="space-y-6">
@@ -906,6 +1679,124 @@ const AdminScreen = ({ user, onBack }) => {
           )}
         </div>
       </div>
+      {blobPreview && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="blob-preview-dialog-title"
+        >
+          <div
+            className="absolute inset-0 bg-gray-900/70"
+            onClick={closeBlobPreview}
+            aria-hidden="true"
+          />
+          <div className="relative z-10 w-full max-w-5xl max-h-full bg-white rounded-lg shadow-2xl flex flex-col overflow-hidden">
+            <div className="flex items-start justify-between gap-4 px-6 py-4 border-b border-gray-200">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 text-lg font-semibold text-gray-900">
+                  <FileText className="h-5 w-5 text-blue-600" />
+                  <span
+                    id="blob-preview-dialog-title"
+                    className="truncate"
+                    title={blobPreview.filename}
+                  >
+                    {blobPreview.filename}
+                  </span>
+                </div>
+                <p className="text-xs text-gray-500 mt-1">
+                  {blobPreview.contentType || 'application/octet-stream'} • {formatBytes(blobPreview.size)}
+                  {blobPreview.downloadedAt && ` • Retrieved ${formatDateTime(blobPreview.downloadedAt)}`}
+                </p>
+                {blobPreview.key && (
+                  <p className="text-[11px] text-gray-400 mt-1 break-all">Blob key: {blobPreview.key}</p>
+                )}
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <button
+                  type="button"
+                  onClick={openBlobPreviewInNewTab}
+                  className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-blue-600 border border-blue-200 rounded hover:bg-blue-50"
+                >
+                  <Eye className="h-4 w-4" />
+                  <span>Open in new tab</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={closeBlobPreview}
+                  className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-600 border border-gray-200 rounded hover:bg-gray-50"
+                >
+                  <X className="h-4 w-4" />
+                  <span>Close</span>
+                </button>
+              </div>
+            </div>
+            <div className="flex-1 bg-gray-100">
+              {blobPreview.previewType === 'image' && (
+                <div className="flex h-full items-center justify-center bg-white p-6">
+                  <img
+                    src={blobPreview.objectUrl}
+                    alt={`Preview of ${blobPreview.filename}`}
+                    className="max-h-full max-w-full object-contain"
+                  />
+                </div>
+              )}
+              {blobPreview.previewType === 'pdf' && (
+                <object
+                  data={blobPreview.objectUrl}
+                  type={blobPreview.contentType || 'application/pdf'}
+                  className="w-full h-full min-h-[420px] bg-white"
+                >
+                  <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-gray-600">
+                    <p className="font-medium">Unable to display PDF preview due to browser restrictions.</p>
+                    <p>Use the “Open in new tab” button above to view the full document.</p>
+                  </div>
+                </object>
+              )}
+              {blobPreview.previewType === 'video' && (
+                <div className="flex h-full items-center justify-center bg-black">
+                  <video
+                    src={blobPreview.objectUrl}
+                    controls
+                    className="h-full w-full"
+                  >
+                    <track kind="captions" />
+                    Your browser does not support embedded video playback.
+                  </video>
+                </div>
+              )}
+              {blobPreview.previewType === 'audio' && (
+                <div className="flex h-full flex-col items-center justify-center gap-4 bg-white p-6">
+                  <audio src={blobPreview.objectUrl} controls className="w-full">
+                    Your browser does not support embedded audio playback.
+                  </audio>
+                  <p className="text-xs text-gray-500">If playback fails, use the “Open in new tab” option.</p>
+                </div>
+              )}
+              {blobPreview.previewType === 'text' && blobPreview.textPreview?.text && (
+                <div className="h-full overflow-auto bg-white p-6">
+                  <pre className="whitespace-pre-wrap break-words text-xs leading-5 text-gray-800">
+                    {blobPreview.textPreview.text}
+                  </pre>
+                  {blobPreview.textPreview.truncated && (
+                    <p className="mt-3 text-xs text-gray-500">
+                      Preview truncated to {Math.round(TEXT_PREVIEW_BYTE_LIMIT / 1024)}KB. Use “Open in new tab” to view the complete file.
+                    </p>
+                  )}
+                </div>
+              )}
+              {(!blobPreview.previewType ||
+                !['image', 'pdf', 'video', 'audio', 'text'].includes(blobPreview.previewType) ||
+                (blobPreview.previewType === 'text' && !blobPreview.textPreview?.text)) && (
+                <div className="flex h-full flex-col items-center justify-center gap-3 bg-white p-6 text-center text-sm text-gray-600">
+                  <p className="font-medium">This file type cannot be previewed securely within the dashboard.</p>
+                  <p>Use the “Open in new tab” button to view or download the document.</p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/services/blobAdminService.js
+++ b/src/services/blobAdminService.js
@@ -1,0 +1,146 @@
+// src/services/blobAdminService.js - Admin-facing helper for Netlify Blob inventory
+import authService from './authService';
+
+const ADMIN_BLOB_FUNCTION =
+  process.env.REACT_APP_ADMIN_BLOB_FUNCTION || '/.netlify/functions/admin-blob-list';
+
+const sanitizeQueryParam = (value) => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value).trim();
+};
+
+const buildQueryString = (params = {}) => {
+  const entries = Object.entries(params).filter(([, value]) => value !== undefined && value !== null && value !== '');
+  if (entries.length === 0) {
+    return '';
+  }
+
+  const searchParams = new URLSearchParams();
+  entries.forEach(([key, value]) => {
+    searchParams.set(key, String(value));
+  });
+  return `?${searchParams.toString()}`;
+};
+
+const normalizeRoles = (roles = []) =>
+  Array.isArray(roles)
+    ? roles
+        .map((role) => (typeof role === 'string' ? role.trim() : ''))
+        .filter(Boolean)
+    : [];
+
+const ensureAdminUser = async (user) => {
+  const currentUser = user || (await authService.getUser());
+  const userId = currentUser?.sub || (await authService.getUserId());
+
+  if (!userId) {
+    throw new Error('Administrator authentication is required to access Netlify blobs.');
+  }
+
+  let token;
+  try {
+    token = await authService.getToken();
+  } catch (error) {
+    throw new Error(`Authentication failed: ${error.message}`);
+  }
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    'x-user-id': userId,
+  };
+
+  const roles = normalizeRoles(currentUser?.roles);
+  if (roles.length > 0) {
+    headers['x-user-roles'] = roles.join(',');
+  }
+
+  if (typeof currentUser?.organization === 'string' && currentUser.organization.trim()) {
+    headers['x-user-organization'] = currentUser.organization.trim();
+  }
+
+  return { headers, userId, roles, currentUser };
+};
+
+async function listBlobs({ user, prefix, limit } = {}) {
+  const { headers } = await ensureAdminUser(user);
+
+  const numericLimit = Number(limit);
+  const queryString = buildQueryString({
+    prefix: sanitizeQueryParam(prefix),
+    limit: Number.isFinite(numericLimit) && numericLimit > 0 ? Math.floor(numericLimit) : undefined,
+  });
+
+  const endpoint = ADMIN_BLOB_FUNCTION;
+  let response;
+  try {
+    response = await fetch(`${endpoint}${queryString}`, {
+      method: 'GET',
+      headers,
+    });
+  } catch (error) {
+    throw new Error('Unable to reach Netlify blob inventory service.');
+  }
+
+  let data;
+  try {
+    data = await response.json();
+  } catch (error) {
+    throw new Error('Failed to parse Netlify blob inventory response.');
+  }
+
+  if (!response.ok) {
+    const message = typeof data?.error === 'string' ? data.error : data?.message;
+    throw new Error(message || `Request failed with status ${response.status}`);
+  }
+
+  return data;
+}
+
+async function downloadBlob({ user, key } = {}) {
+  const { headers } = await ensureAdminUser(user);
+
+  const sanitizedKey = sanitizeQueryParam(key);
+  if (!sanitizedKey) {
+    throw new Error('A blob key is required to download a Netlify blob.');
+  }
+
+  const queryString = buildQueryString({ key: sanitizedKey });
+  const endpoint = ADMIN_BLOB_FUNCTION;
+  let response;
+  try {
+    response = await fetch(`${endpoint}${queryString}`, {
+      method: 'GET',
+      headers,
+    });
+  } catch (error) {
+    throw new Error('Unable to reach Netlify blob download service.');
+  }
+
+  let data;
+  try {
+    data = await response.json();
+  } catch (error) {
+    throw new Error('Failed to parse Netlify blob download response.');
+  }
+
+  if (!response.ok) {
+    const message = typeof data?.error === 'string' ? data.error : data?.message;
+    throw new Error(message || `Download failed with status ${response.status}`);
+  }
+
+  if (!data || typeof data.data !== 'string') {
+    throw new Error('Download response did not include blob data.');
+  }
+
+  return data;
+}
+
+const blobAdminService = {
+  listBlobs,
+  downloadBlob,
+};
+
+export default blobAdminService;


### PR DESCRIPTION
## Summary
- detect downloaded blob content types and derive preview-specific handling in the admin dashboard
- decode safe text snippets for inline viewing while tracking preview truncation limits
- replace the iframe-based viewer with media-specific renderers and clear fallbacks to avoid CSP frame-src violations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd729f881c832a9904b09cd78d4756