### PR TITLE
Add OpenAI dependency for Netlify function

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@netlify/blobs": "^6.4.0",
     "@neondatabase/serverless": "^0.9.0",
+    "openai": "^4.52.0",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^2.1.5",
     "lucide-react": "^0.263.1",


### PR DESCRIPTION
## Summary
- add the OpenAI SDK to the project dependencies so Netlify can resolve the import used by the chat function

## Testing
- npm install --package-lock-only *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/openai)*

------
https://chatgpt.com/codex/tasks/task_e_68e30b02af0c832ab0fc7c723a36fdbb