### PR TITLE
Fix system prompt template literal termination

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -54,7 +54,7 @@ Deep Dive Example:
 AcceleraQA, Deep Dive: Assess whether electronic signatures in a vendor-hosted CTMS require validation under 21 CFR Part 11.
 Quick Check Example:
 AcceleraQA, Quick Check: Is audit trail review mandatory under EMA Annex 11?
-
+`,
 };
 // Auth0 Configuration with enhanced validation
 export const AUTH0_CONFIG = {


### PR DESCRIPTION
## Summary
- properly terminate the multi-line `SYSTEM_PROMPT` template literal to resolve the build syntax error

## Testing
- npm run build *(fails: existing ESLint no-undef errors for globalThis)*

------
https://chatgpt.com/codex/tasks/task_e_68dd88ab9938832ab783a9f34a9b2e29